### PR TITLE
Support extraConfig being a dict

### DIFF
--- a/doc/source/advanced.md
+++ b/doc/source/advanced.md
@@ -92,8 +92,10 @@ Code. Some examples of things you can do:
    supported in the helm chart
 
 Unfortunately, you have to write your python *in* your YAML file. There's no way
-to include a file in `config.yaml`. Remember to use a `|` for multi-line strings
-in YAML:
+to include a file in `config.yaml`.
+
+You can specify `hub.extraConfig` as a raw string (remember to use the `|` for multi-line
+YAML strings):
 
 ```yaml
 hub:
@@ -102,6 +104,19 @@ hub:
     c.Spawner.environment += {
        "CURRENT_TIME": str(time.time())
     }
+```
+
+You can also specify `hub.extraConfig` as a dictionary, if you want to logically
+split your customizations. The code will be evaluated in alphabetical sorted
+order of the key.
+
+```yaml
+hub:
+  extraConfig:
+   00-first-config: |
+     # some code
+   10-second-config: |
+     # some other code
 ```
 
 ### `hub.extraConfigMap`

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -1,4 +1,5 @@
 import os
+import glob
 import sys
 import yaml
 from tornado.httpclient import AsyncHTTPClient
@@ -295,6 +296,6 @@ else:
     # Set default to {} so subconfigs can easily update it
     c.KubeSpawner.singleuser_extra_pod_config = {}
 
-extra_config_path = '/etc/jupyterhub/config/hub.extra-config.py'
-if os.path.exists(extra_config_path):
-    load_subconfig(extra_config_path)
+extra_configs = sorted(glob.glob('/etc/jupyterhub/config/hub.extra-config.*.py'))
+for ec in extra_configs:
+    load_subconfig(ec)

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -96,8 +96,16 @@ data:
     {{ end }}
   {{- end }}
   {{ if .Values.hub.extraConfig -}}
-  hub.extra-config.py: |
+  {{ $extraConfigType := typeOf .Values.hub.extraConfig -}}
+  {{ if eq $extraConfigType "string" -}}
+  hub.extra-config.default.py: |
 {{ .Values.hub.extraConfig | indent 4 }}
+  {{ else if eq $extraConfigType "map[string]interface {}" -}}
+  {{ range $key, $value := .Values.hub.extraConfig -}}
+  hub.extra-config.{{ $key }}.py: |
+{{ $value | indent 4 }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   {{ if .Values.hub.extraConfigVars -}}
   hub.extra-vars: {{ toJson .Values.hub.extraConfigVars | quote }}


### PR DESCRIPTION
Using an alphabetically ordered dict also allows meta-charts to
*insert* config between specific upstream configs.

Fixes #320