### PR TITLE
resync build.py from binderhub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ development.
 5. Create a virtualenv & install the library required for builds to happen:
    ```bash
    python3 -m venv .
-   pip install ruamel.yaml python_dateutil
+   pip install ruamel.yaml
    ```
  6. Now run `build.py` to build the requisite docker images inside minikube:
     ```bash


### PR DESCRIPTION
Includes fixes needed for it to work with binderhub (https://github.com/jupyterhub/binderhub/pull/343).

None of the changes should affect this repo, other than the removed need for messing with dates.