### PR TITLE
Bump helm chart to v0.6

### DIFF
--- a/doc/source/debug.rst
+++ b/doc/source/debug.rst
@@ -110,7 +110,7 @@ To fix this, let's add a tag to our ``config.yaml`` file::
 
 Then run a helm upgrade::
 
-    helm upgrade jhub jupyterhub/jupyterhub --version=v0.5 -f config.yaml
+    helm upgrade jhub jupyterhub/jupyterhub --version=v0.6 -f config.yaml
 
 where ``jhub`` is the helm release name (substitute the release name that you
 chose during setup).

--- a/doc/source/extending-jupyterhub.rst
+++ b/doc/source/extending-jupyterhub.rst
@@ -19,7 +19,7 @@ The general method to modify your Kubernetes deployment is to:
 
      .. code-block:: bash
 
-        helm upgrade <YOUR_RELEASE_NAME> jupyterhub/jupyterhub --version=v0.5 -f config.yaml
+        helm upgrade <YOUR_RELEASE_NAME> jupyterhub/jupyterhub --version=v0.6 -f config.yaml
 
    Where ``<YOUR_RELEASE_NAME>`` is the parameter you passed to ``--name`` when
    `installing jupyterhub <setup-jupyterhub.html#install-jupyterhub>`_ with

--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -85,7 +85,7 @@ Install JupyterHub
    .. code:: bash
 
       helm install jupyterhub/jupyterhub \
-          --version=v0.5 \
+          --version=v0.6 \
           --name=<YOUR-RELEASE-NAME> \
           --namespace=<YOUR-NAMESPACE> \
           -f config.yaml

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Multi-user Jupyter installation
 name: jupyterhub
-version: v0.6.0
+version: v0.6

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -30,7 +30,7 @@ hub:
   extraVolumeMounts: []
   image:
     name: jupyterhub/k8s-hub
-    tag: v0.5.0
+    tag: v0.6
   resources:
     requests:
       cpu: 0.2
@@ -118,7 +118,7 @@ singleuser:
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools
-      tag: a21cecb
+      tag: v0.6
   cloudMetadata:
     enabled: false
     ip: 169.254.169.254
@@ -144,7 +144,7 @@ singleuser:
       storageClass:
   image:
     name: jupyterhub/k8s-singleuser-sample
-    tag: v0.5.0
+    tag: v0.6
   startTimeout: 300
   cpu:
     limit:
@@ -161,13 +161,13 @@ prePuller:
     extraEnv: {}
     image:
       name: jupyterhub/k8s-pre-puller
-      tag: 2b02899
+      tag: v0.6
   continuous:
     enabled: false
   pause:
     image:
       name: gcr.io/google_containers/pause
-      tag: "3.0"
+      tag: '3.0'
 
 ingress:
   enabled: false


### PR DESCRIPTION
This bumps the helm chart to v0.6 and updates the documentation to reflect the new release.