### PR TITLE
Allow setting extra sidecar containers to the hub

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         runAsUser: {{ .Values.hub.uid }}
         fsGroup: {{ .Values.hub.fsGid }}
       containers:
+      {{- if .Values.hub.extraContainers }}
+{{ toYaml .Values.hub.extraContainers | indent 6 }}
+      {{ end }}
       - name: hub-container
         image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
         command:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -25,6 +25,7 @@ hub:
   extraConfig: ''
   extraConfigMap: {}
   extraEnv: {}
+  extraContainers: []
   image:
     name: jupyterhub/k8s-hub
     tag: a27db6f


### PR DESCRIPTION
This allows for easier customization of the hub pod. Primarily
useful when you need a sidecar db proxy, such as when using
Google Cloud's managed SQL options (https://cloud.google.com/sql/docs/postgres/sql-proxy)