### PR TITLE
fix newlines between multiple hub.extraConfig entries

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -120,7 +120,7 @@ data:
   {{ range $key, $value := .Values.hub.extraConfig -}}
   hub.extra-config.{{ $key }}.py: |
 {{ $value | indent 4 }}
-  {{- end }}
+  {{ end }}
   {{- end }}
   {{- end }}
   {{ if .Values.hub.extraConfigVars -}}


### PR DESCRIPTION
truncating whitespace with `{- end }` results in nesting configs within each other, e.g.

```yaml
hub.extra-config.foo.py: |
  foo-config
  hub.extra-config.bar.py: |
  bar-config
```