### PR TITLE
Fix #372 - build.py corrupts yaml

### DIFF
--- a/build.py
+++ b/build.py
@@ -9,7 +9,7 @@ from ruamel.yaml import YAML
 
 # use safe roundtrip yaml loader
 yaml = YAML(typ='rt')
-yaml.indent(offset=2)
+yaml.indent(mapping=2, offset=2, sequence=4)
 
 def last_modified_commit(*paths, **kwargs):
     return subprocess.check_output([


### PR DESCRIPTION
So the issue is that `sequence=4` is required to give valid yaml when for you have for example the following within your `values.yaml`. It becomes corrupt [when the `dump` method is invoked](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/373/commits/9701a909ad2ff3a01962116ac95083bc1d9879da#diff-2955d5257f635de1df53f55a171ca5c7R103).

```yaml
  # ...
  extraVolumeMounts:
    - name: volume-nbgrader
      mountPath: /home/jovyan/exchange
```

if not, it becomes this corrupt yaml using `sequence=2` as default indentation for some reason [discussed here](https://stackoverflow.com/questions/44388701/how-get-the-sequences-properly-indented-with-ruamel-yaml).

```yaml
  # ...
  extraVolumeMounts:
    - name: volume-nbgrader
    mountPath: /home/jovyan/exchange
```

NOTE: `typ=rt`, `mapping=2`, and `offset=2` are default values and could be removed, but I left them there...

closes #372