### PR TITLE
use absolute path to travis ssh key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
     docker login -u ${DOCKER_USERNAME} -p "${DOCKER_PASSWORD}"
     export PUSH="--push --publish-chart"
   fi
-- "GIT_SSH_COMMAND='ssh -i travis' ./build.py --commit-range ${TRAVIS_COMMIT_RANGE} $PUSH"
+- GIT_SSH_COMMAND="ssh -i $PWD/travis" ./build.py --commit-range ${TRAVIS_COMMIT_RANGE} $PUSH
 - ./ci/test.sh
 before_install:
 - |


### PR DESCRIPTION
git is run from a few different working directories, so abspath should be more portable

This should fix the build after #325