### PR TITLE
add /hub to proxy error-target

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -64,7 +64,7 @@ proxy:
       - --api-ip=0.0.0.0
       - --api-port=8001
       - --default-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
-      - --error-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
+      - --error-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)/hub/error
       - --log-level=debug
     resources:
       requests:


### PR DESCRIPTION
avoids redirect when asking the Hub to render an error page