### PR TITLE
Fix hub service pod selector

### DIFF
--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -8,7 +8,7 @@ spec:
   loadBalancerIP: {{ .Values.hub.service.loadBalancerIP }}
   {{- end }}
   selector:
-    name: hub-pod
+    name: hub
   ports:
     - protocol: TCP
       port: 8081


### PR DESCRIPTION
I just ran into this whilst working on travis/minikube tests (#289)

Related to the change in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/319
