### PR TITLE
Bump kubespawner version

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -43,7 +43,7 @@ RUN pip3 install --no-cache-dir \
          oauthenticator==0.7.2 \
          cryptography==2.0.3
 
-RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@06f3d6c
+RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@06a2e09
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 ADD cull_idle_servers.py /usr/local/bin/cull_idle_servers.py


### PR DESCRIPTION
Gets in https://github.com/jupyterhub/kubespawner/pull/103. The chart is broken
without it.