### PR TITLE
unpin dev requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-PyGithub==1.35
-python-dateutil==2.6.1
-ruamel.yaml==0.15.35
+PyGithub>=1
+python-dateutil>=2
+ruamel.yaml>=0.15


### PR DESCRIPTION
pinning strict requirements is okay for application deploymens to do, but not for user environments, which is how we are using dev-requirements in CONTRIBUTING.md