### PR TITLE
node disk size interaction docs

### DIFF
--- a/doc/source/user-storage.md
+++ b/doc/source/user-storage.md
@@ -67,8 +67,8 @@ resources you request.
 
    Some cloud providers have a limited number of disks that can be attached to
    each node. Since JupyterHub allocates one disk per user for
-   persistent storage, this limits the number of users that can be present in
-   each node (and usually this is not configurable). If you need users to have
+   persistent storage, this limits the number of users that can be running in
+   a each node at any point of time. If you need users to have
    persistent storage, and you end up hitting this limit, you must use
    *more* nodes in order to accommodate the disk for each user. In this
    case, we recommend allocating *fewer* resources per node (e.g. RAM) since

--- a/doc/source/user-storage.md
+++ b/doc/source/user-storage.md
@@ -51,7 +51,7 @@ attach it to their new pod, rather than creating a new `PVC`.
 
 ### How can this process break down?
 
-When Kubernetes uses the `PVC` to create a new user`PV`, it
+When Kubernetes uses the `PVC` to create a new user `PV`, it
 is sending a command to the underlying API of whatever cloud
 provider Kubernetes is running on. Occasionally, the request
 for a specific `PV` might fail - for example, if your account
@@ -61,6 +61,19 @@ Another common issue is limits on the number of volumes that
 may be simultaneously attached to a node in your cluster. Check
 your cloud provider for details on the limits of storage
 resources you request.
+
+```eval_rst
+.. note::
+
+   Some cloud providers have a limited number of disks that can be attached to
+   each node. Since JupyterHub allocates one disk per user for
+   persistent storage, this limits the number of users that can be present in
+   each node (and usually this is not configurable). If you need users to have
+   persistent storage, and you end up hitting this limit, you must use
+   *more* nodes in order to accommodate the disk for each user. In this
+   case, we recommend allocating *fewer* resources per node (e.g. RAM) since
+   you'll have fewer users packed onto a single node.
+```
 
 ## Configuration
 

--- a/doc/source/user-storage.md
+++ b/doc/source/user-storage.md
@@ -68,7 +68,7 @@ resources you request.
    Some cloud providers have a limited number of disks that can be attached to
    each node. Since JupyterHub allocates one disk per user for
    persistent storage, this limits the number of users that can be running in
-   a each node at any point of time. If you need users to have
+   a node at any point of time. If you need users to have
    persistent storage, and you end up hitting this limit, you must use
    *more* nodes in order to accommodate the disk for each user. In this
    case, we recommend allocating *fewer* resources per node (e.g. RAM) since


### PR DESCRIPTION
Adds a warning to the user storage section about node disk size limits.

closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/274