### PR TITLE
[0.5.x] base singleuser-sample on docker-stacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 VERSION=$(shell git rev-parse --short HEAD)
 IMAGE_PREFIX=jupyterhub/k8s
+JUPYTERHUB_VERSION ?= 0.8.0rc1
 PUSH_IMAGES=no
-BUILD_ARGS=
+BUILD_ARGS=--build-arg JUPYTERHUB_VERSION=$(JUPYTERHUB_VERSION)
 
 images: build-images push-images
 build-images: build-image/hub build-image/singleuser-sample

--- a/build.py
+++ b/build.py
@@ -4,6 +4,8 @@ import subprocess
 import argparse
 import yaml
 
+JUPYTERHUB_VERSION = '0.8.0rc1'
+
 def last_git_modified(path):
     return subprocess.check_output([
         'git',
@@ -29,7 +31,8 @@ def build_images(prefix, images, commit_range=None, push=False):
         image_spec = '{}{}:{}'.format(prefix, image, tag)
 
         subprocess.check_call([
-            'docker', 'build', '-t', image_spec, image_path
+            'docker', 'build', '-t', image_spec, image_path,
+            '--build-arg', 'JUPYTERHUB_VERSION=%s' % JUPYTERHUB_VERSION,
         ])
         if push:
             subprocess.check_call([

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -26,8 +26,10 @@ RUN adduser --disabled-password \
     --force-badname \
     ${NB_USER}
 
+ARG JUPYTERHUB_VERSION=0.7.2
+
 RUN pip3 install --no-cache-dir \
-         jupyterhub==0.8.0b5 \
+         jupyterhub==$JUPYTERHUB_VERSION \
          statsd==3.2.1 \
          jupyterhub-dummyauthenticator==0.3.1 \
          jupyterhub-tmpauthenticator==0.4 \

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -26,7 +26,7 @@ RUN adduser --disabled-password \
     --force-badname \
     ${NB_USER}
 
-ARG JUPYTERHUB_VERSION=0.7.2
+ARG JUPYTERHUB_VERSION=0.8
 
 RUN pip3 install --no-cache-dir \
          jupyterhub==$JUPYTERHUB_VERSION \

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -4,5 +4,5 @@ FROM jupyter/base-notebook:ae885c0a6226
 
 # pin jupyterhub to match the Hub version
 # set via --build-arg in Makefile
-ARG JUPYTERHUB_VERSION=0.7.2
+ARG JUPYTERHUB_VERSION=0.8
 RUN pip install --no-cache jupyterhub==$JUPYTERHUB_VERSION

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -2,6 +2,7 @@ FROM jupyter/base-notebook:ae885c0a6226
 
 # conda/pip/apt install additional packages here, if desired.
 
-# Set working directory to $HOME, needed for persistence
-# docker-stacks default is ~/work, which won't exist if we mount $HOME as a volume
-WORKDIR $HOME
+# pin jupyterhub to match the Hub version
+# set via --build-arg in Makefile
+ARG JUPYTERHUB_VERSION=0.7.2
+RUN pip install --no-cache jupyterhub==$JUPYTERHUB_VERSION

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,21 +1,7 @@
-FROM ubuntu:17.04
+FROM jupyter/base-notebook:ae885c0a6226
 
-ENV PATH /srv/venv/bin:$PATH
+# conda/pip/apt install additional packages here, if desired.
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends python3 python3-venv && \
-    apt-get purge && apt-get clean
-
-RUN adduser --disabled-password --gecos "Default Jupyter user" jovyan
-
-RUN mkdir -p /srv/venv && chown -R jovyan:jovyan /srv/venv
-
-USER jovyan
-
-RUN python3 -m venv /srv/venv
-RUN /srv/venv/bin/pip3 install --no-cache-dir notebook ipykernel jupyterhub==0.8.0b5
-
-
-WORKDIR /home/jovyan
-
-EXPOSE 8888
+# Set working directory to $HOME, needed for persistence
+# docker-stacks default is ~/work, which won't exist if we mount $HOME as a volume
+WORKDIR $HOME


### PR DESCRIPTION
Use smallest base-notebook with placeholder for installation of packages.

JUPYTERHUB_VERSION is a build arg and specified in the Makefile

includes #190 to avoid adding unused build arg to binderhub image