### PR TITLE
Initial network Policies for hub proxy singleuser

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -170,11 +170,10 @@ data:
   {{ if .Values.singleuser.cpu.guarantee -}}
   singleuser.cpu.guarantee: {{ .Values.singleuser.cpu.guarantee | quote}}
   {{- end }}
-  {{ if .Values.singleuser.extraLabels -}}
   singleuser.extra-labels: |
-    {{ range $key, $value := .Values.singleuser.extraLabels -}}
+    hub.jupyter.org/network-access-hub: "true"
+  {{ range $key, $value := .Values.singleuser.extraLabels -}}
     {{ $key | quote }}: {{ $value | quote }}
-    {{- end }}
   {{- end }}
   {{ if .Values.singleuser.extraEnv -}}
   singleuser.extra-env: |

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         component: hub
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+        hub.jupyter.org/network-access-proxy-api: "true"
+        hub.jupyter.org/network-access-proxy-http: "true"
+        hub.jupyter.org/network-access-singleuser: "true"
         {{ if .Values.hub.labels -}}
         # Because toYaml + indent is super flaky
         {{ range $key, $value := .Values.proxy.labels -}}

--- a/jupyterhub/templates/hub/netpol-hub.yaml
+++ b/jupyterhub/templates/hub/netpol-hub.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.hub.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hub-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: hub
+      app: jupyterhub
+      component: hub
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          name: proxy
+          component: proxy
+    - podSelector:
+        matchLabels:
+          app: jupyterhub
+          component: singleuser-server
+    ports:
+    - protocol: TCP
+      port: 8081
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          name: proxy
+          component: proxy
+    ports:
+    - protocol: TCP
+      port: 8001
+  - to:
+    - podSelector:
+        matchLabels:
+          app: jupyterhub
+          component: singleuser-server
+    ports:
+    - protocol: TCP
+      port: 8888
+    # FIXME: Find a rule to explicitly allow access to kubernetes API
+{{ if .Values.hub.networkPolicy.egress }}
+{{ toYaml .Values.hub.networkPolicy.egress | indent 2 }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/hub/netpol-hub.yaml
+++ b/jupyterhub/templates/hub/netpol-hub.yaml
@@ -21,28 +21,11 @@ spec:
     - protocol: TCP
       port: 8081
   egress:
-  - to:
-    - podSelector:
-        matchLabels:
-          name: proxy
-          component: proxy
-    ports:
-    - protocol: TCP
-      port: 8001
-  - to:
-    - podSelector:
-        matchLabels:
-          app: jupyterhub
-          component: singleuser-server
-    ports:
-    - protocol: TCP
-      port: 8888
-  - ports:
-    # Kubernetes api-server
-    - protocol: TCP
-      port: 443
-    - protocol: TCP
-      port: 6443
+  # The default is to allow all egress for hub
+  # If you want to restrict it the following egress is required
+  # proxy:8001
+  # singleuser:8888
+  # Kubernetes api-server
 {{ if .Values.hub.networkPolicy.egress }}
 {{ toYaml .Values.hub.networkPolicy.egress | indent 2 }}
 {{- end }}

--- a/jupyterhub/templates/hub/netpol-hub.yaml
+++ b/jupyterhub/templates/hub/netpol-hub.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: hub-network-policy
-  namespace: default
 spec:
   podSelector:
     matchLabels:

--- a/jupyterhub/templates/hub/netpol-hub.yaml
+++ b/jupyterhub/templates/hub/netpol-hub.yaml
@@ -42,7 +42,12 @@ spec:
     ports:
     - protocol: TCP
       port: 8888
-    # FIXME: Find a rule to explicitly allow access to kubernetes API
+  - ports:
+    # Kubernetes api-server
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
 {{ if .Values.hub.networkPolicy.egress }}
 {{ toYaml .Values.hub.networkPolicy.egress | indent 2 }}
 {{- end }}

--- a/jupyterhub/templates/hub/netpol-hub.yaml
+++ b/jupyterhub/templates/hub/netpol-hub.yaml
@@ -16,12 +16,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          name: proxy
-          component: proxy
-    - podSelector:
-        matchLabels:
-          app: jupyterhub
-          component: singleuser-server
+          hub.jupyter.org/network-access-hub: "true"
     ports:
     - protocol: TCP
       port: 8081

--- a/jupyterhub/templates/hub/netpol-singleuser.yaml
+++ b/jupyterhub/templates/hub/netpol-singleuser.yaml
@@ -29,16 +29,6 @@ spec:
     ports:
     - protocol: TCP
       port: 8081
-  - to:
-    - podSelector:
-        matchLabels:
-          name: proxy
-          component: proxy
-    ports:
-    - protocol: TCP
-      port: 8000
-    - protocol: TCP
-      port: 8001
 {{ if .Values.singleuser.networkPolicy.egress }}
 {{ toYaml .Values.singleuser.networkPolicy.egress | indent 2 }}
 {{- end }}

--- a/jupyterhub/templates/hub/netpol-singleuser.yaml
+++ b/jupyterhub/templates/hub/netpol-singleuser.yaml
@@ -15,13 +15,7 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          name: hub
-          app: jupyterhub
-          component: hub
-    - podSelector:
-        matchLabels:
-          name: proxy
-          component: proxy
+          hub.jupyter.org/network-access-singleuser: "true"
     ports:
     - protocol: TCP
       port: 8888

--- a/jupyterhub/templates/hub/netpol-singleuser.yaml
+++ b/jupyterhub/templates/hub/netpol-singleuser.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.singleuser.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: singleuser-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: jupyterhub
+      component: singleuser-server
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          name: hub
+          app: jupyterhub
+          component: hub
+    - podSelector:
+        matchLabels:
+          name: proxy
+          component: proxy
+    ports:
+    - protocol: TCP
+      port: 8888
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          name: hub
+          app: jupyterhub
+          component: hub
+    ports:
+    - protocol: TCP
+      port: 8081
+  - to:
+    - podSelector:
+        matchLabels:
+          name: proxy
+          component: proxy
+    ports:
+    - protocol: TCP
+      port: 8000
+    - protocol: TCP
+      port: 8001
+{{ if .Values.singleuser.networkPolicy.egress }}
+{{ toYaml .Values.singleuser.networkPolicy.egress | indent 2 }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/hub/netpol-singleuser.yaml
+++ b/jupyterhub/templates/hub/netpol-singleuser.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: singleuser-network-policy
-  namespace: default
 spec:
   podSelector:
     matchLabels:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -31,6 +31,8 @@ spec:
         # required for kube-lego to work
         app: kube-lego
         {{- end }}
+        hub.jupyter.org/network-access-hub: "true"
+        hub.jupyter.org/network-access-singleuser: "true"
     spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: proxy

--- a/jupyterhub/templates/proxy/netpol-proxy.yaml
+++ b/jupyterhub/templates/proxy/netpol-proxy.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.proxy.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: proxy-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      name: proxy
+      component: proxy
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 80
+    - protocol: TCP
+      port: 443
+  - from:
+    - podSelector:
+        matchLabels:
+          name: hub
+          app: jupyterhub
+          component: hub
+    ports:
+    - protocol: TCP
+      port: 8000
+    - protocol: TCP
+      port: 8001
+    - protocol: TCP
+      port: 8080
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          name: hub
+          app: jupyterhub
+          component: hub
+    ports:
+    - protocol: TCP
+      port: 8081
+  - to:
+    - podSelector:
+        matchLabels:
+          app: jupyterhub
+          component: singleuser-server
+    ports:
+    - protocol: TCP
+      port: 8888
+{{- if .Values.proxy.networkPolicy.egress }}
+{{ toYaml .Values.proxy.networkPolicy.egress | indent 2 }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/proxy/netpol-proxy.yaml
+++ b/jupyterhub/templates/proxy/netpol-proxy.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: proxy-network-policy
-  namespace: default
 spec:
   podSelector:
     matchLabels:

--- a/jupyterhub/templates/proxy/netpol-proxy.yaml
+++ b/jupyterhub/templates/proxy/netpol-proxy.yaml
@@ -17,6 +17,12 @@ spec:
       port: 80
     - protocol: TCP
       port: 443
+    # kube-lego /healthz
+    - protocol: TCP
+      port: 8080
+    # nginx /healthz
+    - protocol: TCP
+      port: 10254
   - from:
     - podSelector:
         matchLabels:
@@ -24,12 +30,10 @@ spec:
           app: jupyterhub
           component: hub
     ports:
-    - protocol: TCP
-      port: 8000
-    - protocol: TCP
-      port: 8001
-    - protocol: TCP
-      port: 8080
+      - protocol: TCP
+        port: 8000
+      - protocol: TCP
+        port: 8001
   egress:
   - to:
     - podSelector:
@@ -38,8 +42,8 @@ spec:
           app: jupyterhub
           component: hub
     ports:
-    - protocol: TCP
-      port: 8081
+      - protocol: TCP
+        port: 8081
   - to:
     - podSelector:
         matchLabels:
@@ -48,6 +52,12 @@ spec:
     ports:
     - protocol: TCP
       port: 8888
+  - ports:
+    # Kubernetes api-server
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
 {{- if .Values.proxy.networkPolicy.egress }}
 {{ toYaml .Values.proxy.networkPolicy.egress | indent 2 }}
 {{- end }}

--- a/jupyterhub/templates/proxy/netpol-proxy.yaml
+++ b/jupyterhub/templates/proxy/netpol-proxy.yaml
@@ -26,12 +26,15 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          name: hub
-          app: jupyterhub
-          component: hub
+          hub.jupyter.org/network-access-proxy-http: "true"
     ports:
       - protocol: TCP
         port: 8000
+  - from:
+    - podSelector:
+        matchLabels:
+          hub.jupyter.org/network-access-proxy-api: "true"
+    ports:
       - protocol: TCP
         port: 8001
   egress:

--- a/jupyterhub/templates/proxy/netpol-proxy.yaml
+++ b/jupyterhub/templates/proxy/netpol-proxy.yaml
@@ -38,29 +38,11 @@ spec:
       - protocol: TCP
         port: 8001
   egress:
-  - to:
-    - podSelector:
-        matchLabels:
-          name: hub
-          app: jupyterhub
-          component: hub
-    ports:
-      - protocol: TCP
-        port: 8081
-  - to:
-    - podSelector:
-        matchLabels:
-          app: jupyterhub
-          component: singleuser-server
-    ports:
-    - protocol: TCP
-      port: 8888
-  - ports:
-    # Kubernetes api-server
-    - protocol: TCP
-      port: 443
-    - protocol: TCP
-      port: 6443
+  # The default is to allow all egress for proxy
+  # If you want to restrict it the following egress is required
+  # hub:8081
+  # singleuser:8888
+  # Kubernetes api-server
 {{- if .Values.proxy.networkPolicy.egress }}
 {{ toYaml .Values.proxy.networkPolicy.egress | indent 2 }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -39,6 +39,15 @@ hub:
   imagePullPolicy: IfNotPresent
   pdb:
     enabled: true
+  networkPolicy:
+    enabled: false
+    egress:
+    # FIXME: Find a rule to explicitly allow access to kubernetes API
+    # Once this is done the following can be removed unless external auth
+    # is required since other egress is handled by other rules
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
 
 rbac:
   enabled: true
@@ -97,6 +106,15 @@ proxy:
       key:
       cert:
     hosts: []
+  networkPolicy:
+    enabled: false
+    egress:
+    # May be required for lets-encrypt? Otherwise should be safe to disable
+    - ports:
+      - protocol: TCP
+        port: 80
+      - protocol: TCP
+        port: 443
 
 
 # Google OAuth secrets
@@ -122,6 +140,15 @@ singleuser:
   cloudMetadata:
     enabled: false
     ip: 169.254.169.254
+  networkPolicy:
+    enabled: false
+    egress:
+    # Required egress is handled by other rules so it's safe to modify this
+    - to:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except:
+            - 169.254.169.254/32
   extraLabels: {}
   extraEnv: {}
   lifecycleHooks:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -42,7 +42,6 @@ hub:
   networkPolicy:
     enabled: false
     egress:
-    # The following can be removed unless external auth is used
       - to:
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -107,12 +106,9 @@ proxy:
   networkPolicy:
     enabled: false
     egress:
-    # May be required for lets-encrypt? Otherwise should be safe to disable
-      - ports:
-        - protocol: TCP
-          port: 80
-        - protocol: TCP
-          port: 443
+      - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
 
 
 # Google OAuth secrets

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -42,12 +42,10 @@ hub:
   networkPolicy:
     enabled: false
     egress:
-    # FIXME: Find a rule to explicitly allow access to kubernetes API
-    # Once this is done the following can be removed unless external auth
-    # is required since other egress is handled by other rules
-    - to:
-      - ipBlock:
-          cidr: 0.0.0.0/0
+    # The following can be removed unless external auth is used
+      - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
 
 rbac:
   enabled: true
@@ -110,11 +108,11 @@ proxy:
     enabled: false
     egress:
     # May be required for lets-encrypt? Otherwise should be safe to disable
-    - ports:
-      - protocol: TCP
-        port: 80
-      - protocol: TCP
-        port: 443
+      - ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
 
 
 # Google OAuth secrets
@@ -144,11 +142,11 @@ singleuser:
     enabled: false
     egress:
     # Required egress is handled by other rules so it's safe to modify this
-    - to:
-      - ipBlock:
-          cidr: 0.0.0.0/0
-          except:
-            - 169.254.169.254/32
+      - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
   extraLabels: {}
   extraEnv: {}
   lifecycleHooks:


### PR DESCRIPTION
Adds network policies based on https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/534#issuecomment-368542041

For now I've included ingress and egress rules so that there's a record of what was discussed above.

Policies are enabled by setting `{hub,proxy,singleuser}.networkPolicy.enabled`, default is `False`.

I've added `{hub,proxy,singleuser}.networkPolicy.egress` with the egress rules I thought could be optional, the idea being:
- Ingress/Egress rules which are required for jupyterhub pods to minimally function should always be defined
- Rules which are useful but which someone might want to restrict further are defaults which can be overridden

Since the proxy and hub should be trusted relaxing the rules and allowing all egress for them could be OK, the main benefit of egress rules are for restricting the singleuser servers.

Example of overriding singleuser egress to allow only DNS lookups and a access to single network:
```
singleuser:
  storage:
    type: none
  networkPolicy:
    enabled: true
    egress:
      - ports:
        - port: 53
          protocol: UDP
      - to:
        - ipBlock:
            cidr: 193.60.0.0/14
```
This works for me on openstack (Kubespray, canal network plugin). I've been trying to get this testable with minikube but it works only intermittently (See https://gist.github.com/manics/fe07200d535d12c59623801678f873d0 for setup if you're interested)