### PR TITLE
Ensure newlines are present in services config

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -79,8 +79,8 @@ data:
       {{ if ne $key "apiToken" -}}
       {{$key}}: {{ $value }}
       {{- end }}
-      {{- end }}
-    {{- end }}
+      {{ end }}
+    {{ end }}
   {{- end }}
   {{ if .Values.hub.extraConfig -}}
   hub.extra-config.py: |


### PR DESCRIPTION
The current configmap leads to an incorrect service yaml. For example, this config:
```
hub:
  baseUrl: /test1/
  cookieSecret: XXXXXXXX
  db:
    type: sqlite-memory
  extraConfig: |
    # https://github.com/jupyterhub/jupyterhub/wiki/Debug-Jupyterhub
    c.JupyterHub.log_level = 'DEBUG'
    c.Spawner.debug = True
  services:
    showenv:
      admin: true
      command: '["sh", "-c", "env | grep JUPYTER; exit 1"]'
    cull-idle-localhost:
      admin: true
      command: '["/usr/local/bin/cull_idle_servers.py", "--timeout=3600", "--cull-every=600", "--url=http://127.0.0.1:8081/test1/hub/api"]'

cull:
  enabled: false
```
leads to this `hub.service` key:`kubectl get cm hub-config -o yaml`
```
  hub.services: |
    # include hub.services *except* api_tokens
    cull-idle-localhost:
      admin: truecommand: ["/usr/local/bin/cull_idle_servers.py", "--timeout=3600", "--cull-every=600", "--url=http://127.0.0.1:8081/test1/hub/api"]showenv:
      admin: truecommand: ["sh", "-c", "env | grep JUPYTER; exit 1"]
```
Note the missing newlines between multiple key-values in a service, and the missing newline between the two services.

With this PR this is the output:
```
  hub.services: "# include hub.services *except* api_tokens\ncull-idle-localhost:\n
    \ admin: true\n  command: [\"/usr/local/bin/cull_idle_servers.py\", \"--timeout=3600\",
    \"--cull-every=600\", \"--url=http://127.0.0.1:8081/test1/hub/api\"]\n  \nshowenv:\n
    \ admin: true\n  command: [\"sh\", \"-c\", \"env | grep JUPYTER; exit 1\"]\n  \n"
```



