### PR TITLE
Only do branch builds for master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ script:
 - ./build.py --commit-range ${TRAVIS_COMMIT_RANGE}
 - ./ci/test.sh
 
+branches:
+  only:
+  - master
+
 deploy:
   provider: script
   skip_cleanup: true


### PR DESCRIPTION
When new PRs come in, sometimes they're based off a branch
in the upstream repo. This causes them to often fail, since
we have branch builds enabled - but we only care about those for
master. This explicitly makes that be the case.