### PR TITLE
Change RBAC to true

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -36,7 +36,7 @@ hub:
   imagePullPolicy: IfNotPresent
 
 rbac:
-  enabled: false
+  enabled: true
 
 proxy:
   secretToken: ''


### PR DESCRIPTION
Newer kubernetes cluster setups almost always come with RBAC
enforced, so let's work by default on them.