### PR TITLE
Customization options for dynamic storage

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -58,27 +58,29 @@ c.KubeSpawner.singleuser_node_selector = get_config('singleuser.node-selector')
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':
-    c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
+    pvc_name_template = get_config('singleuser.storage.dynamic.pvc-name-template')
+    volume_name_template = get_config('singleuser.storage.dynamic.volume-name-template')
+    c.KubeSpawner.pvc_name_template = pvc_name_template
     c.KubeSpawner.user_storage_pvc_ensure = True
     storage_class = get_config('singleuser.storage.dynamic.storage-class', None)
     if storage_class:
         c.KubeSpawner.user_storage_class = storage_class
-    c.KubeSpawner.user_storage_access_modes = ['ReadWriteOnce']
+    c.KubeSpawner.user_storage_access_modes = get_config('singleuser.storage.dynamic.storage-access-modes')
     c.KubeSpawner.user_storage_capacity = get_config('singleuser.storage.capacity')
 
     # Add volumes to singleuser pods
     c.KubeSpawner.volumes = [
         {
-            'name': 'volume-{username}{servername}',
+            'name': volume_name_template,
             'persistentVolumeClaim': {
-                'claimName': 'claim-{username}{servername}'
+                'claimName': pvc_name_template
             }
         }
     ]
     c.KubeSpawner.volume_mounts = [
         {
             'mountPath': get_config('singleuser.storage.home_mount_path'),
-            'name': 'volume-{username}{servername}'
+            'name': volume_name_template
         }
     ]
 elif storage_type == 'static':

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -149,6 +149,9 @@ data:
   singleuser.storage.extra-volume-mounts: {{ toJson .Values.singleuser.storage.extraVolumeMounts | quote }}
   {{ if eq .Values.singleuser.storage.type "dynamic" -}}
   singleuser.storage.capacity: {{.Values.singleuser.storage.capacity | quote }}
+  singleuser.storage.dynamic.pvc-name-template: {{ .Values.singleuser.storage.dynamic.pvcNameTemplate | quote }}
+  singleuser.storage.dynamic.volume-name-template: {{ .Values.singleuser.storage.dynamic.volumeNameTemplate | quote }}
+  singleuser.storage.dynamic.storage-access-modes: {{ .Values.singleuser.storage.dynamic.storageAccessModes | quote }}
   {{ if .Values.singleuser.storage.dynamic.storageClass -}}
   singleuser.storage.dynamic.storage-class: {{ .Values.singleuser.storage.dynamic.storageClass | quote }}
   {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -142,6 +142,9 @@ singleuser:
     homeMountPath: /home/jovyan
     dynamic:
       storageClass:
+      pvcNameTemplate: 'claim-{username}{servername}'
+      volumeNameTemplate: 'volume-{username}{servername}'
+      storageAccessModes: ['ReadWriteOnce']
   image:
     name: jupyterhub/k8s-singleuser-sample
     tag: generated-by-chartpress


### PR DESCRIPTION
This allows the pvc and volumes used for single user to have custom names, which is useful is the user names are long (> 60 characters) as this will fail in kubernetes.