### PR TITLE
disable rbac on minikube

### DIFF
--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -16,4 +16,7 @@ singleuser:
     guarantee: null
 
 prePuller:
-  enabled: False
+  enabled: false
+
+rbac:
+  enabled: false


### PR DESCRIPTION
since it's usually not available and now on by default