### PR TITLE
[0.5.x] support loading service tokens

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -52,6 +52,18 @@ data:
   {{- end }}
 
   hub.concurrent-spawn-limit: {{ .Values.hub.concurrentSpawnLimit | quote }}
+  {{ if .Values.hub.services -}}
+  hub.services: |
+    # include hub.services *except* api_tokens
+    {{ range $name, $service := .Values.hub.services -}}
+    {{$name}}:
+      {{ range $key, $value := $service -}}
+      {{ if ne $key "apiToken" -}}
+      {{$key}}: {{ $value }}
+      {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
   {{ if .Values.hub.extraConfig -}}
   hub.extra-config.py: |
 {{ .Values.hub.extraConfig | indent 4 }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -25,6 +25,9 @@ spec:
       - name: config
         configMap:
           name: hub-config
+      - name: secret
+        secret:
+          secretName: hub-secret
       {{ if eq .Values.hub.db.type "sqlite-pvc" }}
       - name: hub-db-dir
         persistentVolumeClaim:
@@ -39,6 +42,8 @@ spec:
         volumeMounts:
           - mountPath: /etc/jupyterhub/config/
             name: config
+          - mountPath: /etc/jupyterhub/secret/
+            name: secret
         {{ if eq .Values.hub.db.type "sqlite-pvc" }}
           - mountPath: /srv/jupyterhub
             name: hub-db-dir
@@ -70,15 +75,6 @@ spec:
             secretKeyRef:
               name: hub-secret
               key: proxy.token
-        {{ range $key, $value := .Values.hub.services -}}
-        {{ if $value.apiToken }}
-        - name: "SERVICE_TOKEN_{{$key | upper}}"
-          valueFrom:
-            secretKeyRef:
-              name: hub-secret
-              key: "services.token-{{$key}}"
-        {{ end -}}
-        {{ end -}}
         {{ range $key, $value := .Values.hub.extraEnv -}}
         - name: {{ $key | quote }}
           value: {{ $value | quote }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -70,6 +70,15 @@ spec:
             secretKeyRef:
               name: hub-secret
               key: proxy.token
+        {{ range $key, $value := .Values.hub.services -}}
+        {{ if $value.apiToken }}
+        - name: "SERVICE_TOKEN_{{$key | upper}}"
+          valueFrom:
+            secretKeyRef:
+              name: hub-secret
+              key: "services.token-{{$key}}"
+        {{ end -}}
+        {{ end -}}
         {{ range $key, $value := .Values.hub.extraEnv -}}
         - name: {{ $key | quote }}
           value: {{ $value | quote }}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -10,6 +10,6 @@ data:
   {{- end }}
   {{ range $key, $value := .Values.hub.services -}}
   {{ if $value.apiToken }}
-  services.token-{{$key}}: {{ $value.apiToken | b64enc | quote }}
+  services.token.{{$key}}: {{ $value.apiToken | b64enc | quote }}
   {{ end }}
   {{ end }}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -8,3 +8,8 @@ data:
   {{ if .Values.hub.cookieSecret }}
   hub.cookie-secret: {{ .Values.hub.cookieSecret | b64enc | quote }}
   {{- end }}
+  {{ range $key, $value := .Values.hub.services -}}
+  {{ if $value.apiToken }}
+  services.token-{{$key}}: {{ $value.apiToken | b64enc | quote }}
+  {{ end }}
+  {{ end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -31,6 +31,7 @@ hub:
     requests:
       cpu: 0.2
       memory: 512Mi
+  services: {}
   imagePullPolicy: IfNotPresent
   whitelist:
     users: null


### PR DESCRIPTION
the main part of #165

hub.services is stored in configmap. Token is loaded as SERVICE_TOKEN_[NAME] via hub-secret

For example:

```yaml
hub.services:
  binder:
    admin: true
    apiToken: 'generated-secret'
```