### PR TITLE
nicer schema page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+doc/build/
+doc/source/_static/schema.txt
 
 # PyBuilder
 target/

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -6,3 +6,4 @@ dependencies:
 - sphinx>=1.3.6,!=1.5.4
 - pip:
     - recommonmark==0.4.0
+    - pyyaml

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -1,0 +1,27 @@
+div#helm-chart-schema h2,
+div#helm-chart-schema h3,
+div#helm-chart-schema h4,
+div#helm-chart-schema h5,
+div#helm-chart-schema h6 {
+    font-family: courier new;
+}
+
+h3, h3 ~ * {
+  margin-left: 3% !important;
+}
+
+h4, h4 ~ * {
+  margin-left: 6% !important;
+}
+
+h5, h5 ~ * {
+  margin-left: 9% !important;
+}
+
+h6, h6 ~ * {
+  margin-left: 12% !important;
+}
+
+h7, h7 ~ * {
+  margin-left: 15% !important;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,6 +41,9 @@ source_parsers = {
     '.md': 'recommonmark.parser.CommonMarkParser',
 }
 
+def setup(app):
+    app.add_stylesheet('custom.css')
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
@@ -191,3 +194,31 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+
+# Generate the rST for the JSON schema
+import yaml
+with open('../../jupyterhub/schema.yaml') as ff:
+    data = yaml.load(ff)
+
+levels = ['-', '~', '^', '"', ',']
+def parse_yaml(yaml, count=0, pre=''):
+    if 'properties' in yaml:
+        count += 1
+        for key, val in yaml['properties'].items():
+            lines.append(pre+key)
+            lines.append(levels[count] * len(pre+key))
+            lines.append('')
+            if 'description' in val:
+                for ln in val['description'].split('\n'):
+                    lines.append(ln)
+                lines.append('')
+
+            parse_yaml(val, count, pre+'{}.'.format(key))
+        count -= 1
+
+lines = []
+count = 0
+parse_yaml(data)
+
+with open('_static/schema.txt', 'w') as ff:
+    ff.write('\n'.join(lines))

--- a/doc/source/schema.rst
+++ b/doc/source/schema.rst
@@ -11,8 +11,6 @@ off of different Docker images, manage security and authentication, and more.
 Below is a description of the fields that are exposed with the JupyterHub
 helm chart. For more detailed information about some specific things you can do
 with modifications to the helm chart, see the :ref:`extending-jupyterhub` and
-:ref:`user_experience` pages.
+:ref:`user_experience`.
 
-.. literalinclude:: ../../jupyterhub/schema.yaml
-   :language: yaml
-   :linenos:
+.. include:: _static/schema.txt


### PR DESCRIPTION
This adds some python to the end of `conf.py` that generates rST headers based off of the JSON schema. It gives us more control over the information that we expose on the `schema.rst` page, and lets us style it however we like.

e.g. of how it looks now:

http://predictablynoisy.com/zero-to-jupyterhub-k8s/schema.html

thoughts?