### PR TITLE
pass storage class parameter through

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -71,7 +71,7 @@ storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':
     c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
     c.KubeSpawner.user_storage_pvc_ensure = True
-    storage_class = get_config('singleuser.storage.class')
+    storage_class = get_config('singleuser.storage.dynamic.storageclass', None)
     if storage_class:
         c.KubeSpawner.user_storage_class = storage_class
     c.KubeSpawner.user_storage_access_modes = ['ReadWriteOnce']

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -71,7 +71,7 @@ storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':
     c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
     c.KubeSpawner.user_storage_pvc_ensure = True
-    storage_class = get_config('singleuser.storage.dynamic.storageclass', None)
+    storage_class = get_config('singleuser.storage.dynamic.storage-class', None)
     if storage_class:
         c.KubeSpawner.user_storage_class = storage_class
     c.KubeSpawner.user_storage_access_modes = ['ReadWriteOnce']

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -71,7 +71,9 @@ storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':
     c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
     c.KubeSpawner.user_storage_pvc_ensure = True
-    c.KubeSpawner.user_storage_class = get_config('singleuser.storage.class')
+    storage_class = get_config('singleuser.storage.class')
+    if storage_class:
+        c.KubeSpawner.user_storage_class = storage_class
     c.KubeSpawner.user_storage_access_modes = ['ReadWriteOnce']
     c.KubeSpawner.user_storage_capacity = get_config('singleuser.storage.capacity')
 

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -90,6 +90,7 @@ data:
   singleuser.storage.extra-volume-mounts: {{ toJson .Values.singleuser.storage.extraVolumeMounts | quote }}
   {{ if eq .Values.singleuser.storage.type "dynamic" -}}
   singleuser.storage.capacity: {{.Values.singleuser.storage.capacity | quote }}
+  singleuser.storage.class: {{.Values.singleuser.storage.class | quote }}
   {{ else if eq .Values.singleuser.storage.type "static" -}}
   singleuser.storage.static.pvc-name: {{ .Values.singleuser.storage.static.pvcName | quote }}
   singleuser.storage.static.sub-path: {{ .Values.singleuser.storage.static.subPath | quote }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -90,7 +90,9 @@ data:
   singleuser.storage.extra-volume-mounts: {{ toJson .Values.singleuser.storage.extraVolumeMounts | quote }}
   {{ if eq .Values.singleuser.storage.type "dynamic" -}}
   singleuser.storage.capacity: {{.Values.singleuser.storage.capacity | quote }}
-  singleuser.storage.class: {{.Values.singleuser.storage.class | quote }}
+  {{ if .Values.singleuser.storage.dynamic.storageclass -}}
+  singleuser.storage.dynamic.storageclass: {{ .Values.singleuser.storage.dynamic.storageclass | quote }}
+  {{- end }}
   {{ else if eq .Values.singleuser.storage.type "static" -}}
   singleuser.storage.static.pvc-name: {{ .Values.singleuser.storage.static.pvcName | quote }}
   singleuser.storage.static.sub-path: {{ .Values.singleuser.storage.static.subPath | quote }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -90,8 +90,8 @@ data:
   singleuser.storage.extra-volume-mounts: {{ toJson .Values.singleuser.storage.extraVolumeMounts | quote }}
   {{ if eq .Values.singleuser.storage.type "dynamic" -}}
   singleuser.storage.capacity: {{.Values.singleuser.storage.capacity | quote }}
-  {{ if .Values.singleuser.storage.dynamic.storageclass -}}
-  singleuser.storage.dynamic.storageclass: {{ .Values.singleuser.storage.dynamic.storageclass | quote }}
+  {{ if .Values.singleuser.storage.dynamic.storageClass -}}
+  singleuser.storage.dynamic.storage-class: {{ .Values.singleuser.storage.dynamic.storageClass | quote }}
   {{- end }}
   {{ else if eq .Values.singleuser.storage.type "static" -}}
   singleuser.storage.static.pvc-name: {{ .Values.singleuser.storage.static.pvcName | quote }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -109,6 +109,7 @@ singleuser:
       subPath: '{username}'
     capacity: 10Gi
     homeMountPath: /home/jovyan
+    class: null
   image:
     name: jupyterhub/k8s-singleuser-sample
     tag: v0.4

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -110,7 +110,7 @@ singleuser:
     capacity: 10Gi
     homeMountPath: /home/jovyan
     dynamic:
-      storageclass:
+      storageClass:
   image:
     name: jupyterhub/k8s-singleuser-sample
     tag: v0.4

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -109,7 +109,8 @@ singleuser:
       subPath: '{username}'
     capacity: 10Gi
     homeMountPath: /home/jovyan
-    class: null
+    dynamic:
+      storageclass:
   image:
     name: jupyterhub/k8s-singleuser-sample
     tag: v0.4


### PR DESCRIPTION
it was used by `KubeSpawner` but not available in `helm`. I tested it with a `rook-block` storage class and worked fine.