### PR TITLE
moving environment.yml to binder folder and freezing bqplot version

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,7 +1,10 @@
-# This is for Binder.
 # Need to install bqplot with conda so it calls the javascript extension.
+name: bqplot
+channels:
+  - conda-forge
+  - anaconda
 dependencies:
-  - bqplot
+  - bqplot=0.9.0
   - pip:
     - sphinx
     - recommonmark


### PR DESCRIPTION
we may remove the cost estimator button soon, but in the meantime this just ensures that it will continue to build now that bqplot has been updated.