### PR TITLE
Cluster autoscaling - PDB for singleuser-server pods

### DIFF
--- a/jupyterhub/templates/singleuser/pdb.yaml
+++ b/jupyterhub/templates/singleuser/pdb.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.singleuser.pdb.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: singleuser-server
+  labels:
+    app: jupyterhub
+    component: singleuser-server
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: jupyterhub
+      component: singleuser-server
+{{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -127,6 +127,8 @@ singleuser:
   lifecycleHooks:
   initContainers:
   nodeSelector: {}
+  pdb:
+    enabled: true
   uid: 1000
   fsGid: 1000
   serviceAccountName:


### PR DESCRIPTION
## PR summary
Solves one relevant part in allowing clusters to autoscale. Denying the cluster autoscaler the ability to disrupt singleuser-server pods.

This part: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/503#issuecomment-367073761 