### PR TITLE
Block access to cloud metadata endpoints by default

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -10,6 +10,8 @@ charts:
         valuesPath: hub.image
         buildArgs:
           JUPYTERHUB_VERSION: 0.8.1
+      network-tools:
+        valuesPath: singleuser.networkTools.image
       pre-puller:
         valuesPath: prePuller.hook.image
       singleuser-sample:

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -105,7 +105,7 @@ if lifecycle_hooks:
 
 init_containers = get_config('singleuser.init-containers')
 if init_containers:
-    c.KubeSpawner.singleuser_init_containers += init_containers
+    c.KubeSpawner.singleuser_init_containers.extend(init_containers)
 
 # Gives spawned containers access to the API of the hub
 c.KubeSpawner.hub_connect_ip = os.environ['HUB_SERVICE_HOST']

--- a/images/network-tools/Dockerfile
+++ b/images/network-tools/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.6
+
+RUN apk add --no-cache iptables

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -76,6 +76,13 @@ data:
   {{ if .Values.singleuser.initContainers -}}
   singleuser.init-containers: {{ toJson .Values.singleuser.initContainers | quote }}
   {{- end }}
+
+  singleuser.network-tools.image.name: {{ .Values.singleuser.networkTools.image.name | quote }}
+  singleuser.network-tools.image.tag: {{ .Values.singleuser.networkTools.image.tag | quote }}
+
+  singleuser.cloud-metadata: |
+{{ toYaml .Values.singleuser.cloudMetadata | indent 4 }}
+
   singleuser.start-timeout: {{ .Values.singleuser.startTimeout | quote }}
   hub.concurrent-spawn-limit: {{ .Values.hub.concurrentSpawnLimit | quote }}
   {{ if .Values.hub.activeServerLimit }}

--- a/jupyterhub/templates/pre-puller/_helpers.yaml
+++ b/jupyterhub/templates/pre-puller/_helpers.yaml
@@ -29,13 +29,22 @@ spec:
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
       initContainers:
-      - name: image-pull
+      - name: image-pull-singleuser
         image: {{ .top.Values.singleuser.image.name }}:{{ .top.Values.singleuser.image.tag }}
         imagePullPolicy: IfNotPresent
         command:
           - /bin/sh
           - -c
           - echo "Pulling complete"
+      {{ if not .top.Values.singleuser.cloudMetadata.enabled }}
+      - name: image-pull-metadata-block
+        image: {{ .top.Values.singleuser.networkTools.image.name }}:{{ .top.Values.singleuser.networkTools.image.tag }}
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - -c
+          - echo "Pulling complete"
+      {{ end }}
       containers:
       - name: pause
         image: {{ .top.Values.prePuller.pause.image.name }}:{{ .top.Values.prePuller.pause.image.tag }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -111,7 +111,15 @@ auth:
     enabled: false
     cryptoKey:
 
+
 singleuser:
+  networkTools:
+    image:
+      name: jupyterhub/k8s-network-tools
+      tag: a21cecb
+  cloudMetadata:
+    enabled: false
+    ip: 169.254.169.254
   extraLabels: {}
   extraEnv: {}
   lifecycleHooks:


### PR DESCRIPTION
Uses an iptables block to block access to the cloud metadata
ip used by the most common cloud providers (Google, AWS, Azure).
This is enabled by default so we can be secure by default.

Fixes #407 

TODO:

- [x] Pre-pull this image too
- [x] Fixup security docs to refer to this