### PR TITLE
Update create-k8s-cluster.rst

### DIFF
--- a/doc/source/create-k8s-cluster.rst
+++ b/doc/source/create-k8s-cluster.rst
@@ -62,7 +62,7 @@ connect your credit card or other payment method to your google cloud account.
           --num-nodes=3 \
           --machine-type=n1-standard-2 \
           --zone=us-central1-b \
-          --cluster-version=1.8.4-gke.1
+          --cluster-version=1.8.6-gke.0
 
    where:
 


### PR DESCRIPTION
1.8.4-gke.1 is not valid anymore. 1.8.6-gke.0 must be used