### PR TITLE
adding a warning about the cost estimator

### DIFF
--- a/doc/source/cost.rst
+++ b/doc/source/cost.rst
@@ -36,16 +36,17 @@ you'll be able to choose the computational requirements you have, as well as
 draw a pattern of usage you expect over time. It will estimate the costs for
 you.
 
+.. warning::
+
+   **The cost estimator is a very rough estimate.** It is based on Google Cloud
+   Engine instances served from Oregon. Costs will vary based on your
+   location / provider, and will be highly variable if you implement any kind
+   of auto-scaling. Treat it as an order-of-magnitude estimate, not a hard rule.
+
 .. raw:: html
 
    <a target="_blank" href="http://mybinder.org/v2/gh/jupyterhub/zero-to-jupyterhub-k8s/master?filepath=doc/ntbk/draw_function.ipynb">
    <button style="background-color: rgb(235, 119, 55); border: 1px solid; border-color: black; color: white; padding: 15px 32px; text-align: center; text-decoration: none; font-size: 16px; margin: 4px 2px; cursor: pointer; border-radius: 8px;">Launch the Cost Estimator</button></a>
-
-.. note::
-
-   These are cost estimates based on Google Cloud Engine instances served from
-   Oregon. Costs will vary based on your location / provider, so double check
-   with their numbers to see how they compare to this demo.
 
 For a description of how these costs are broken down, see below.
 


### PR DESCRIPTION
We've had a few conversations about whether to keep / remove the cost estimator, but in the meantime this makes the warning about accuracy a bit more obvious / clear.

Note: I'd prefer if this didn't turn into a "should we just remove the cost estimator link entirely" conversation...I'm happy to have that in another issue. In this case I just want to make sure the warning message is better :-)