### PR TITLE
fix syntax error on helm install

### DIFF
--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -81,7 +81,7 @@ Install JupyterHub
 
    .. code:: bash
 
-      helm install jupyterhub/jupyterhub
+      helm install jupyterhub/jupyterhub \
           --version=v0.4 \
           --name=<YOUR-RELEASE-NAME> \
           --namespace=<YOUR-NAMESPACE> \


### PR DESCRIPTION
add missing backslash for line continuation