### PR TITLE
Allow explicitly setting 'hub.db.upgrade' to force upgrades

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -44,9 +44,22 @@ spec:
           - jupyterhub
           - --config
           - /srv/jupyterhub_config.py
-          {{ if or (eq .Values.hub.db.type "sqlite-pvc") .Values.hub.db.upgrade }}
-          # Automatic db upgrades for sqlite!
+          # We want to do automatic upgrades for sqlite-pvc by default, but allow users
+          # to opt out of that if they want. Users using their own db need to 'opt in'
+          # Go Templates treat nil and "" and false as 'false', making this code complex.
+          # We can probably make this a one-liner, but doing combinations of boolean vars
+          # in go templates is very inelegant & hard to reason about.
+          {{- $upgradeType := typeOf .Values.hub.db.upgrade }}
+          {{- if eq $upgradeType "bool" }}
+          # .Values.hub.db.upgrade has been explicitly set to true or false
+          {{- if .Values.hub.db.upgrade }}
           - --upgrade-db
+          {{- end }}
+          {{- else if eq $upgradeType "<nil>" }}
+          # .Values.hub.db.upgrade is nil
+          {{- if eq .Values.hub.db.type "sqlite-pvc" }}
+          - --upgrade-db
+          {{- end }}
           {{- end }}
         volumeMounts:
           - mountPath: /etc/jupyterhub/config/

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           - jupyterhub
           - --config
           - /srv/jupyterhub_config.py
-          {{ if eq .Values.hub.db.type "sqlite-pvc" }}
+          {{ if or (eq .Values.hub.db.type "sqlite-pvc") .Values.hub.db.upgrade }}
           # Automatic db upgrades for sqlite!
           - --upgrade-db
           {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -12,6 +12,7 @@ hub:
   activeServerLimit:
   db:
     type: sqlite-pvc
+    upgrade: false
     pvc:
       annotations: {}
       selector: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -12,7 +12,7 @@ hub:
   activeServerLimit:
   db:
     type: sqlite-pvc
-    upgrade: false
+    upgrade: null
     pvc:
       annotations: {}
       selector: {}


### PR DESCRIPTION
This is for people *not* on SQLite. This allows them to do an upgrade
by doing a deploy with this setting set to true, rather than having
to hunt down which version of JupyterHub we're running in the helm
chart and use that to upgrade.