### PR TITLE
[REVIEW BUT NOT MERGE] Don't restart hub pod to pick up config change

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -42,7 +42,8 @@ RUN pip3 install --no-cache-dir \
          mwoauth==0.3.2 \
          globus_sdk[jwt]==1.2.1 \
          oauthenticator==0.7.2 \
-         cryptography==2.0.3
+         cryptography==2.0.3 \
+         watchdog==0.8.3
 
 RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@v0.7.1
 
@@ -58,4 +59,3 @@ RUN chown ${NB_USER}:${NB_USER} /srv/jupyterhub
 EXPOSE 8081
 
 USER ${NB_USER}
-CMD ["jupyterhub", "--config", "/srv/jupyterhub_config.py"]

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -18,10 +18,6 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-      annotations:
-        # This lets us autorestart when the configmap changes!
-        checksum/config-map: {{ include (print $.Template.BasePath "/hub/configmap.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/hub/secret.yaml") . | sha256sum }}
     spec:
       nodeSelector: {{ toJson .Values.hub.nodeSelector }}
       volumes:
@@ -49,6 +45,18 @@ spec:
       - name: hub-container
         image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
         command:
+          - watchmedo
+          - auto-restart
+          - --directory
+          - /etc/jupyterhub/config/
+          - --directory
+          - /etc/jupyterhub/secret/
+          - --interval
+          - "5"
+          - --ignore-directories
+          - --ignore-pattern
+          - '.*'
+          - --
           - jupyterhub
           - --config
           - /srv/jupyterhub_config.py


### PR DESCRIPTION
Instead, whenever configmap changes, let's just restart the
hub *process*. We launch it with the watchdog manager, which
can restart processes when files change.

We try to have a 5s timeout to make sure that we don't restart
too many times for the same file. We also ignore files starting
with a '.' and directory changes for the same reason.

Note that this means changes can take upto 20s to propagate, 
due to [caching](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically). However,
unlike restarting the pod, it has the following advantages:

1. The hub is still serving traffic during this time
2. No scheduling latency
3. With sqlite on a persistent disk, it could take upto a minute
    for them to restart

So I think it's worth it to make it happen!