### PR TITLE
Move whitelist & admin options under 'auth'

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -210,7 +210,7 @@ c.JupyterHub.admin_access = get_config('admin.access')
 
 c.Authenticator.admin_users = get_config('admin.users', [])
 
-c.Authenticator.whitelist = get_config('hub.whitelist.users', [])
+c.Authenticator.whitelist = get_config('auth.whitelist.users', [])
 
 c.JupyterHub.services = []
 

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -205,10 +205,10 @@ c.KubeSpawner.environment = {
 c.KubeSpawner.environment.update(get_config('singleuser.extra-env', {}))
 
 # Enable admins to access user servers
-c.JupyterHub.admin_access = get_config('admin.access')
+c.JupyterHub.admin_access = get_config('auth.admin.access')
 
 
-c.Authenticator.admin_users = get_config('admin.users', [])
+c.Authenticator.admin_users = get_config('auth.admin.users', [])
 
 c.Authenticator.whitelist = get_config('auth.whitelist.users', [])
 

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -136,12 +136,10 @@ data:
   {{ else -}}
   hub.db_url: {{ .Values.hub.db.url | quote }}
   {{- end }}
-  admin.access: {{ .Values.admin.access | quote }}
-  {{ if .Values.admin.users -}}
+  auth.admin.access: {{ .Values.auth.admin.access | quote }}
+  {{ if .Values.auth.admin.users -}}
   admin.users: |
-    {{ range $user := .Values.admin.users -}}
-    - {{ $user }}
-    {{ end }}
+{{ .Values.auth.admin.users | indent 4 }}
   {{- end }}
   {{ range $key, $value := .Values.hub.extraConfigMap -}}
   custom.{{ $key }}: {{ toJson $value | quote }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -42,6 +42,10 @@ data:
   auth.mediawiki.index-url: {{.Values.auth.mediawiki.indexUrl | quote}}
   {{- end }}
 
+  {{ if .Values.auth.whitelist.users -}}
+  auth.whitelist.users: |
+{{ .Values.auth.whitelist.users | indent 4}}
+  {{- end }}
   {{ if eq .Values.auth.type "dummy" -}}
   {{ if .Values.auth.dummy.password -}}
   auth.dummy.password: {{ .Values.auth.dummy.password | quote }}
@@ -131,12 +135,6 @@ data:
   hub.db_url: "sqlite://"
   {{ else -}}
   hub.db_url: {{ .Values.hub.db.url | quote }}
-  {{- end }}
-  {{ if .Values.hub.whitelist.users -}}
-  hub.whitelist.users: |
-    {{ range $user := .Values.hub.whitelist.users -}}
-    - {{ $user }}
-    {{ end }}
   {{- end }}
   admin.access: {{ .Values.admin.access | quote }}
   {{ if .Values.admin.users -}}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -33,8 +33,6 @@ hub:
       memory: 512Mi
   services: {}
   imagePullPolicy: IfNotPresent
-  whitelist:
-    users:
 
 proxy:
   secretToken: generate with openssl rand -hex 64
@@ -91,6 +89,8 @@ proxy:
 # Google OAuth secrets
 auth:
   type: dummy
+  whitelist:
+    users:
   dummy:
     password:
 

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -91,6 +91,9 @@ auth:
   type: dummy
   whitelist:
     users:
+  admin:
+    access: true
+    users:
   dummy:
     password:
 
@@ -140,6 +143,3 @@ cull:
   timeout: 3600
   every: 600
 
-admin:
-  access: true
-  users:


### PR DESCRIPTION
This is where they logically belong, rather than under hub or as a top level entry.