### PR TITLE
[REVIEW BUT NOT MERGE YET] Fix idle culler not working in some clusters

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -13,7 +13,6 @@ def get_config(key, default=None):
     try:
         with open(path) as f:
             data = yaml.safe_load(f)
-            print(key, data)
             return data
     except FileNotFoundError:
         return default
@@ -239,6 +238,7 @@ if get_config('cull.enabled', False):
         '/usr/local/bin/cull_idle_servers.py',
         '--timeout=%s' % cull_timeout,
         '--cull-every=%s' % cull_every,
+        '--url=http://127.0.0.1:8081/hub/api'
     ]
     if get_config('cull.users'):
         cull_cmd.append('--cull-users')


### PR DESCRIPTION
In some clusters, 'hairpin mode' does not quite work - you can't
talk to a pod via its service IP from itself. We don't need it,
since we can just use 127.0.0.1. So we do that!

Also remove a debug print that's been in here forever

Better fix for #280