### PR TITLE
Bump base version to v0.7

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Multi-user Jupyter installation
 name: jupyterhub
-version: v0.6
+version: v0.7


### PR DESCRIPTION
This would make CI produce charts like v0.7-<something>
which is more accurate

We should amend the release process to make this be a part
of it!