### PR TITLE
Install helm chart in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,14 @@ install:
 - helm init --client-only
 script:
 - |
-  if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+  if [[ "$TRAVIS_PULL_REQUEST" == "false" && ( "$TRAVIS_BRANCH" = master || "$TRAVIS_BRANCH" == v0.4.x ) ]]; then
     docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
     export PUSH="--push --publish-chart"
   fi
 - "./build.py build --commit-range ${TRAVIS_COMMIT_RANGE} $PUSH"
-branches:
-  only:
-  - master
-  - v0.4.x
 before_install:
 - |
-  if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+  if [[ "$TRAVIS_PULL_REQUEST" == "false" && ( "$TRAVIS_BRANCH" = master || "$TRAVIS_BRANCH" == v0.4.x ) ]]; then
     openssl aes-256-cbc -K $encrypted_c6b45058ffe8_key -iv $encrypted_c6b45058ffe8_iv -in travis.enc -out travis -d
     chmod 0400 travis
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,8 @@ services:
 - docker
 install:
 - pip install --no-cache-dir ruamel.yaml python-dateutil
-- mkdir -p bin
-- export PATH=$PWD/bin:$PATH
-- curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz | tar -xz -C bin --strip-components 1 linux-amd64/helm
-- chmod +x bin/helm
-- helm init --client-only
+- . ci/minikube.env
+- ./ci/install.sh
 script:
 - |
   if [[ "$TRAVIS_PULL_REQUEST" == "false" && ( "$TRAVIS_BRANCH" = master || "$TRAVIS_BRANCH" == v0.4.x ) ]]; then
@@ -17,6 +14,7 @@ script:
     export PUSH="--push --publish-chart"
   fi
 - "./build.py build --commit-range ${TRAVIS_COMMIT_RANGE} $PUSH"
+- ./ci/test.sh
 before_install:
 - |
   if [[ "$TRAVIS_PULL_REQUEST" == "false" && ( "$TRAVIS_BRANCH" = master || "$TRAVIS_BRANCH" == v0.4.x ) ]]; then

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provider "virtualbox" do |vb|
+     vb.memory = "3072"
+     vb.cpus = 2
+  end
+  config.vm.provision "shell", path: "trusty-setup.sh"
+  config.vm.synced_folder "../", "/zero-to-jupyterhub-k8s"
+end

--- a/ci/Vagrantfile
+++ b/ci/Vagrantfile
@@ -1,6 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# To test in vagrant:
+# vagrant up
+# vagrant ssh
+# . ci/minikube.env
+# /zero-to-jupyterhub-k8s/install.sh
+# /zero-to-jupyterhub-k8s/test.sh
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.provider "virtualbox" do |vb|

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -ex
+# install nsenter if missing (needed by kube on trusty)
+if ! which nsenter; then
+  curl -L https://github.com/minrk/git-crypt-bin/releases/download/trusty/nsenter > nsenter
+  echo "5652bda3fbea6078896705130286b491b6b1885d7b13bda1dfc9bdfb08b49a2e  nsenter" | shasum -a 256 -c -
+  chmod +x nsenter
+  sudo mv nsenter /usr/local/bin/
+fi
+
+# install kubectl, minikube
+# based on https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
+echo "installing kubectl"
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl
+chmod +x kubectl
+mv kubectl bin/
+
+echo "installing minikube"
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_VERSION}/minikube-linux-amd64
+chmod +x minikube
+mv minikube bin/
+
+echo "starting minikube"
+sudo $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
+minikube update-context
+
+echo "waiting for kubernetes"
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
+  sleep 1
+done
+
+echo "installing helm"
+curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz \
+  | tar -xz -C bin --strip-components 1 linux-amd64/helm
+chmod +x bin/helm
+helm init
+
+echo "waiting for tiller"
+until helm version; do
+    sleep 1
+  done
+helm version
+
+echo "installing git-crypt"
+curl -L https://github.com/minrk/git-crypt-bin/releases/download/0.5.0/git-crypt > bin/git-crypt
+echo "46c288cc849c23a28239de3386c6050e5c7d7acd50b1d0248d86e6efff09c61b  bin/git-crypt" | shasum -a 256 -c -
+chmod +x bin/git-crypt

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -ex
+
+mkdir -p bin
+
 # install nsenter if missing (needed by kube on trusty)
 if ! which nsenter; then
   curl -L https://github.com/minrk/git-crypt-bin/releases/download/trusty/nsenter > nsenter
@@ -21,7 +24,7 @@ chmod +x minikube
 mv minikube bin/
 
 echo "starting minikube"
-sudo $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
+sudo CHANGE_MINIKUBE_NONE_USER=true $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
 minikube update-context
 
 echo "waiting for kubernetes"
@@ -29,6 +32,7 @@ JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.ty
 until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
   sleep 1
 done
+kubectl get nodes
 
 echo "installing helm"
 curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz \

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -1,0 +1,3 @@
+export MINIKUBE_VERSION=0.24.1
+export KUBE_VERSION=1.8.0
+export PATH="$HOME/bin:$PATH"

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -1,3 +1,3 @@
 export MINIKUBE_VERSION=0.24.1
 export KUBE_VERSION=1.8.0
-export PATH="$HOME/bin:$PATH"
+export PATH="$PWD/bin:$PATH"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eux
+
+IP=$(ifconfig eth0 | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')
+TEST_NAMESPACE=jupyterhub-test
+TEST_URL=http://$IP:31212
+
+helm install --name jupyterhub-test --namespace $TEST_NAMESPACE ./jupyterhub/ -f minikube-config.yaml
+
+echo "waiting for pods to become ready"
+JSONPATH='{range .items[*]}{@.status.phase};{end}'
+until kubectl get pod --namespace $TEST_NAMESPACE -o jsonpath="$JSONPATH" | grep -q -i "^\(running;\)\+$"; do
+    kubectl get pod --namespace $TEST_NAMESPACE
+    sleep 1
+done
+
+echo "waiting for servers to become responsive"
+until curl -s $TEST_URL > /dev/null; do
+    sleep 1
+done
+
+echo "checking jupyterhub version"
+curl $TEST_URL/hub/api | grep version

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -12,13 +12,13 @@ echo "waiting for pods to become ready"
 JSONPATH='{range .items[*]}{@.status.phase};{end}'
 until kubectl get pod --namespace $TEST_NAMESPACE -o jsonpath="$JSONPATH" | grep -q -i "^\(running;\)\+$"; do
     kubectl get pod --namespace $TEST_NAMESPACE
-    sleep 1
+    sleep 5
 done
 
 echo "waiting for servers to become responsive"
 until curl -s $TEST_URL > /dev/null; do
-    sleep 1
+    sleep 5
 done
 
-echo "checking jupyterhub version"
-curl $TEST_URL/hub/api | grep version
+echo "getting jupyterhub version"
+curl -s $TEST_URL/hub/api | grep version

--- a/ci/trusty-setup.sh
+++ b/ci/trusty-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eux
+
+apt-get -q update
+apt-get -q install -y socat
+
+# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#install-docker-ce
+apt-get -q install -y linux-image-extra-$(uname -r) linux-image-extra-virtual
+
+#DOCKER_DEB=docker-ce_17.09.0~ce-0~ubuntu_amd64.deb
+DOCKER_DEB=docker-ce_17.03.2~ce-0~ubuntu-trusty_amd64.deb
+curl -O https://download.docker.com/linux/ubuntu/dists/trusty/pool/stable/amd64/$DOCKER_DEB
+# dpkg won't install dependencies
+dpkg -i $DOCKER_DEB || sudo apt-get install -f -y
+docker info
+
+install -o vagrant -g vagrant -d /home/vagrant/bin
+
+# Workaround Minikube DNS problems
+# https://github.com/kubernetes/minikube/issues/2027#issuecomment-338221646
+cat << EOF > /etc/resolv.conf
+nameserver 8.8.4.4
+nameserver 8.8.8.8
+EOF
+sed -i -re "s/^(127.0.0.1\\s.+)/\\1 `hostname`/" /etc/hosts


### PR DESCRIPTION
Install the helm chart in travis.

- Copies ci/install.sh from jupyterhub/binderhub with some minor changes: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/commit/983dbb5f5f6eb9e72938e15e1004309f5ce34ae3
- Adds a Vagrantfile and script to roughly approximate the travis trusty docker environment (makes configuring minikube easier)
- Modifies `.travis.yml` to always run instead of being limited to `master` and `v0.4.x`, but it should only push to those branches (untested)

Closes #289 