### PR TITLE
Add info about minikube install for MacOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ development.
 1. [Download & install minikube](https://github.com/kubernetes/minikube#installation)
 
    For MacOS, you may find installing from https://github.com/kubernetes/minikube/releases
-   may be more stable than using Homebrew.
+   is more stable than using Homebrew.
 
 2. Start minikube
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ We recommend using [minikube](https://github.com/kubernetes/minikube) for local
 development.
 
 1. [Download & install minikube](https://github.com/kubernetes/minikube#installation)
+
+   For MacOS, you may find installing from https://github.com/kubernetes/minikube/releases
+   may be more stable than using Homebrew.
+
 2. Start minikube
    ```
    minikube start


### PR DESCRIPTION
Add same wording that we have in BinderHub contributing re: installing from binaries instead of homebrew for MacOS.