### PR TITLE
Use hub.baseUrl for ingress path

### DIFF
--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -14,11 +14,12 @@ metadata:
     {{- end }}
 spec:
   rules:
+    {{- $root := . -}}
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: {{ $root.Values.hub.baseUrl }}
             backend:
               serviceName: proxy-public
               servicePort: 80


### PR DESCRIPTION
If `hub.baseUrl` is set this is probably because a user wants to host multiple web services under a domain. The Ingress controller should therefore use this as the path instead of `/`.