### PR TITLE
Put [jupyterhub] in commit messages when pushing built charts

### DIFF
--- a/build.py
+++ b/build.py
@@ -86,7 +86,7 @@ def publish_pages():
     subprocess.check_call([
         'git',
         'commit',
-        '-m', 'Automatic update for commit {}'.format(version)
+        '-m', '[jupyterhub] Automatic update for commit {}'.format(version)
     ], cwd='gh-pages')
     subprocess.check_call(
         ['git', 'push', 'origin', 'gh-pages'],


### PR DESCRIPTION
To differentiate it from the binderhub chart pushes