### PR TITLE
default extraConfig is a dict

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -22,7 +22,7 @@ hub:
       storageClassName:
     url:
   labels: {}
-  extraConfig: ''
+  extraConfig: {}
   extraConfigMap: {}
   extraEnv: {}
   extraContainers: []


### PR DESCRIPTION
avoids warning:

> warning: destination for extraConfig is a table. Ignoring non-table value

does not appear to affect behavior, though, only the warnings. I believe the ignored value is the default `extraConfig` empty string, which has no effect.

closes https://github.com/jupyterhub/binderhub/issues/483