### PR TITLE
Use travis_retry with deploy.sh

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -5,4 +5,4 @@ set -x
 chmod 0400 travis
 docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 export GIT_SSH_COMMAND="ssh -i ${PWD}/travis"
-./build.py --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart
+travis_retry ./build.py --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart


### PR DESCRIPTION
Post-merge, sometimes deploy fails because of build network
failures. This then breaks every succeeding PR, since the image
has not been pushed.

This will retry the build + push upto 3 times if it fails.

Fixes #434