### PR TITLE
Update required master version for GKE

### DIFF
--- a/doc/source/create-k8s-cluster.rst
+++ b/doc/source/create-k8s-cluster.rst
@@ -64,7 +64,7 @@ connect your credit card or other payment method to your google cloud account.
           --num-nodes=3 \
           --machine-type=n1-standard-2 \
           --zone=us-central1-b \
-          --cluster-version=1.8.4-gke.0
+          --cluster-version=1.8.4-gke.1
 
    where:
 


### PR DESCRIPTION
Previous version is no longer available. This info is gleamed
from https://cloud.google.com/kubernetes-engine/release-notes