### PR TITLE
Put time in RBAC for pre-puller names

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -23,8 +23,8 @@ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${MINIKUBE_V
 chmod +x minikube
 mv minikube bin/
 
-echo "starting minikube"
-sudo CHANGE_MINIKUBE_NONE_USER=true $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION}
+echo "starting minikube with RBAC"
+sudo CHANGE_MINIKUBE_NONE_USER=true $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
 minikube update-context
 
 echo "waiting for kubernetes"
@@ -38,7 +38,10 @@ echo "installing helm"
 curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz \
   | tar -xz -C bin --strip-components 1 linux-amd64/helm
 chmod +x bin/helm
-helm init
+
+kubectl --namespace kube-system create sa tiller
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+helm init --service-account tiller
 
 
 echo "waiting for tiller"

--- a/jupyterhub/templates/pre-puller/job.yaml
+++ b/jupyterhub/templates/pre-puller/job.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       restartPolicy: Never
       {{ if .Values.rbac.enabled }}
-      serviceAccountName: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+      serviceAccountName: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
       {{- end }}
       containers:
         - image: {{ .Values.prePuller.hook.image.name }}:{{ .Values.prePuller.hook.image.tag }}

--- a/jupyterhub/templates/pre-puller/rbac.yaml
+++ b/jupyterhub/templates/pre-puller/rbac.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -15,7 +15,7 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
@@ -27,33 +27,33 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
 roleRef:
   kind: ClusterRole
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
 roleRef:
   kind: Role
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
@@ -62,6 +62,6 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
-  name: pre-puller-{{ .Release.Name }}-{{ .Release.Revision }}
+  name: pre-puller-{{ .Release.Time.Seconds }}-{{.Release.Name}}-{{.Release.Revision}}
 {{ end }}
 {{ end }}

--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -16,9 +16,6 @@ singleuser:
   memory:
     guarantee: null
 
-rbac:
-  enabled: false
-
 prePuller:
   hook:
     enabled: false


### PR DESCRIPTION
This allows users to retry easier if helm fails to install.

Also enables RBAC in our Travis tests, so we can catch RBAC issues here!

Fixes #425
