### PR TITLE
Update references.txt with new user environment link

### DIFF
--- a/doc/source/reference.txt
+++ b/doc/source/reference.txt
@@ -10,4 +10,4 @@ The [JupyterHub helm chart](https://github.com/jupyterhub/zero-to-jupyterhub-k8s
 Below is a description of the fields that are exposed with the JupyterHub helm chart.
 For more guided information about some specific things you can do with
 modifications to the helm chart, see the [extending jupyterhub](extending-jupyterhub.html)
-and [user experience](user-experience.html) pages.
+and [user environment](user-environment.html) pages.


### PR DESCRIPTION
This fix is for issue #561 

Updated references.txt replacing the old `user-experience.html` link with new `user-environment.html` link. Changed the link text to be 'user environment'