### PR TITLE
Fix travis failures

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -35,7 +35,7 @@ RUN pip3 install --no-cache-dir \
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 
-ADD z2jh.py /usr/local/lib/python3.5/dist-packages/z2jh.py
+ADD z2jh.py /usr/local/lib/python3.6/dist-packages/z2jh.py
 ADD cull_idle_servers.py /usr/local/bin/cull_idle_servers.py
 
 WORKDIR /srv/jupyterhub

--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -18,3 +18,7 @@ singleuser:
 
 rbac:
   enabled: false
+
+prePuller:
+  hook:
+    enabled: false


### PR DESCRIPTION
- Running pre-puller on travis causes trouble, since it takes
  more than 10mins apparently to pull the singleuser image from
  dockerhub. This causes all times we do not rebuild the singleuser
  image to fail on travis

- Fixup z2jh.py location for python3.6