### PR TITLE
configmap admin.users should be prefixed by auth.

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -146,7 +146,7 @@ data:
   {{- end }}
   auth.admin.access: {{ .Values.auth.admin.access | quote }}
   {{ if .Values.auth.admin.users -}}
-  admin.users: |
+  auth.admin.users: |
 {{ .Values.auth.admin.users | indent 4 }}
   {{- end }}
   {{ range $key, $value := .Values.hub.extraConfigMap -}}


### PR DESCRIPTION
`admin.users` in the hub config map doesn't match `auth.admin.users` in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/3ebd38bf6b3b564ecead63b30606499f4cb41fc1/images/hub/jupyterhub_config.py#L220