### PR TITLE
Doc: fix a link in the glossary

### DIFF
--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -16,7 +16,7 @@ succinct and relevant as possible, and provide links to learn more details.
       A user who can access the JupyterHub admin panel. They can start/stop user
       pods, and potentially access their notebooks.
 
-   `authenticator <http://jupyterhub.readthedocs.io/en/stable/authenticators.html>`_
+   `authenticator <http://jupyterhub.readthedocs.io/en/latest/reference/authenticators.html>`_
       The way in which users are authenticated to log into JupyterHub. There
       are many authenticators available, like GitHub, Google, MediaWiki,
       Dummy (anyone can log in), etc.


### PR DESCRIPTION
Drive-by updated, previous link to jupyterhub authenticator docs returned 404.