### PR TITLE
Provide defaults for master that at least sort of work

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -26,7 +26,7 @@ hub:
   extraEnv: {}
   image:
     name: jupyterhub/k8s-hub
-    tag: v0.4
+    tag: 0f87fa7
   resources:
     requests:
       cpu: 0.2
@@ -117,7 +117,7 @@ singleuser:
       storageClass:
   image:
     name: jupyterhub/k8s-singleuser-sample
-    tag: v0.4
+    tag: 3bf055a
   cpu:
     limit:
     guarantee:


### PR DESCRIPTION
Currently running master directly will fail, since the image
being specified is too old. This fixes it a little by updating
to more recent image. This isn't a long term solution, since
we need to keep bumping it manually every time we change the image.
But it helps people out right now who wanna run master...

Fixes #252 