### PR TITLE
Bump kubespawner version

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -44,7 +44,7 @@ RUN pip3 install --no-cache-dir \
          oauthenticator==0.7.2 \
          cryptography==2.0.3
 
-RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@v0.7.1
+RUN pip3 --no-cache-dir install git+https://github.com/jupyterhub/kubespawner@5c9bf38
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 ADD cull_idle_servers.py /usr/local/bin/cull_idle_servers.py


### PR DESCRIPTION
https://github.com/jupyterhub/kubespawner/pull/64 got merged!

Note that this is a noop for z2jh users for now. Sometime in the 0.6 or 0.7 timescale
we will enable using the Kubernetes Ingress controllers as an option (not default).