### PR TITLE
add timeout to helm install

### DIFF
--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -114,6 +114,11 @@ Install JupyterHub
       you should delete the release by running
       ``helm delete --purge <YOUR-RELEASE-NAME>``. Then reinstall by repeating this
       step. If it persists, also do ``kubectl delete <YOUR-NAMESPACE>`` and try again.
+      
+      If you're pulling from a large Docker image you may get a
+      ``Error: timed out waiting for the condition`` error,
+      add a ``--timeout=SOME-LARGE-NUMBER``
+      parameter to the ``helm install`` command.
 
 2. While Step 1 is running, you can see the pods being created by entering in
    a different terminal:


### PR DESCRIPTION
if you're pulling from a large docker image you might get a ``Error: timed out waiting for the condition``, adding the ``--timeout`` parameters fixes this.