### PR TITLE
Corrected url to jupyterhub helm-chart

### DIFF
--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -68,7 +68,7 @@ Install JupyterHub
 
    .. code:: bash
 
-      helm install https://github.com/jupyterhub/helm-chart/releases/download/v0.3/jupyterhub-0.3.tgz \
+      helm install https://github.com/jupyterhub/helm-chart/releases/download/v0.3.1/jupyterhub-v0.3.1.tgz \
           --name=<YOUR_RELEASE_NAME> \
           --namespace=<YOUR_NAMESPACE> \
           -f config.yaml


### PR DESCRIPTION
Corrected URL to new address (now jupyterhub-v0.3.x was jupyterhub-0.3.x) and also updated to latest v0.3.1