### PR TITLE
avoid culling users whose servers haven't stopped

### DIFF
--- a/images/hub/cull_idle_servers.py
+++ b/images/hub/cull_idle_servers.py
@@ -113,16 +113,17 @@ if __name__ == '__main__':
         help="""Cull users in addition to servers.
                 This is for use in temporary-user cases such as tmpnb.""",
     )
-    
+
     parse_command_line()
     if not options.cull_every:
         options.cull_every = options.timeout // 2
     api_token = os.environ['JUPYTERHUB_API_TOKEN']
-    
+
     loop = IOLoop.current()
     cull = lambda : cull_idle(options.url, api_token, options.timeout, options.cull_users)
-    # run once before scheduling periodic call
-    loop.run_sync(cull)
+    # schedule first cull immediately
+    # because PeriodicCallback doesn't start until the end of the first interval
+    loop.add_callback(cull)
     # schedule periodic cull
     pc = PeriodicCallback(cull, 1e3 * options.cull_every)
     pc.start()

--- a/images/hub/cull_idle_servers.py
+++ b/images/hub/cull_idle_servers.py
@@ -75,6 +75,8 @@ def cull_idle(url, api_token, timeout, cull_users=False):
                 msg = "Server for {} is slow to stop.".format(user['name'])
                 if cull_users:
                     app_log.warning(msg + " Not culling user yet.")
+                    # return here so we don't continue to cull the user
+                    # which will fail if the server is still trying to shutdown
                     return
                 app_log.warning(msg)
         if cull_users:
@@ -93,6 +95,8 @@ def cull_idle(url, api_token, timeout, cull_users=False):
             continue
         last_activity = parse_date(user['last_activity'])
         if last_activity < cull_limit:
+            # user might be in a transition (e.g. starting or stopping)
+            # don't try to cull if this is happening
             if user['pending']:
                 app_log.warning("Not culling user %s with pending %s", user['name'], user['pending'])
                 continue


### PR DESCRIPTION
attempting to cull a user whose server is slow to stop results in a `400 DELETE` error, which seems to exit the culler process.

user will be deleted in a later round when the server has finished stopping.

The initial request in `call_sync` was failing, which causes the script to exit. This is replaced with an `add_callback`, in which case errors are logged instead of exiting.

closes #522