### PR TITLE
Bump version to v0.6.0

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Multi-user Jupyter installation
 name: jupyterhub
-version: v0.5.0
+version: v0.6.0


### PR DESCRIPTION
This starts producing builds in jupyterhub.github.io/helm-chart
that will start as v0.6.0-<hash> rather than the incorrect
v0.5.0-<hash>