### PR TITLE
Change heading levels in 'turn-it-off'

### DIFF
--- a/doc/source/turn-off.rst
+++ b/doc/source/turn-off.rst
@@ -37,7 +37,7 @@ before doing the cloud provider specific setup.
       kubectl delete namespace <your-namespace>
 
 Google Cloud Platform
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 1. Perform the steps above for all cloud providers. These cloud provider agnostic steps will
    delete the helm chart and delete the hub's namespace. This must be done before proceeding.
@@ -71,7 +71,7 @@ Google Cloud Platform
    related to your JupyterHub cluster after you have deleted the cluster.
 
 Amazon Web Services (AWS)
-~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------
 
 1. Perform the steps above for all cloud providers. These cloud provider agnostic steps will
    delete the helm chart and delete the hub's namespace. This must be done before proceeding.


### PR DESCRIPTION
The current setup, where we have:

```
<h3> "For all clouds"

<instructions>

<h4> <specific-cloud-instructions>
```

Seem strange to me, since it's putting "GKE" or "AWS" 'under'
"For all clouds". It also makes the ToC a bit strange.

Not sure if this is the right thing to do!