### PR TITLE
Upgrade pip in the hub Docker image

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -29,6 +29,7 @@ RUN adduser --disabled-password \
 ARG JUPYTERHUB_VERSION=0.8.*
 
 ADD requirements.txt /tmp/requirements.txt
+RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir \
          jupyterhub==${JUPYTERHUB_VERSION} \
          -r /tmp/requirements.txt


### PR DESCRIPTION
Otherwise this happens during startup:

```
[I 2018-01-28 14:42:58.656 JupyterHub service:266] Starting service 'cull-idle': ['/usr/local/bin/cull_idle_servers.py', '--timeout=3600', '--cull-every=600', '--url=http://127.0.0.1:8081/hub/api']
[I 2018-01-28 14:42:58.660 JupyterHub service:109] Spawning /usr/local/bin/cull_idle_servers.py --timeout=3600 --cull-every=600 --url=http://127.0.0.1:8081/hub/api
[E 2018-01-28 14:42:58.696 JupyterHub app:1623]
    Traceback (most recent call last):
      File "/usr/local/lib/python3.5/dist-packages/jupyterhub/app.py", line 1621, in launch_instance_async
        yield self.start()
      File "/usr/local/lib/python3.5/dist-packages/jupyterhub/app.py", line 1569, in start
        yield self.proxy.check_routes(self.users, self._service_map)
      File "/usr/local/lib/python3.5/dist-packages/jupyterhub/proxy.py", line 294, in check_routes
        routes = yield self.get_all_routes()
      File "/usr/local/lib/python3.5/dist-packages/jupyterhub/proxy.py", line 589, in get_all_routes
        resp = yield self.api_request('', client=client)
      File "/usr/local/lib/python3.5/dist-packages/tornado/curl_httpclient.py", line 214, in _process_queue
        curl.info["headers"])
      File "/usr/local/lib/python3.5/dist-packages/tornado/curl_httpclient.py", line 306, in _curl_setup_request
        for k, v in request.headers.get_all()])
    UnicodeEncodeError: 'ascii' codec can't encode character '\u201c' in position 21: ordinal not in range(128)
    
Traceback (most recent call last):
  File "/usr/local/bin/cull_idle_servers.py", line 114, in &lt;module&gt;
    loop.run_sync(cull)
  File "/usr/local/lib/python3.5/dist-packages/tornado/ioloop.py", line 458, in run_sync
    return future_cell[0].result()
  File "/usr/local/lib/python3.5/dist-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "&lt;string&gt;", line 4, in raise_exc_info
  File "/usr/local/lib/python3.5/dist-packages/tornado/gen.py", line 1063, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/bin/cull_idle_servers.py", line 58, in cull_idle
    resp = yield client.fetch(req)
  File "/usr/local/lib/python3.5/dist-packages/tornado/gen.py", line 1055, in run
    value = future.result()
  File "/usr/local/lib/python3.5/dist-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "&lt;string&gt;", line 4, in raise_exc_info
  File "/usr/local/lib/python3.5/dist-packages/tornado/iostream.py", line 738, in _read_to_buffer
    chunk = self.read_from_fd()
  File "/usr/local/lib/python3.5/dist-packages/tornado/iostream.py", line 1052, in read_from_fd
    chunk = self.socket.recv(self.read_chunk_size)
ConnectionResetError: [Errno 104] Connection reset by peer
```

Built and tested image available at `snormore/k8s-hub:v0.5.0-1`