### PR TITLE
Revert "Use travis_retry with deploy.sh"

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -5,4 +5,4 @@ set -x
 chmod 0400 travis
 docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 export GIT_SSH_COMMAND="ssh -i ${PWD}/travis"
-travis_retry ./build.py --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart
+./build.py --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart


### PR DESCRIPTION
travis_retry is not available during retry stage!

This broke our CI.

Reverts jupyterhub/zero-to-jupyterhub-k8s#435