### PR TITLE
Setup a pdb for hub and proxy

### DIFF
--- a/jupyterhub/templates/hub/pdb.yaml
+++ b/jupyterhub/templates/hub/pdb.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.hub.pdb.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: hub
+  labels:
+    app: jupyterhub
+    component: hub
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: jupyterhub
+      component: hub
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+{{- end }}

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.proxy.pdb.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: proxy
+  labels:
+    app: jupyterhub
+    component: proxy
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      # Explicitly not using 'app' since sometimes app needs to be 'kube-lego' for proxy
+      component: proxy
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+{{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -35,6 +35,8 @@ hub:
       memory: 512Mi
   services: {}
   imagePullPolicy: IfNotPresent
+  pdb:
+    enabled: true
 
 rbac:
   enabled: true
@@ -82,6 +84,8 @@ proxy:
     resources: {}
   labels:
   nodeSelector: {}
+  pdb:
+    enabled: true
   https:
     enabled: true
     type: letsencrypt


### PR DESCRIPTION
This provides a hint to autoscalers that nodes with these
services running should be considered last for scaling down. This
helps keep them from being disrupted unless needed.

Fixes #390