### PR TITLE
Pin helm version to v2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@ then you have run into this bug. You can downgrade helm by:
 
 ```bash
 curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > install-helm.bash
-bash install-helm.bash --version 2.6.2
-helm install --upgrade
+bash install-helm.bash --version v2.6.2
+helm init --upgrade
 ```
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,18 @@ If you are running v0.4 of the chart, you should upgrade to v0.5 first
 before upgrading to v0.6. You can find out what version you are using
 by running `helm list`.
 
-#### Troubleshooting
+### Helm Version recommendation
 
-If your helm upgrade fails due to the error `no Ingress with the name "jupyterhub-internal" found`,
-you may be experiencing a [helm bug](https://github.com/kubernetes/helm/issues/3275). To work
-around this, run `kubectl --namespace=<YOUR-NAMESPACE> delete ingress jupyterhub-internal` and
-re-run the `helm upgrade` command. Note that this will cause a short unavailability of your hub
-over HTTPS, which will resume normal availability once the deployment upgrade completes.
+Due to a [severe bug](https://github.com/kubernetes/helm/issues/3275) in helm v2.7 and 2.8,
+we currently recommend users stick to helm version 2.6 if possible.
+If you run into an error along the lines of `no Ingress with the name "jupyterhub-internal" found`,
+then you have run into this bug. You can downgrade helm by:
+
+```bash
+curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > install-helm.bash
+bash install-helm.bash --version 2.6.2
+helm install --upgrade
+```
 
 ### New Features
 

--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -16,7 +16,7 @@ terminal:
    .. code:: bash
 
       curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > install-helm.bash
-      bash install-helm.bash --version 2.6.2
+      bash install-helm.bash --version v2.6.2
 
 
 `Alternative methods for helm installation <https://github.com/kubernetes/helm/blob/master/docs/install.md>`_

--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -15,10 +15,15 @@ terminal:
 
    .. code:: bash
 
-      curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+      curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > install-helm.bash
+      bash install-helm.bash --version 2.6.2
+
 
 `Alternative methods for helm installation <https://github.com/kubernetes/helm/blob/master/docs/install.md>`_
 exist if you prefer to install without using the script.
+
+We highly recommend sticking to version 2.6.2 of helm until this severe
+`bug <https://github.com/kubernetes/helm/issues/3275>`_ is fixed.
 
 .. _helm-rbac:
 
@@ -72,10 +77,11 @@ It should provide output like:
 
    .. code-block:: bash
 
-      Client: &version.Version{SemVer:"v2.4.1", GitCommit:"46d9ea82e2c925186e1fc620a8320ce1314cbb02", GitTreeState:"clean"}
-      Server: &version.Version{SemVer:"v2.4.1", GitCommit:"46d9ea82e2c925186e1fc620a8320ce1314cbb02", GitTreeState:"clean"}
+      Client: &version.Version{SemVer:"v2.6.2", GitCommit:"46d9ea82e2c925186e1fc620a8320ce1314cbb02", GitTreeState:"clean"}
+      Server: &version.Version{SemVer:"v2.6.2", GitCommit:"46d9ea82e2c925186e1fc620a8320ce1314cbb02", GitTreeState:"clean"}
 
-Make sure you have at least version 2.4.1!
+Make sure you have at least version 2.6.2, but not newer (until
+`this bug <https://github.com/kubernetes/helm/issues/3275>`_ is fixed)
 
 If you receive an error that the Server is unreachable, do another `helm version`
 in 15-30 seconds, and it should display the Server version.


### PR DESCRIPTION
https://github.com/kubernetes/helm/issues/3275 has caused
serious amounts of downtime in the last week or so for
various deployments at Berkeley, so let's recommend people use
the last known version that did not have these issues.