### PR TITLE
Update conda environment for RTD

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -4,5 +4,6 @@ channels:
 dependencies:
 - python=3.5
 - sphinx>=1.3.6,!=1.5.4
+- mkdocs
 - pip:
     - recommonmark==0.4.0


### PR DESCRIPTION
RTD is currently depending on mkdocs for its default conda build environment. Although we don't use mkdocs, RTD is trying to load mkdocs from the default conda channel and failing https://github.com/rtfd/readthedocs.org/issues/2975. This PR adds mkdocs to our `environment.yml` that uses conda-forge as its channel. This workaround allowed the docs to build until a more suitable fix is added to RTD.