### PR TITLE
fill image tags values.yaml with placeholders

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Multi-user Jupyter installation
 name: jupyterhub
-version: v0.7
+version: v0.7-dev

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -30,7 +30,7 @@ hub:
   extraVolumeMounts: []
   image:
     name: jupyterhub/k8s-hub
-    tag: v0.6
+    tag: generated-by-chartpress
   resources:
     requests:
       cpu: 0.2
@@ -118,7 +118,7 @@ singleuser:
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools
-      tag: v0.6
+      tag: generated-by-chartpress
   cloudMetadata:
     enabled: false
     ip: 169.254.169.254
@@ -144,7 +144,7 @@ singleuser:
       storageClass:
   image:
     name: jupyterhub/k8s-singleuser-sample
-    tag: v0.6
+    tag: generated-by-chartpress
   startTimeout: 300
   cpu:
     limit:
@@ -160,8 +160,8 @@ prePuller:
     enabled: true
     extraEnv: {}
     image:
-      name: jupyterhub/k8s-pre-puller
-      tag: v0.6
+      name: jupyterhub/k8s-image-awaiter
+      tag: generated-by-chartpress
   continuous:
     enabled: false
   pause:


### PR DESCRIPTION
these values (both name and tag) are autogenerated by chartpress, so the values stores in values.yaml will never be used.

We could also replace these with an empty dict, so that it's extra clear that the image data needs to be filled out by running `chartpress`, and the values.yaml tracked by the repo is never valid.

cc @consideRatio who I think may have run into an issue related to this.