### PR TITLE
Add commands to secure tiller.

### DIFF
--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -60,16 +60,7 @@ Ensure that `tiller is secure <https://engineering.bitnami.com/articles/helm-sec
 
    .. code:: bash
 
-      kubectl -n kube-system patch deployment tiller-deploy --patch '
-      spec:
-        template:
-          spec:
-            containers:
-              - name: tiller
-                ports: []
-                command: ["/tiller"]
-                args: ["--listen=localhost:44134"]
-      '
+      kubectl --namespace=kube-system patch deployment tiller-deploy --type=json --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["/tiller", "--listen=localhost:44134"]}]'
 
 Next Step
 ---------

--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -34,25 +34,6 @@ cluster. At the terminal, enter:
 
 This command only needs to run once per Kubernetes cluster.
 
-Secure Helm
-~~~~~~~~~~~
-
-Ensure that `tiller is secure <https://engineering.bitnami.com/articles/helm-security.html>`_ from access inside the cluster:
-
-   .. code:: bash
-
-      kubectl -n kube-system delete service tiller-deploy
-      kubectl -n kube-system patch deployment tiller-deploy --patch '
-      spec:
-        template:
-          spec:
-            containers:
-              - name: tiller
-                ports: []
-                command: ["/tiller"]
-                args: ["--listen=localhost:44134"]
-      '
-
 Verify
 ------
 
@@ -71,6 +52,25 @@ It should provide output like
       Server: &version.Version{SemVer:"v2.4.1", GitCommit:"46d9ea82e2c925186e1fc620a8320ce1314cbb02", GitTreeState:"clean"}
 
 Make sure you have at least version 2.4.1!
+
+Secure Helm
+~~~~~~~~~~~
+
+Ensure that `tiller is secure <https://engineering.bitnami.com/articles/helm-security.html>`_ from access inside the cluster:
+
+   .. code:: bash
+
+      kubectl -n kube-system delete service tiller-deploy
+      kubectl -n kube-system patch deployment tiller-deploy --patch '
+      spec:
+        template:
+          spec:
+            containers:
+              - name: tiller
+                ports: []
+                command: ["/tiller"]
+                args: ["--listen=localhost:44134"]
+      '
 
 Next Step
 ---------

--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -60,7 +60,6 @@ Ensure that `tiller is secure <https://engineering.bitnami.com/articles/helm-sec
 
    .. code:: bash
 
-      kubectl -n kube-system delete service tiller-deploy
       kubectl -n kube-system patch deployment tiller-deploy --patch '
       spec:
         template:

--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -34,6 +34,24 @@ cluster. At the terminal, enter:
 
 This command only needs to run once per Kubernetes cluster.
 
+### Secure Helm ###
+
+Ensure that `tiller is secure <https://engineering.bitnami.com/articles/helm-security.html>`_ from access inside the cluster:
+
+   .. code:: bash
+
+      kubectl -n kube-system delete service tiller-deploy
+      kubectl -n kube-system patch deployment tiller-deploy --patch '
+      spec:
+        template:
+          spec:
+            containers:
+              - name: tiller
+                ports: []
+                command: ["/tiller"]
+                args: ["--listen=localhost:44134"]
+      '
+
 Verify
 ------
 

--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -34,7 +34,8 @@ cluster. At the terminal, enter:
 
 This command only needs to run once per Kubernetes cluster.
 
-### Secure Helm ###
+Secure Helm
+~~~~~~~~~~~
 
 Ensure that `tiller is secure <https://engineering.bitnami.com/articles/helm-security.html>`_ from access inside the cluster:
 


### PR DESCRIPTION
Tiller is open to connections inside the cluster and someone could try to exploit that. This problem is documented at https://engineering.bitnami.com/articles/helm-security.html.

Until there is an easier fix, I think we need to tell people to essentially `type this` to secure their clusters.