### PR TITLE
Simplify secretToken + cookieSecret specification

### DIFF
--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -23,31 +23,24 @@ For the following steps, use your favorite code editor. We'll use the
    entering ``nano config.yaml`` at the terminal will start the editor and
    open the config file.
 
-2. Create two random hex strings to use as security tokens. Run these two
-   commands (they’re the same command but run them twice) in a terminal:
+2. Create a random hex string to use as a security token. Run this command
+   in a terminal
 
    .. code-block:: bash
 
        openssl rand -hex 32
-       openssl rand -hex 32
 
-   Copy the output each time, we’ll use these hex strings in the next step.
+   Copy the output for use in the next step
 
 3. Insert these lines into the ``config.yaml`` file. When editing YAML files,
    use straight quotes and spaces and avoid using curly quotes or tabs.
-   Substitute each occurrence of ``RANDOM_STRING_N`` below with the output of
-   ``openssl rand -hex 32``. The random hex strings are tokens that will be used
-   to secure your JupyterHub instance (make sure that you keep the quotation
-   marks):
+   Substitute ``RANDOM_STRING`` below with the output of ``openssl rand -hex 32``
+   from step 2.
 
    .. code-block:: yaml
 
-      hub:
-        # output of first execution of 'openssl rand -hex 32'
-        cookieSecret: "RANDOM_STRING_1"
       proxy:
-        # output of second execution of 'openssl rand -hex 32'
-        secretToken: "RANDOM_STRING_2"
+        secretToken: "RANDOM_STRING"
 
 .. Don't put an example here! People will just copy paste that & that's a security issue.
 

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hub-secret
 type: Opaque
 data:
-  # {{ required "proxy.secretToken must be a 32byte random string generated with openssl rand -hex 32" .Values.proxy.secretToken }}
+  # {{ required "proxy.secretToken must be a 32 byte random string generated with `openssl rand -hex 32`" .Values.proxy.secretToken }}
   proxy.token: {{ .Values.proxy.secretToken | b64enc | quote }}
   {{ if .Values.hub.cookieSecret }}
   hub.cookie-secret: {{ .Values.hub.cookieSecret | b64enc | quote }}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hub-secret
 type: Opaque
 data:
+  # {{ required "proxy.secretToken must be a 32byte random string generated with openssl rand -hex 32" .Values.proxy.secretToken }}
   proxy.token: {{ .Values.proxy.secretToken | b64enc | quote }}
   {{ if .Values.hub.cookieSecret }}
   hub.cookie-secret: {{ .Values.hub.cookieSecret | b64enc | quote }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -36,7 +36,7 @@ hub:
   imagePullPolicy: IfNotPresent
 
 proxy:
-  secretToken: generate with openssl rand -hex 64
+  secretToken: ''
   rbac:
     enabled: false
   service:


### PR DESCRIPTION
- No need to ask users to generate 2 random strings
- Not specifying proxy.secretToken will actually produce an informative error message