### PR TITLE
Solves #251: add a note to the doc on 63 chars limit

### DIFF
--- a/doc/source/user-experience.rst
+++ b/doc/source/user-experience.rst
@@ -58,7 +58,7 @@ existing image, such as the ``scipy-notebook`` image, complete these steps:
 
    .. note::
    
-      Container name cannot be longer than 63 characters.
+      Container image name cannot be longer than 63 characters.
 
       Always use an explicit ``tag``, such as a specific commit.
 

--- a/doc/source/user-experience.rst
+++ b/doc/source/user-experience.rst
@@ -57,6 +57,8 @@ existing image, such as the ``scipy-notebook`` image, complete these steps:
            tag: 8e15d329f1e9
 
    .. note::
+   
+      Container name cannot be longer than 63 characters.
 
       Always use an explicit ``tag``, such as a specific commit.
 


### PR DESCRIPTION
Trivial change in doc to address https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/251