### PR TITLE
Allow mutliple extraEnv entries

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -111,9 +111,9 @@ data:
   {{- end }}
   {{ if .Values.singleuser.extraEnv -}}
   singleuser.extra-env: |
-    {{ range $key, $value := .Values.singleuser.extraEnv -}}
+    {{ range $key, $value := .Values.singleuser.extraEnv }}
     {{ $key | quote }}: {{ $value | quote }}
-    {{- end }}
+    {{ end }}
   {{- end }}
   token.cookie_secret: {{ .Values.hub.cookieSecret | quote }}
   hub.base_url: {{ .Values.hub.baseUrl | quote }}


### PR DESCRIPTION
When I tried to specify multiple entries in extraEnv, the hub pod would get stuck in a crash loop.  The logs indicated a problem parsing `/etc/jupyterhub/config/hub.extra-config.py`.  As best I could guess from the error message, it was getting everything on a single line.

This change in the templating seems to solve the problem.