### PR TITLE
Call reference documentation reference & not as schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,7 @@ instance/
 
 # Sphinx documentation
 doc/build/
-doc/source/schema.md
+doc/source/reference.md
 
 # PyBuilder
 target/

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -196,7 +196,7 @@ epub_copyright = copyright
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
 
-# Generate the JSON schema markdown file for the docs.
+# Generate the JSON schema markdown file for the reference docs.
 import yaml
 with open('../../jupyterhub/schema.yaml') as ff:
     data = yaml.load(ff)
@@ -222,11 +222,11 @@ count = 0
 parse_yaml(data)
 
 # Generate the `.md` file
-with open('schema.txt', 'r') as ff:
+with open('reference.txt', 'r') as ff:
     new_lines = ff.readlines()
     new_lines = new_lines[1:]
     new_lines = [ln.strip('\n') for ln in new_lines]
 new_lines += lines
 
-with open('schema.md', 'w') as ff:
+with open('reference.md', 'w') as ff:
     ff.write('\n'.join(new_lines))

--- a/doc/source/extending-jupyterhub.rst
+++ b/doc/source/extending-jupyterhub.rst
@@ -5,7 +5,7 @@ Extending your JupyterHub setup
 
 The helm chart used to install JupyterHub has a lot of options for you to tweak.
 For a semi-complete list of the changes you can apply via your helm-chart,
-see the :ref:`helm-chart-schema`.
+see the :ref:`helm-chart-reference`.
 
 .. _apply-config-changes:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -37,7 +37,7 @@ JupyterHub deployment.
 
    extending-jupyterhub
    user-experience
-   schema
+   reference
    tools
 
 

--- a/doc/source/reference.txt
+++ b/doc/source/reference.txt
@@ -1,6 +1,6 @@
 DO NOT EDIT THIS LINE. This file is used in `conf.py to generate schema.md`. Edit below and changes will propagate to the build.
 ```eval_rst
-.. _helm-chart-schema:
+.. _helm-chart-reference:
 ```
 
 # Configuration Reference

--- a/doc/source/schema.txt
+++ b/doc/source/schema.txt
@@ -3,11 +3,11 @@ DO NOT EDIT THIS LINE. This file is used in `conf.py to generate schema.md`. Edi
 .. _helm-chart-schema:
 ```
 
-# Helm Chart Schema
+# Configuration Reference
 
-The [JupyterHub helm chart](https://github.com/jupyterhub/helm-chart). is configurable so that you can customize your Kubernetes setup however you'd like. You can extend user resources, build off of different Docker images, manage security and authentication, and more.
+The [JupyterHub helm chart](https://github.com/jupyterhub/zero-to-jupyterhub-k8s) is configurable so that you can customize your JupyterHub setup however you'd like. You can extend user resources, build off of different Docker images, manage security and authentication, and more.
 
 Below is a description of the fields that are exposed with the JupyterHub helm chart.
-For more detailed information about some specific things you can do with
+For more guided information about some specific things you can do with
 modifications to the helm chart, see the [extending jupyterhub](extending-jupyterhub.html)
 and [user experience](user-experience.html) pages.

--- a/doc/source/user-experience.rst
+++ b/doc/source/user-experience.rst
@@ -16,7 +16,7 @@ groups improves the user experience for all Hub users.
 
 This page contains instructions for a few common ways you can extend the
 user experience for your kubernetes deployment. For a list of all the
-options you can configure with your helm chart, see the :ref:`helm-chart-schema`.
+options you can configure with your helm chart, see the :ref:`helm-chart-reference`.
 
 Tailoring the user environment
 ------------------------------


### PR DESCRIPTION
The schema is an implementation detail, what this is doing is
producing reference docs