### PR TITLE
updating storage documentation

### DIFF
--- a/doc/source/advanced.md
+++ b/doc/source/advanced.md
@@ -9,7 +9,7 @@ complex installations.
 
 If you are using a Kubernetes Cluster that does not provide public IPs for
 services directly, you need to use
-an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) 
+an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 to get traffic into your JupyterHub. This varies wildly
 based on how your cluster was set up, which is why this is in the 'Advanced' section.
 
@@ -27,7 +27,7 @@ You can specify multiple hosts that should be routed to the hub by listing them
 under `ingress.hosts`.
 
 Note that you need to install and configure an
-[Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-controllers) 
+[Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-controllers)
 for the ingress object to work. We recommend the
 [nginx ingress](https://github.com/kubernetes/charts/tree/master/stable/nginx-ingress)
 controller maintained by the community.
@@ -128,7 +128,7 @@ easily separate your code (which goes in `hub.extraConfig`) from your config
 
 For example, if you use the following snippet in your config.yaml file:
 
-```config.yaml
+```yaml
 hub:
   extraConfigMap:
     myString: Hello!

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,7 +42,12 @@ source_parsers = {
     '.md': 'recommonmark.parser.CommonMarkParser',
 }
 
+
 def setup(app):
+    app.add_config_value('recommonmark_config', {
+            'enable_eval_rst': True,
+            'enable_auto_doc_ref': True,
+            }, True)
     app.add_stylesheet('custom.css')
     app.add_transform(AutoStructify)
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -55,6 +55,7 @@ helm chart fields.
    extending-jupyterhub
    user-environment
    user-resources
+   user-storage
    user-management
 
 .. _administrator-guide:

--- a/doc/source/user-resources.rst
+++ b/doc/source/user-resources.rst
@@ -73,53 +73,11 @@ This would limit your users to a maximum of .5 of a CPU (so 1/2 of a CPU core), 
 
    Remember to :ref:`apply the change <apply-config-changes>` after changing your ``config.yaml`` file!
 
-.. _user_storage:
-
-Allocate user storage
----------------------
-
-By default, each user receives their own, 10Gi disk for storage when they log
-in to JupyterHub. This storage can be turned off or changed as described in
-these sections.
-
-Turn off per-user persistent storage
+Modifying user storage type and size
 ------------------------------------
 
-If you do not wish for users to have any persistent storage, it can be
-turned off. Edit the ``config.yaml`` file and set the storage type to
-``none``:
-
-   .. code-block:: yaml
-
-      singleuser:
-        storage:
-          type: none
-
-Next :ref:`apply the changes <apply-config-changes>`.
-
-After the changes are applied, new users will no longer be allocated a
-persistent ``$HOME`` directory. Any currently running users will still have
-access to their storage until their server is restarted.
-
-Change per-user persistent storage size
----------------------------------------
-
-By default, storage for user home directories are sized to 10Gi each. To
-increase or decrease this value, edit the ``config.yaml`` file:
-
-.. code-block:: yaml
-
-   singleuser:
-      storage:
-        capacity: 5Gi
-
-This example will make all **new** user's home directories be 5Gi each,
-instead of the default 10Gi.
-
-.. important::
-
-   The disks of "logged in" users will not change or be decreased in
-   this example.
+See the :ref:`user-storage` for information on how to modify the type and
+size of storage that your users have access to.
 
 Expanding and contracting the size of your cluster
 --------------------------------------------------

--- a/doc/source/user-storage.md
+++ b/doc/source/user-storage.md
@@ -1,0 +1,200 @@
+```eval_rst
+.. _user-storage:
+```
+
+# User storage in JupyterHub
+
+JupyterHub uses Kubernetes to manage user storage,
+however there are still some cloud-provider-specific considerations
+that must be taken. This document describes the persistent
+storage at a conceptual level, then gives details about
+how to customize persistent storage for some major cloud
+providers.
+
+## How does JupyterHub manage storage?
+
+For the purposes of this guide, we'll describe "storage" as
+a "volume" - a location on a disk where a user's data resides.
+Kubernetes handles the creation and allocation of persistent
+volumes, under-the-hood it uses the cloud provider's API to
+issue the proper commands. To that extent most of our discussion
+around volumes will describe Kubernetes objects.
+
+There are two primary Kubernetes objects involved in allocating
+storage to pods:
+
+* A `PersistentVolumeClaim` (`PVC`) specifies what kind of storage is required. It is specified in your `config.yaml` file.
+* A `PersistentVolume` (`PV`) is the actual volume where the user's data resides. It is created by Kubernetes using a `PVC`.
+
+As these are both Kubernetes objects, they can be queried
+with the standard `kubectl` commands (e.g., `kubectl get pvc`)
+
+In JupyterHub, each user gets their own `PersistentVolumeClaim`
+object, representing the data attached to their account.
+When a new user starts their JupyterHub server, a
+`PersistentVolumeClaim` is created for that user. This claim
+tells Kubernetes what kind of storage (e.g., ssd vs. hd) as
+well as how much storage is needed. Kubernetes checks to see
+whether a `PersistentVolume` object for that user exists (since
+this is a new user, none will exist). If no `PV` object exists,
+then Kubernetes will use the `PVC` to create a new `PV` object
+for the user.
+
+Now that a `PV` exists for the user, Kubernetes next must
+attach (or "mount") that `PV` to the user's pod (which runs
+user code). Once this is accomplished, the user will have
+access to their `PV` within JupyterHub. Note that this all happens
+under-the-hood and automatically when a user logs in.
+
+`PersistentVolumeClaim`s and `PersistentVolume`s are not
+deleted unless the `PersistentVolumeClaim` is explicitly deleted
+by the JupyterHub administrator. When a user shuts down their
+server, their user pod is deleted and their volume is
+detached from the pod, *but the `PVC` and `PV` objects still exist*. This means that
+in the future, when the user logs back in, JupyterHub will
+detect that the user has a pre-existing `PVC` and will simply
+attach it to their new pod, rather than creating a new `PVC`.
+
+### How can this process break down?
+
+When Kubernetes uses the `PVC` to create a new user`PV`, it
+is sending a command to the underlying API of whatever cloud
+provider Kubernetes is running on. Occasionally, the request
+for a specific `PV` might fail - for example, if your account
+has reached the limit in the amount of disk space available.
+Another common issue is limits on the number of volumes that
+may be simultaneously attached to a node in your cluster. Check
+your cloud provider for details on the limits of storage
+resources you request.
+
+
+## Configuration
+
+Most configuration for storage is done at the cluster level and
+is not unique to JupyterHub. However, some bits are, and we will
+demonstrate here how to configure those.
+
+Note that new `PVC`s for pre-existing users will **not** be
+created unless the old ones are destroyed. If you update your
+users' `PVC`  config via `config.yaml`, then any **new** users will
+have the new `PVC` created for them, but **old** users will not.
+To force an upgrade of the storage type for old users, you will
+need to manually delete their `PVC` (e.g.
+`kubectl --namespace=<your-namespace> delete pvc <pvc-name>`).
+**This will delete all of the user's data** so we recommend
+backing up their filesystem first if you want to retain their data.
+
+After you delete the user's `PVC`, upon their next log-in a new
+`PVC` will be created for them according to your updated `PVC`
+specification.
+
+### Type of storage provisioned
+
+A [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) object
+is used to determine what kind of `PersistentVolume`s are provisioned for your
+users. Most popular cloud providers have a `StorageClass` marked as default. You
+can find out your default `StorageClass` by doing:
+
+```bash
+kubectl get storageclass
+```
+
+and looking for the object with `(default)` next to its name.
+
+To change the kind of `PersistentVolume`s provisioned for your users,
+
+1. Create a new `StorageClass` object following the
+   [kubernetes documentation](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+2. Specify the name of the `StorageClass` you just created in `config.yaml`
+   ```yaml
+   singleuser:
+     storage:
+       dynamic:
+         storageClass: <storageclass-name>
+   ```
+3. Do a `helm upgrade`
+
+Note that this will only affect new users who are logging in. We recommend
+you do this before users start heavily using your cluster.
+
+We will provide examples for popular cloud providers here, but will generally
+defer to the Kubernetes documentation.
+
+#### Google Cloud
+
+On Google Cloud, the default `StorageClass` will provision
+Standard [Google Persistent Disk](https://cloud.google.com/compute/docs/disks/#pdspecs)s.
+These run on Hard Disks, and are not very fast. If you want to use SSDs, you
+can create a new `StorageClass` by first putting the following `yaml` into a new file:
+
+```yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: jupyterhub-user-ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+  zones: <your-cluster-zone>
+```
+
+Replace `<your-cluster-zone>` with the Zone in which you created your cluster (you can find
+this with `gcloud container clusters list`).
+
+Next, create this object by running `kubectl apply -f <filename>`
+from the commandline. The [Kubernetes Docs](https://kubernetes.io/docs/concepts/storage/storage-classes/#gce)
+have more information on what the various fields mean. The most important field is `parameters.type`,
+which specifies the type of storage you wish to use. For example:
+
+* `pd-ssd` makes this `StorageClass` provision SSDs.
+* `pd-standard` will provision non-SSD disks.
+
+Once you have created this `StorageClass`, you can configure your JupyterHub's `PVC`
+template with the following in your `config.yaml`:
+
+```yaml
+singleuser:
+  storage:
+    dynamic:
+      storageClass: jupyterhub-user-ssd
+```
+
+Note that for `storageClass:` we use the name that we specified
+above in `metadata: name:`.
+
+#### Size of storage provisioned
+
+You can set the size of storage requested by JupyterHub in the `PVC` in
+your `config.yaml`.
+
+```yaml
+storage:
+  capacity: 2Gi
+```
+
+This will request a `2Gi` volume per user. The default requests a `10Gi`
+volume per user.
+
+We recommend you use the [IEC Prefixes](https://physics.nist.gov/cuu/Units/binary.html)
+(Ki, Mi, Gi, etc) for specifying how much storage you want. `2Gi` (IEC Prefix) is
+`(2 * 1024 * 1024 * 1024)` bytes, while `2G` (SI Prefix) is `(2 * 1000 * 1000 * 1000)` bytes.
+
+## Turn off per-user persistent storage
+
+If you do not wish for users to have any persistent storage, it can be
+turned off. Edit the `config.yaml` file and set the storage type to
+`none`:
+
+``` yaml
+      singleuser:
+        storage:
+          type: none
+```
+
+```eval_rst
+Next :ref:`apply the changes <apply-config-changes>`.
+```
+
+After the changes are applied, new users will no longer be allocated a
+persistent ``$HOME`` directory. Any currently running users will still have
+access to their storage until their server is restarted.

--- a/doc/source/user-storage.md
+++ b/doc/source/user-storage.md
@@ -7,6 +7,7 @@
 
 For the purposes of this guide, we'll describe "storage" as
 a "volume" - a location on a disk where a user's data resides.
+
 Kubernetes handles the creation and allocation of persistent
 volumes, under-the-hood it uses the cloud provider's API to
 issue the proper commands. To that extent most of our discussion
@@ -17,9 +18,9 @@ primary Kubernetes objects involved in allocating
 storage to pods:
 
 * A `PersistentVolumeClaim` (`PVC`) specifies what kind of storage is required. Its configuration is specified in your `config.yaml` file.
-* A `PersistentVolume` (`PV`) is the actual volume where the user's data resides. It is created by Kubernetes using a details in a `PVC`.
+* A `PersistentVolume` (`PV`) is the actual volume where the user's data resides. It is created by Kubernetes using details in a `PVC`.
 
-As these are both Kubernetes objects, they can be queried
+As Kubernetes objects, they can be queried
 with the standard `kubectl` commands (e.g., `kubectl --namespace=<your-namespace> get pvc`)
 
 In JupyterHub, each user gets their own `PersistentVolumeClaim`
@@ -43,8 +44,8 @@ under-the-hood and automatically when a user logs in.
 deleted unless the `PersistentVolumeClaim` is explicitly deleted
 by the JupyterHub administrator. When a user shuts down their
 server, their user pod is deleted and their volume is
-detached from the pod, *but the `PVC` and `PV` objects still exist*. This means that
-in the future, when the user logs back in, JupyterHub will
+detached from the pod, *but the `PVC` and `PV` objects still exist*.
+In the future, when the user logs back in, JupyterHub will
 detect that the user has a pre-existing `PVC` and will simply
 attach it to their new pod, rather than creating a new `PVC`.
 
@@ -55,6 +56,7 @@ is sending a command to the underlying API of whatever cloud
 provider Kubernetes is running on. Occasionally, the request
 for a specific `PV` might fail - for example, if your account
 has reached the limit in the amount of disk space available.
+
 Another common issue is limits on the number of volumes that
 may be simultaneously attached to a node in your cluster. Check
 your cloud provider for details on the limits of storage
@@ -116,8 +118,9 @@ defer to the Kubernetes documentation.
 
 On Google Cloud, the default `StorageClass` will provision
 Standard [Google Persistent Disk](https://cloud.google.com/compute/docs/disks/#pdspecs)s.
-These run on Hard Disks, and are not very fast. If you want to use SSDs, you
-can create a new `StorageClass` by first putting the following `yaml` into a new file:
+These run on Hard Disks. For more performance, you may want to use SSDs.
+To use SSDs, you can create a new `StorageClass` by first putting the following `yaml` into a new file. We recommend a descriptive name such
+as `storageclass.yaml`, which we'll use below:
 
 ```yaml
 kind: StorageClass
@@ -133,12 +136,12 @@ parameters:
 Replace `<your-cluster-zone>` with the Zone in which you created your cluster (you can find
 this with `gcloud container clusters list`).
 
-Next, create this object by running `kubectl apply -f <filename>`
+Next, create this object by running `kubectl apply -f storageclass.yaml`
 from the commandline. The [Kubernetes Docs](https://kubernetes.io/docs/concepts/storage/storage-classes/#gce)
 have more information on what the various fields mean. The most important field is `parameters.type`,
 which specifies the type of storage you wish to use. The two options are:
 
-* `pd-ssd` makes this `StorageClass` provision SSDs.
+* `pd-ssd` makes `StorageClass` provision SSDs.
 * `pd-standard` will provision non-SSD disks.
 
 Once you have created this `StorageClass`, you can configure your JupyterHub's `PVC`


### PR DESCRIPTION
This PR updates the documentation for user storage, it does a few main things:

* Incorporate the new storage documentation that we worked on in the hackmd
* Split off the current storage documentation into its own file `user-storage.md`
* Converted the old storage documentation into `md` since that's what the new documentation was written in

Would be worth double-checking the links etc, because converting the old rST into sphinx-friendly markdown is kind of confusing, but I think I figured it out. Here's a demo:

http://predictablynoisy.com/zero-to-jupyterhub-k8s/user-storage.html