### PR TITLE
Remove duplicated section about whitelist

### DIFF
--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -84,16 +84,6 @@ tape archive, public cloud, or your own laptop. Start a Globus app
           identityProvider: "youruniversity.edu"
 
 
-To add a whitelist of usernames add to the config file under `auth`:
-
-.. code-block:: yaml
-
-     auth:
-         whitelist:
-             users:
-                - user1
-                - user2
-
 Full Example of Google OAuth2
 -----------------------------
 


### PR DESCRIPTION
this seems to be a run-away section that was moved to the end of the doc.