### PR TITLE
sidebar improvements

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -64,23 +64,36 @@ img.logo {
 
 /* Sidebar TOC and headers */
 
+div.sphinxsidebarwrapper div {
+    margin-bottom: .8em;
+}
 div.sphinxsidebar h3 {
     font-size: 1.3em;
-    padding-top: .8em;
+    padding-top: 0px;
     font-weight: 800;
+    margin-left: 0px !important;
 }
 
 div.sphinxsidebar p.caption {
     font-size: 1.2em;
     margin-bottom: 0px;
+    margin-left: 0px !important;
+    font-weight: 900;
+    color: #767676;
 }
 
 div.sphinxsidebar ul {
     font-size: .8em;
     margin-top: 0px;
     padding-left: 3%;
+    margin-left: 0px !important;
 }
 
 div.relations ul {
     font-size: 1em;
+    margin-left: 0px !important;
+}
+
+div#searchbox form {
+    margin-left: 0px !important;
 }

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -61,3 +61,26 @@ img.logo {
 .prev-next-top {
   margin-bottom: 1em;
 }
+
+/* Sidebar TOC and headers */
+
+div.sphinxsidebar h3 {
+    font-size: 1.3em;
+    padding-top: .8em;
+    font-weight: 800;
+}
+
+div.sphinxsidebar p.caption {
+    font-size: 1.2em;
+    margin-bottom: 0px;
+}
+
+div.sphinxsidebar ul {
+    font-size: .8em;
+    margin-top: 0px;
+    padding-left: 3%;
+}
+
+div.relations ul {
+    font-size: 1em;
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -115,6 +115,7 @@ html_theme_options = {
     'github_user': 'jupyterhub',
     'github_repo': 'zero-to-jupyterhub-k8s',
     'github_banner': False,
+    'github_button': False,
     'show_powered_by': False,
     'extra_nav_links': {
         'GitHub Repo': 'http://github.com/jupyterhub/zero-to-jupyterhub-k8s',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -125,10 +125,10 @@ html_theme_options = {
 html_sidebars = {
     '**': [
         'about.html',
+        'searchbox.html',
         'navigation.html',
         'relations.html',
         'sourcelink.html',
-        'searchbox.html'
     ],
 }
 


### PR DESCRIPTION
This makes a couple of small improvements to the sidebar:

* Moving the search bar to the top of the sidebar so it's more discoverable
* Tweaking the CSS so that section headers are larger than content underneath + bold so that they're more easily separable visually

Old
<img src="https://user-images.githubusercontent.com/1839645/35872819-b915c5fa-0b1c-11e8-89c5-e2765fd6deb4.png" width=150px />

New
<img src="https://user-images.githubusercontent.com/1839645/35878880-84904294-0b2e-11e8-8bf7-5288b212293d.png" width=150px />

Here's a live version: http://predictablynoisy.com/zero-to-jupyterhub-k8s/

What do folks think about the CSS tweaks? @willingc ?

closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/482