### PR TITLE
define proxy.secretToken and NodePort in minikube-config

### DIFF
--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -1,7 +1,13 @@
+proxy:
+  secretToken: 97141abb55ea5321867979cb57bb2e6a86a2f4d6bb166fca45aedb07c212c42d
+  service:
+    type: NodePort
+    nodePort: 31212
+
 hub:
-    cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf
-    db:
-      type: sqlite-memory
+  cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf
+  db:
+    type: sqlite-memory
 
 singleuser:
   storage:


### PR DESCRIPTION
so it can be used unmodified for testing with a predictable URL