### PR TITLE
Make daemonsets do a rolling update

### DIFF
--- a/jupyterhub/templates/image-puller/_helper.yaml
+++ b/jupyterhub/templates/image-puller/_helper.yaml
@@ -33,9 +33,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      # Arbitrarily large number, since we want all the old daemonsets to die immediately
-      # and new ones to be born
-      maxUnavailable: 1000
+      maxUnavailable: 100%
   template:
     metadata:
       labels:

--- a/jupyterhub/templates/image-puller/_helper.yaml
+++ b/jupyterhub/templates/image-puller/_helper.yaml
@@ -30,6 +30,12 @@ spec:
         component: {{ .name }}
         release: {{ .top.Release.Name }}
         heritage: {{ .top.Release.Service }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Arbitrarily large number, since we want all the old daemonsets to die immediately
+      # and new ones to be born
+      maxUnavailable: 1000
   template:
     metadata:
       labels:


### PR DESCRIPTION
Without this, the continuous pre-puller pods do not work,
since they're stuck in the old image version forever.

https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
has more info