### PR TITLE
Added Globus Integration

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -40,6 +40,7 @@ RUN pip3 install --no-cache-dir \
          psycopg2==2.7.1 \
          pycurl==7.43.0 \
          mwoauth==0.3.2 \
+         globus_sdk[jwt]==1.2.1 \
          oauthenticator==0.7.2 \
          cryptography==2.0.3
 

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -167,6 +167,12 @@ elif auth_type == 'mediawiki':
     c.MWOAuthenticator.client_id = get_config('auth.mediawiki.client-id')
     c.MWOAuthenticator.client_secret = get_config('auth.mediawiki.client-secret')
     c.MWOAuthenticator.index_url = get_config('auth.mediawiki.index-url')
+elif auth_type == 'globus':
+    c.JupyterHub.authenticator_class = 'oauthenticator.globus.GlobusOAuthenticator'
+    c.GlobusOAuthenticator.oauth_callback_url = get_config('auth.globus.callback-url')
+    c.GlobusOAuthenticator.client_id = get_config('auth.globus.client-id')
+    c.GlobusOAuthenticator.client_secret = get_config('auth.globus.client-secret')
+    c.GlobusOAuthenticator.identity_provider = get_config('auth.globus.identity-provider', '')
 elif auth_type == 'hmac':
     c.JupyterHub.authenticator_class = 'hmacauthenticator.HMACAuthenticator'
     c.HMACAuthenticator.secret_key = bytes.fromhex(get_config('auth.hmac.secret-key'))

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -41,6 +41,12 @@ data:
   auth.mediawiki.client-secret: {{.Values.auth.mediawiki.clientSecret | quote}}
   auth.mediawiki.index-url: {{.Values.auth.mediawiki.indexUrl | quote}}
   {{- end }}
+  {{ if eq .Values.auth.type "globus" -}}
+  auth.globus.client-id: {{.Values.auth.globus.clientId | quote}}
+  auth.globus.client-secret: {{.Values.auth.globus.clientSecret | quote}}
+  auth.globus.callback-url: {{.Values.auth.globus.callbackUrl | quote}}
+  auth.globus.identity-provider: {{.Values.auth.globus.identityProvider | quote}}
+  {{- end }}
 
   {{ if .Values.auth.whitelist.users -}}
   auth.whitelist.users: |


### PR DESCRIPTION
The following changes add Globus as an identity provider, with very similar configuration to the other OAuthenticators: 

    auth:
      type: globus
      globus:
        clientId: "my-client-id"
        clientSecret: "my-client-secret"
        callbackUrl: "https://my-domain/hub/oauth_callback"

Tested with the latest merged changes to the kubespawner: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/292
See also: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/227