### PR TITLE
Change a raw block to a code block

### DIFF
--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -162,7 +162,7 @@ public, such as GitHub or Google.
 
 You can specify this list of usernames in your `config.yaml`:
 
-.. raw:: yaml
+.. code-block:: yaml
 
    auth:
      whitelist:


### PR DESCRIPTION
On readthedocs, the raw block does not seem to be rendered