### PR TITLE
Add directive and fix formatting for glossary

### DIFF
--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -3,26 +3,33 @@
 Glossary
 ========
 
-.. Additions to the glossary are welcomed. Please add in alphabetical order.
-
 A partial glossary of terms used in this guide. For more complete
 descriptions of the components in JupyterHub, see `the list of tools
 used in JupyterHub <tools.html>`_. Here we try to keep the definition as
 succinct and relevant as possible, and provide links to learn more details.
 
-admin user
-    A user who can access the JupyterHub admin panel. They can start/stop user
-    pods, and potentially access their notebooks.
+.. Additions to the glossary are welcomed. Please add in alphabetical order.
 
-`authenticator <http://jupyterhub.readthedocs.io/en/stable/authenticators.html>`_
-    The way in which users are authenticated to log into JupyterHub. There are
-    many authenticators available, like GitHub, Google, MediaWiki,
-    Dummy (anyone can log in), etc.
+.. glossary::
 
-culler
-  A separate process that stops the user pods of users who have not been
-  active in a configured interval.
+   admin user
+      A user who can access the JupyterHub admin panel. They can start/stop user
+      pods, and potentially access their notebooks.
 
-persistent storage
-    A filesystem attached to a user pod that allows the user to store
-    notebooks and files that persist across multiple logins.
+   `authenticator <http://jupyterhub.readthedocs.io/en/stable/authenticators.html>`_
+      The way in which users are authenticated to log into JupyterHub. There
+      are many authenticators available, like GitHub, Google, MediaWiki,
+      Dummy (anyone can log in), etc.
+
+   culler
+      A separate process that stops the user pods of users who have not been
+      active in a configured interval.
+
+   docker image
+      A docker image is similar to a recipe that Docker can use to build
+      a working space which gives users the tools, libraries, and capabilities to
+      be productive.
+
+   persistent storage
+      A filesystem attached to a user pod that allows the user to store
+      notebooks and files that persist across multiple logins.


### PR DESCRIPTION
This PR adds a glossary directive and reformats the `glossary.rst` file. With these changes, glossary terms throughout the guide can be linked to the glossary with the following syntax:

```
:term:`word`
```
