### PR TITLE
Fix typo causing helm to hang when unschedulable nodes exist

### DIFF
--- a/images/pre-puller/node.go
+++ b/images/pre-puller/node.go
@@ -18,7 +18,7 @@ type NodeList struct {
 			Name string `json:"name"`
 		} `json:"metadata"`
 		Spec struct {
-			Unschedulable bool `json:"unscheduleable"`
+			Unschedulable bool `json:"unschedulable"`
 		} `json:"spec"`
 		Status struct {
 			Images []struct {


### PR DESCRIPTION
I seem to make this typo all the time.

Fixes #448 