### PR TITLE
bump singleuser-sample base image

### DIFF
--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:400c69639ea5
+FROM jupyter/base-notebook:27ba57364579
 
 # conda/pip/apt install additional packages here, if desired.
 


### PR DESCRIPTION
should fix path/permissions issues when container is configured to run with elevated permissions, which were briefly broken in docker-stacks and we just so happened to bump the base image while that was true.

cc @cam72cam who reported this on gitter