### PR TITLE
Have hub and proxy stick to same node if possible

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -37,6 +37,20 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/hub/secret.yaml") . | sha256sum }}
     spec:
       nodeSelector: {{ toJson .Values.hub.nodeSelector }}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: component
+                      operator: In
+                      values: ['proxy']
+                    - key: release
+                      operator: In
+                      values: [ {{ .Release.Name | quote }} ]
       volumes:
       - name: config
         configMap:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -36,6 +36,20 @@ spec:
       serviceAccountName: proxy
       {{- end }}
       nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: component
+                      operator: In
+                      values: ['hub']
+                    - key: release
+                      operator: In
+                      values: [ {{ .Release.Name | quote }} ]
       containers:
         - name: nginx
           image: "{{ .Values.proxy.nginx.image.name }}:{{ .Values.proxy.nginx.image.tag }}"


### PR DESCRIPTION
- Makes it easier for autoscaling clusters, since we already
  have a PodDisruptionPolicy that says do not scale down
  clusters with these running!
- As a side effect, also makes hub restarts when doing helm
  upgrades faster, since it is most likely going to come back
  on the same node, which already has PVC attached and image
  pulled

Fixes #395