### PR TITLE
removing google console refs and cleaning up instructions

### DIFF
--- a/doc/source/setup.rst
+++ b/doc/source/setup.rst
@@ -9,36 +9,45 @@ Install cloud computing services + kubernetes
 1. We’ll be using google cloud in this tutorial, though in the future many more cloud platforms will be supported. You should be able to get free credits for trying out google cloud. However, first you need to connect your credit card to your google cloud account.
 2. Go to https://console.cloud.google.com.
 3. Click the hamburger in the top left (it has 3 horizontal lines in one button). Go to “Billing” then “Payment Methods”, and make sure you have a credit card linked to the account. (you should also get $300 in credits).
+4. Install and initialize the gcloud command-line tools, which send commands to google cloud and lets you do things like create / delete clusters.
+   
+   - Go to the `gcloud downloads page <https://cloud.google.com/sdk/downloads>`_
+     to download/install the gcloud SDK.
+   - See the `gcloud documentation <https://cloud.google.com/sdk/>`_ for
+     more information on the gcloud SDK.
+   - Install ``kubectl``, which is a tool for controlling kubernetes.
 
-  .. image:: https://lh6.googleusercontent.com/K6RuUG7kt-DJH5aELuHSwLQM8oTj4qwmktVcR4EFqqHfL7s0szGH7I1SnXUQArIo-yRe7xI8cPlUwxfUyLs_evC5dPcPBJiSh0LxLI_RbO-Yad_7ZrQcVcQfNEAGKCO5En_MtmQU
-
-4. Click the terminal button at the top right of the page (see figure) to open
-   an interactive terminal in the browser. Alternatively install and initialize
-   the gcloud command-line tools, which send commands to google cloud:
-
-   - If you installed gcloud on your own device, then install kubectl as well.
-     It is a tool for controlling kubernetes. kubectl comes preinstalled in the
-     Google Cloud Shell::
-
-         gcloud components install kubectl
+         ``gcloud components install kubectl``
 
 5. Create a kubernetes cluster on google cloud, by typing in the following command.
-
-  **Note**: This may take several minutes, so create a new tab by clicking the `+` button in the console frame. Then move on to “Setting up JupyterHub”.
 
     ``gcloud container clusters create YOUR_CLUSTER --num-nodes=3 --zone=us-central1-b``
 
   * ``--num-nodes`` specifies how many computers to spin up. The higher the number, the greater the cost.
   * ``--zone`` specifies which computer center to use.  To reduce latency, choose a zone closest to whoever is sending the commands. View available zones via `gcloud compute zones list` .
-  * When it’s done initializing your cluster, run `kubectl get node`. It should list three running nodes.
+  * When it’s done initializing your cluster, run ``kubectl get node``. It should list three running nodes.
+
+  .. note::
+
+      This may take several minutes, so create a new shell tab. Then move on to the section “Setting up JupyterHub”. You'll know it's done initializing when ``kubectl get node`` shows your new nodes.
 
 Setting up JupyterHub
 ---------------------
 
-1. Install helm in the same terminal window where you execute gcloud and kubectl:
-    ``curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash``
+1. Install helm:
+
+    .. code::
+
+        curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+
 2. Create a file called ``config.yaml`` to hold the various customizations describing our JupyterHub installation:
+
     ``nano config.yaml``
+
+    .. note::
+
+        Remember where you store your ``config.yaml`` file in case you need to use it again or make changes to it. You'll be able to "re-initialize" helm if you make changes in order to modify the kubernetes setup.
+
 3. Run these two commands (they’re the same command but run them twice)::
 
        openssl rand -hex 32
@@ -57,7 +66,7 @@ Setting up JupyterHub
             # output of second execution of 'openssl rand -hex 32'
             proxy: "RANDOM_STRING_2"
 
-5. Save the file by hitting `Ctrl-X` and make sure to answer ‘yes’ when it asks you to save.
+5. Save the file by hitting ``Ctrl-X`` and make sure to answer ‘yes’ when it asks you to save.
 
 
 Getting it all running
@@ -65,28 +74,38 @@ Getting it all running
 
 1. Run ``helm init`` to prepare the kubernetes cluster for helm installation
 2. Tell helm to create the instances you configured with the ``yaml`` file.
-   This will spin up JupyterHub::
+   This will spin up JupyterHub:
 
-       helm install https://github.com/jupyterhub/helm-chart/releases/download/v0.1/jupyterhub-0.1.tgz --name=YOUR_CHART --namespace=YOUR_NAMESPACE -f config.yaml
+    .. code::
 
-   where:
+        helm install https://github.com/jupyterhub/helm-chart/releases/download/v0.1/jupyterhub-0.1.tgz --name=YOUR_CHART --namespace=YOUR_NAMESPACE -f config.yaml
 
-       1. ``--name`` can be whatever you like. People often name this based off of what this helm config does. So perhaps you might call it `jhub` .
-       2. ``--namespace``  is a nifty feature of kubernetes that essentially lets you have multiple sub-deployments using a single helm-chart. People often use this to have both a “live” and a “dev” environment. You can use whatever you like but make it easy to re-type and remember.
-       3. If you get a ``release named <YOUR_CHART> already exists`` error, then you should delete this helm-chart by running ``helm delete --purge <YOUR_CHART>`` . Then reinstall by repeating this step.
+    where:
 
-3. You can see the pods being created with ``kubectl --namespace=YOUR``_NAMESPACE` `get pod``.
+    1. ``--name`` can be whatever you like. People often name this based off of what this helm config does. So perhaps you might call it `jhub` .
+    2. ``--namespace``  is a nifty feature of kubernetes that essentially lets you have multiple sub-deployments using a single helm-chart. People often use this to have both a “live” and a “dev” environment. You can use whatever you like but make it easy to re-type and remember.
+
+    .. note::
+
+        If you get a ``release named <YOUR_CHART> already exists`` error, then you should delete this helm-chart by running ``helm delete --purge <YOUR_CHART>`` . Then reinstall by repeating this step.
+
+3. You can see the pods being created with ``kubectl --namespace=YOUR_NAMESPACE get pod``.
 4. Wait for the hub and proxy pod to get to running. Ignore cull errors for now; that will be fixed by https://github.com/data-8/jupyterhub-k8s/issues/143.
-5. You can find the IP to use for accessing the JupyterHub with ``kubectl --namespace=<YOUR_NAMESPACE>`` ``get svc`` . The external IP for the ‘proxy-public’ service should be accessible in a minute or two.
+5. You can find the IP to use for accessing the JupyterHub with ``kubectl --namespace=<YOUR_NAMESPACE> get svc`` . The external IP for the ‘proxy-public’ service should be accessible in a minute or two.
 6. The default authenticator is ‘dummy’ - any username / password will let you in!
-
-   .. image:: https://lh5.googleusercontent.com/zNIFrF0TmAKVO4RWXXiosPvl33_YdX_hqQJtN8zbSSILjbfEKZ3xCwc3kGkE7xDhIgpxAGQy-n01Ign8UPNSdbSD5qaIYRUOJx4dciHpwK-sduBms-njh7AhPmPk1_N7K51rHfOs
-      :height: 200px
 
 Turning it all off
 ------------------
 
-1. If you want to stop these resources from running, you’ll need to tell google cloud to explicitly turn off the cluster that we have created. This is possible from the web console if you click on the hamburger menu (the 3 horizontal lines) in the top left, and then click on the `Container Engine` section (see figure). Click on the container you wish to delete and press the “delete” button.
-2. Alternatively, you can run the following command to delete the cluster of your choice.
-    ``gcloud container clusters delete YOUR_CLUSTER --zone=YOUR_ZONE``
-3. Now your cluster resources should be gone after a few moments - double check this or you will continue to incur charges!
+1. If you want to stop these resources from running, you’ll need to tell google cloud to explicitly turn off the cluster that we have created. This is possible `from the web console <https://console.cloud.google.com>`_ if you click on the hamburger menu (the 3 horizontal lines) in the top left, and then click on the ``Container Engine`` section (see figure). Click on the container you wish to delete and press the “delete” button.
+
+   .. image:: https://lh5.googleusercontent.com/zNIFrF0TmAKVO4RWXXiosPvl33_YdX_hqQJtN8zbSSILjbfEKZ3xCwc3kGkE7xDhIgpxAGQy-n01Ign8UPNSdbSD5qaIYRUOJx4dciHpwK-sduBms-njh7AhPmPk1_N7K51rHfOs
+      :height: 200px
+
+   .. note::
+
+      Alternatively, you can run the following command to delete the cluster of your choice.
+
+      ``gcloud container clusters delete YOUR_CLUSTER --zone=YOUR_ZONE``
+
+2. Now your cluster resources should be gone after a few moments - double check this or you will continue to incur charges!


### PR DESCRIPTION
There have been bugs in the interactive google console which made these instructions not work...we couldn't figure them out and think it's probably better to just have people use the user SDK anyway since it's less clunky. (this also fixes some random syntax / display issues I noticed)