### PR TITLE
Bump base image of hub to 17.10

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -10,8 +10,6 @@ RUN apt-get update && \
       libcurl4-openssl-dev \
       libssl-dev \
       build-essential \
-      npm \
-      nodejs-legacy \
       && \
     apt-get purge && apt-get clean
 


### PR DESCRIPTION
- Bumps Python Version to 3.6
- Removes npm / nodejs, which are not required when building
  JupyterHub from pypi