### PR TITLE
Fixes #506, gid=100 instead of 1000, causes storage permission issues?

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -229,7 +229,7 @@ properties:
           Use this only if you are building your own image & know that a group with this gid
           exists inside the hub container! Advanced feature, handle with care!
 
-          Defaults to 1000, which is the uid of the `jovyan` user that is present in the
+          Defaults to 1000, which is the gid of the `jovyan` user that is present in the
           default hub image.
   proxy:
     type: object

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -149,7 +149,7 @@ singleuser:
   initContainers:
   nodeSelector: {}
   uid: 1000
-  fsGid: 1000
+  fsGid: 100
   serviceAccountName:
   schedulerStrategy:
   storage:


### PR DESCRIPTION
@betatim do you know if this will affect peoples storage solution?

Perhaps we could add this for next release and declare in the upgrade instructions to manually set the gid to 1000 again if they will have some old user storage that has a memory of the gid=1000 situation.

closes #506