### PR TITLE
restore ability to specify nodePort on proxy service

### DIFF
--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -52,10 +52,17 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 80
+      # allow proxy.service.nodePort for http
+      {{ if .Values.proxy.service.nodePorts.http -}}
+      nodePort: {{ .Values.proxy.service.nodePorts.http }}
+      {{- end }}
     - name: https
       port: 443
       protocol: TCP
       targetPort: 443
+      {{ if .Values.proxy.service.nodePorts.https -}}
+      nodePort: {{ .Values.proxy.service.nodePorts.https }}
+      {{- end }}
   selector:
     name: proxy
     component: proxy

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -45,7 +45,9 @@ proxy:
     type: LoadBalancer
     labels: {}
     annotations: {}
-    nodePort:
+    nodePorts:
+      http:
+      https:
   chp:
     image:
       name: jupyterhub/configurable-http-proxy

--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -2,7 +2,8 @@ proxy:
   secretToken: 97141abb55ea5321867979cb57bb2e6a86a2f4d6bb166fca45aedb07c212c42d
   service:
     type: NodePort
-    nodePort: 31212
+    nodePorts:
+      http: 31212
 
 hub:
   cookieSecret: 1470700e01f77171c2c67b12130c25081dfbdf2697af8c2f2bd05621b31100bf


### PR DESCRIPTION
use a dict now that there are two ports (http, https)

useful with minikube, required for binderhub testing