### PR TITLE
Revert "Set maxUnavailable appropriately for hub & proxy pods"

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -4,19 +4,6 @@ metadata:
   name: hub
 spec:
   replicas: 1
-  strategy:
-    rollingUpdate:
-      {{ if eq .Values.hub.db.type "sqlite-pvc" }}
-      # If we're using a PVC, set maxUnavailable to 1
-      # This is required, since the pod attached to PVC must die
-      # before new pod can run.
-      maxUnavailable: 1
-      {{ else }}
-      # If we aren't using a PVC, it's ok to spawn up a new pod
-      # before killing the currently running one. This also makes the '--wait'
-      # flag of helm work properly
-      maxUnavailable: 0
-      {{ end }}
   template:
     metadata:
       labels:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -9,12 +9,6 @@ metadata:
   name: proxy
 spec:
   replicas: 1
-  strategy:
-      rollingUpdate:
-          # There's no PVCs attached here, so is ok to set maxUnavailable to 1
-          # This means new pod will be spun up and traffic transferred to it
-          # before old pod is shut down.
-          maxUnavailable: 1
   template:
     metadata:
       annotations:


### PR DESCRIPTION
As @minrk pointed out in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/367#pullrequestreview-86373648,
this is actually unsafe. My comment about the proxy being safe
also do not make sense in hindsight.

This reverts commit 7d03d6459ff8d186abe2e854d524c71eca3c51d3.