### PR TITLE
Fixes #504 - Singleuser pod packing at hub node first

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -285,7 +285,7 @@ if scheduler_strategy == 'pack':
         'affinity': {
             'podAffinity': {
                 'preferredDuringSchedulingIgnoredDuringExecution': [{
-                    'weight': 1000,
+                    'weight': 50,
                     'podAffinityTerm': {
                         'labelSelector': {
                             'matchExpressions': [{
@@ -297,7 +297,7 @@ if scheduler_strategy == 'pack':
                         'topologyKey': 'kubernetes.io/hostname'
                     }
                 }, {
-                    'weight': 100,
+                    'weight': 5,
                     'podAffinityTerm': {
                         'labelSelector': {
                             'matchExpressions': [{

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -285,6 +285,18 @@ if scheduler_strategy == 'pack':
         'affinity': {
             'podAffinity': {
                 'preferredDuringSchedulingIgnoredDuringExecution': [{
+                    'weight': 1000,
+                    'podAffinityTerm': {
+                        'labelSelector': {
+                            'matchExpressions': [{
+                                'key': 'component',
+                                'operator': 'In',
+                                'values': ['hub']
+                            }]
+                        },
+                        'topologyKey': 'kubernetes.io/hostname'
+                    }
+                }, {
                     'weight': 100,
                     'podAffinityTerm': {
                         'labelSelector': {


### PR DESCRIPTION
## Main idea of PR
To make the 'pack' scheduling strategy so that singleuser-pods first schedule on the hub node, and only if it is full, have them schedule on other nodes, and if so they schedule on the nodes with most singleuser images already.

---

With `schedulerStrategy: pack`, I expect my pods to pack into nodes allowing for a kubernetes cluster scaler to scale up and down efficiently. It cannot scale down if there is a hub on the node, so therefore the pods should start packing on the hub node, then onto other nodes.

I got this issue while having 0 users and 2 nodes. When I added my first user it was spread to the non-hub node, then every other user was packed into that node, and later they would populate the hub node. With only one user, I would not be able to scale down even though I had enough nodes to handle the situation, because the user was not packed to the hub node.

This PR solves such issues by adding a big affinity for being in the hub node when the `schedulerStrategy: pack` is set.