### PR TITLE
Allow configuration of OAuthenticator.scope

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -141,7 +141,7 @@ elif auth_type == 'github':
     if len(org_whitelist) != 0:
         c.GitHubOAuthenticator.github_organization_whitelist = org_whitelist
         if not auth_scopes:
-            c.Authenticator.scope = ['read:org'] # required for private membership
+            c.OAuthenticator.scope = ['read:org'] # required for private membership
 elif auth_type == 'cilogon':
     c.JupyterHub.authenticator_class = 'oauthenticator.CILogonOAuthenticator'
     c.CILogonOAuthenticator.oauth_callback_url = get_config('auth.cilogon.callback-url')

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -121,7 +121,6 @@ c.KubeSpawner.cpu_guarantee = get_config('singleuser.cpu.guarantee')
 
 # Allow switching authenticators easily
 auth_type = get_config('auth.type')
-auth_scopes = get_config('auth.scopes')
 email_domain = 'local'
 
 if auth_type == 'google':
@@ -140,8 +139,6 @@ elif auth_type == 'github':
     org_whitelist = get_config('auth.github.org_whitelist', [])
     if len(org_whitelist) != 0:
         c.GitHubOAuthenticator.github_organization_whitelist = org_whitelist
-        if not auth_scopes:
-            c.OAuthenticator.scope = ['read:org'] # required for private membership
 elif auth_type == 'cilogon':
     c.JupyterHub.authenticator_class = 'oauthenticator.CILogonOAuthenticator'
     c.CILogonOAuthenticator.oauth_callback_url = get_config('auth.cilogon.callback-url')
@@ -188,8 +185,7 @@ elif auth_type == 'custom':
 else:
     raise ValueError("Unhandled auth type: %r" % auth_type)
 
-if auth_scopes:
-    c.OAuthenticator.scope = auth_scopes
+c.OAuthenticator.scope = get_config('auth.scopes', [])
 
 c.Authenticator.enable_auth_state = get_config('auth.state.enabled', False)
 

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -121,6 +121,7 @@ c.KubeSpawner.cpu_guarantee = get_config('singleuser.cpu.guarantee')
 
 # Allow switching authenticators easily
 auth_type = get_config('auth.type')
+auth_scopes = get_config('auth.scopes')
 email_domain = 'local'
 
 if auth_type == 'google':
@@ -139,7 +140,8 @@ elif auth_type == 'github':
     org_whitelist = get_config('auth.github.org_whitelist', [])
     if len(org_whitelist) != 0:
         c.GitHubOAuthenticator.github_organization_whitelist = org_whitelist
-        c.GitHubOAuthenticator.scope = ['read:org'] # required for private membership
+        if not auth_scopes:
+            c.Authenticator.scope = ['read:org'] # required for private membership
 elif auth_type == 'cilogon':
     c.JupyterHub.authenticator_class = 'oauthenticator.CILogonOAuthenticator'
     c.CILogonOAuthenticator.oauth_callback_url = get_config('auth.cilogon.callback-url')
@@ -185,6 +187,9 @@ elif auth_type == 'custom':
     auth_config.update(get_config('auth.custom.config') or {})
 else:
     raise ValueError("Unhandled auth type: %r" % auth_type)
+
+if auth_scopes:
+    c.OAuthenticator.scope = auth_scopes
 
 c.Authenticator.enable_auth_state = get_config('auth.state.enabled', False)
 

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -185,7 +185,9 @@ elif auth_type == 'custom':
 else:
     raise ValueError("Unhandled auth type: %r" % auth_type)
 
-c.OAuthenticator.scope = get_config('auth.scopes', [])
+auth_scopes = get_config('auth.scopes')
+if auth_scopes:
+    c.OAuthenticator.scope = auth_scopes
 
 c.Authenticator.enable_auth_state = get_config('auth.state.enabled', False)
 

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -71,6 +71,11 @@ data:
   auth.custom.config : {{ toJson .Values.auth.custom.config | quote }}
   {{- end }}
 
+  {{ if .Values.auth.scopes -}}
+  auth.scopes: |
+{{ toYaml .Values.auth.scopes | indent 4}}
+  {{- end }}
+
   auth.state.enabled: {{ .Values.auth.state.enabled | quote }}
 
   {{ if .Values.singleuser.lifecycleHooks -}}


### PR DESCRIPTION
Follow-up to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/501

This allows [`OAuthenticator.scope`](https://github.com/jupyterhub/oauthenticator/blob/0.7.3/oauthenticator/oauth2.py#L199) to be set. The default is ~`[read:org]` if `auth.github.org_whitelist` is set, otherwise~ empty.

## Examples with Github.

`auth.github.org_whitelist` unset, `auth.scopes` unset:
<img width="531" alt="screen shot 2018-02-22 at 13 28 53" src="https://user-images.githubusercontent.com/1644105/36541032-7ecd90f2-17d4-11e8-8914-6473b350e633.png">

`auth.github.org_whitelist` set, `auth.scopes` set to `[read:org]`:
<img width="526" alt="screen shot 2018-02-22 at 13 28 23" src="https://user-images.githubusercontent.com/1644105/36541054-93ce7728-17d4-11e8-8275-e94bc3487a96.png">

`auth.github.org_whitelist` set, `auth.scopes` set to `[read:org, read:user, user:email]`:
<img width="526" alt="screen shot 2018-02-22 at 13 27 29" src="https://user-images.githubusercontent.com/1644105/36541070-a728fdde-17d4-11e8-963b-01f37ae449b2.png">

In theory this property should also work with other OAuth providers, but I don't have an easy way to test.
