### PR TITLE
Add note about making yourself superuser on GKE

### DIFF
--- a/doc/source/create-k8s-cluster.rst
+++ b/doc/source/create-k8s-cluster.rst
@@ -87,6 +87,14 @@ connect your credit card or other payment method to your google cloud account.
 
    The response should list three running nodes.
 
+6. Give your account super-user permissions, allowing you to perform all
+   the actions needed to set up JupyterHub.
+
+   .. code-block:: bash
+
+      kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=<your-email-address>
+
+
 .. _microsoft-azure:
 
 Setting up Kubernetes on Microsoft Azure Container Service (ACS)


### PR DESCRIPTION
This is needed if you don't want the helm init sequence to fail.
Note that with Kubernetes 1.8 GKE mandates RBAC, so we can't go
back to the simpler times of everything being root.