### PR TITLE
Support for CILogon auth

### DIFF
--- a/doc/source/extending-jupyterhub.rst
+++ b/doc/source/extending-jupyterhub.rst
@@ -74,6 +74,18 @@ For more information see the full example of Google OAuth2 in the next section.
           clientSecret: "an0ther1ongs3cretstr1ng"
           callbackUrl: "http://<your_jupyterhub_host>/hub/oauth_callback"
 
+**CILogon**
+
+.. code-block:: yaml
+
+      auth:
+        type: cilogon
+        github:
+          clientId: "y0urc1logonc1ient1d"
+          clientSecret: "an0ther1ongs3cretstr1ng"
+          callbackUrl: "http://<your_jupyterhub_host>/hub/oauth_callback"
+
+
 To add a whitelist of usernames add to the config file under `hub`:
 
 .. code-block:: yaml

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -40,9 +40,9 @@ RUN pip3 install --no-cache-dir \
          psycopg2==2.7.1 \
          pycurl==7.43.0 \
          mwoauth==0.3.2 \
+         oauthenticator==0.7.2 \
          cryptography==2.0.3
 
-RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/oauthenticator@80676a3e
 RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@5ed86f1
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -141,6 +141,11 @@ elif auth_type == 'github':
     c.GitHubOAuthenticator.oauth_callback_url = get_config('auth.github.callback-url')
     c.GitHubOAuthenticator.client_id = get_config('auth.github.client-id')
     c.GitHubOAuthenticator.client_secret = get_config('auth.github.client-secret')
+elif auth_type == 'cilogon':
+    c.JupyterHub.authenticator_class = 'oauthenticator.CILogonOAuthenticator'
+    c.CILogonOAuthenticator.oauth_callback_url = get_config('auth.cilogon.callback-url')
+    c.CILogonOAuthenticator.client_id = get_config('auth.cilogon.client-id')
+    c.CILogonOAuthenticator.client_secret = get_config('auth.cilogon.client-secret')
 elif auth_type == 'gitlab':
     c.JupyterHub.authenticator_class = 'oauthenticator.gitlab.GitLabOAuthenticator'
     c.GitLabOAuthenticator.oauth_callback_url = get_config('auth.gitlab.callback-url')

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -26,6 +26,11 @@ data:
   auth.github.client-secret: {{.Values.auth.github.clientSecret | quote}}
   auth.github.callback-url: {{.Values.auth.github.callbackUrl | quote}}
   {{- end }}
+  {{ if eq .Values.auth.type "cilogon" -}}
+  auth.cilogon.client-id: {{.Values.auth.cilogon.clientId | quote}}
+  auth.cilogon.client-secret: {{.Values.auth.cilogon.clientSecret | quote}}
+  auth.cilogon.callback-url: {{.Values.auth.cilogon.callbackUrl | quote}}
+  {{- end }}
   {{ if eq .Values.auth.type "gitlab" -}}
   auth.gitlab.client-id: {{.Values.auth.gitlab.clientId | quote}}
   auth.gitlab.client-secret: {{.Values.auth.gitlab.clientSecret | quote}}


### PR DESCRIPTION
Added support for CILogon auth in the configuration yaml.

There is an issue which is unrelated to k8s with CILogon and Jupyterhub 0.8, see https://github.com/jupyterhub/oauthenticator/issues/132.

I implemented a quick workaround in Jupyterhub (https://github.com/jupyterhub/jupyterhub/pull/1474) and tested that CILogon is working properly in my setup.
A proper fix should be ready soon see https://github.com/jupyterhub/oauthenticator/issues/133, I can then update this PR.