### PR TITLE
Separate automatic HTTPS to its own deployment

### DIFF
--- a/jupyterhub/templates/proxy/autohttps/_README.md
+++ b/jupyterhub/templates/proxy/autohttps/_README.md
@@ -1,0 +1,9 @@
+# Automatic HTTPS Terminator
+
+This directory has Kubernetes objects for automatic Let's Encrypt Support.
+When enabled, we create a new deployment object that has an nginx-ingress
+and kube-lego container in it. This is responsible for requesting,
+storing and renewing certificates as needed from Let's Encrypt.
+
+The only change required outside of this directory is in the `proxy-public`
+service, which targets different hubs based on automatic HTTPS status.

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -1,0 +1,122 @@
+{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
+{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
+{{ if $autoHTTPS }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    component: autohttps
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: autohttps
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: autohttps
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        app: kube-lego
+        hub.jupyter.org/network-access-proxy-http: "true"
+    spec:
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: autohttps
+      {{- end }}
+      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: component
+                      operator: In
+                      values: ['hub']
+                    - key: release
+                      operator: In
+                      values: [ {{ .Release.Name | quote }} ]
+      containers:
+        - name: nginx
+          image: "{{ .Values.proxy.nginx.image.name }}:{{ .Values.proxy.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.proxy.nginx.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.proxy.nginx.resources | indent 12 }}
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service={{ .Release.Namespace }}/proxy-http
+            - --configmap={{ .Release.Namespace }}/nginx-proxy-config
+            - --ingress-class=jupyterhub-proxy-tls
+            - --watch-namespace={{ .Release.Namespace }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+        - name: kube-lego
+          image: "{{ .Values.proxy.lego.image.name }}:{{ .Values.proxy.lego.image.tag }}"
+          imagePullPolicy: {{ .Values.proxy.lego.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.proxy.lego.resources | indent 12 }}
+          env:
+            - name: LEGO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LEGO_WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LEGO_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: LEGO_EMAIL
+              # {{ required "proxy.https.letsencrypt.contactEmail is a required field" .Values.proxy.https.letsencrypt.contactEmail }}
+              value: {{ .Values.proxy.https.letsencrypt.contactEmail | quote }}
+            - name: LEGO_SUPPORTED_INGRESS_PROVIDER
+              value: "nginx"
+            - name: LEGO_SUPPORTED_INGRESS_CLASS
+              value: "jupyterhub-proxy-tls,dummy"
+            - name: LEGO_DEFAULT_INGRESS_CLASS
+              value: "jupyterhub-proxy-tls"
+            - name: LEGO_KUBE_ANNOTATION
+              value: "hub.jupyter.org/tls-terminator"
+            - name: LEGO_URL
+              value: "https://acme-v01.api.letsencrypt.org/directory"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+      terminationGracePeriodSeconds: 60
+{{ end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -51,6 +51,9 @@ spec:
             - --configmap={{ .Release.Namespace }}/nginx-proxy-config
             - --ingress-class=jupyterhub-proxy-tls
             - --watch-namespace={{ .Release.Namespace }}
+            {{ if .Values.debug.enabled }}
+            - --v=3
+            {{ end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/jupyterhub/templates/proxy/autohttps/ingress-internal.yaml
+++ b/jupyterhub/templates/proxy/autohttps/ingress-internal.yaml
@@ -1,4 +1,6 @@
-{{- if and .Values.proxy.https.enabled .Values.proxy.https.hosts }}
+{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
+{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
+{{ if $autoHTTPS }}
 # This is solely used to provide auto HTTPS with our bundled kube-lego
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -20,15 +22,7 @@ spec:
       host: {{ $host }}
     {{- end }}
   tls:
-    {{- if eq .Values.proxy.https.type "letsencrypt" }}
     - secretName: kubelego-tls-proxy-{{ .Release.Name }}
-    {{- else if eq .Values.proxy.https.type "manual" }}
-    - secretName: manual-tls-proxy-{{ .Release.Name }}
-    {{- else }}
-    # unhandled type
-    # it would be nice if helm had an `error` function
-    {{ required (printf "https.type must be 'manual' or 'letsencrypt', not '%s'" .Values.proxy.https.type)  ._undefined }}
-    {{- end }}
       hosts:
 {{ toYaml .Values.proxy.https.hosts | indent 8 }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/nginx-configmap.yaml
+++ b/jupyterhub/templates/proxy/autohttps/nginx-configmap.yaml
@@ -1,0 +1,10 @@
+{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
+{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
+{{ if $autoHTTPS }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-proxy-config
+data:
+  proxy-body-size: "{{ .Values.proxy.nginx.proxyBodySize }}"
+{{ end }}

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -1,3 +1,6 @@
+{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
+{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
+{{ if $autoHTTPS }}
 {{ if .Values.rbac.enabled -}}
 # This is way too many permissions, but apparently the nginx-controller
 # is written to sortof assume it is clusterwide ingress provider.
@@ -81,7 +84,7 @@ roleRef:
   name: nginx-{{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    name: proxy
+    name: autohttps
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -179,7 +182,7 @@ roleRef:
   name: nginx
 subjects:
   - kind: ServiceAccount
-    name: proxy
+    name: autohttps
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -196,7 +199,7 @@ roleRef:
   name: kube-lego
 subjects:
   - kind: ServiceAccount
-    name: proxy
+    name: autohttps
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
@@ -207,5 +210,6 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: proxy
+  name: autohttps
 {{- end }}
+{{ end }}

--- a/jupyterhub/templates/proxy/autohttps/service.yaml
+++ b/jupyterhub/templates/proxy/autohttps/service.yaml
@@ -1,0 +1,21 @@
+{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
+{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
+{{ if $autoHTTPS }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-http
+  # toYaml + indent seem a lot more unstable & error prone
+  annotations: {{ toJson .Values.proxy.service.annotations }}
+  labels: {{ toJson .Values.proxy.service.labels }}
+spec:
+  type: ClusterIP
+  selector:
+    name: proxy
+    component: proxy
+    release: {{ .Release.Name }}
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+{{ end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -1,3 +1,5 @@
+{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
+{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -21,7 +23,7 @@ spec:
         component: proxy
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
-        {{- if eq .Values.proxy.https.type "letsencrypt" }}
+        {{- if $autoHTTPS }}
         # required for kube-lego to work
         app: kube-lego
         {{- end }}
@@ -47,6 +49,7 @@ spec:
                       operator: In
                       values: [ {{ .Release.Name | quote }} ]
       containers:
+      {{ if $HTTPS }}
         - name: nginx
           image: "{{ .Values.proxy.nginx.image.name }}:{{ .Values.proxy.nginx.image.tag }}"
           imagePullPolicy: {{ .Values.proxy.nginx.image.pullPolicy }}
@@ -89,7 +92,6 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
-        {{ if and .Values.proxy.https.hosts (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "letsencrypt" ) ) -}}
         - name: kube-lego
           image: "{{ .Values.proxy.lego.image.name }}:{{ .Values.proxy.lego.image.tag }}"
           imagePullPolicy: {{ .Values.proxy.lego.image.pullPolicy }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -1,5 +1,3 @@
-{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
-{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -17,22 +15,14 @@ spec:
         # This lets us autorestart when the secret changes!
         checksum/hub-secret: {{ include (print $.Template.BasePath "/hub/secret.yaml") . | sha256sum }}
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum }}
-        hub.jupyter.org/https-type: {{ .Values.proxy.https.type }}
       labels:
         name: proxy
         component: proxy
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
-        {{- if $autoHTTPS }}
-        # required for kube-lego to work
-        app: kube-lego
-        {{- end }}
         hub.jupyter.org/network-access-hub: "true"
         hub.jupyter.org/network-access-singleuser: "true"
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: proxy
-      {{- end }}
       nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
       affinity:
         podAffinity:
@@ -49,89 +39,6 @@ spec:
                       operator: In
                       values: [ {{ .Release.Name | quote }} ]
       containers:
-      {{ if $HTTPS }}
-        - name: nginx
-          image: "{{ .Values.proxy.nginx.image.name }}:{{ .Values.proxy.nginx.image.tag }}"
-          imagePullPolicy: {{ .Values.proxy.nginx.image.pullPolicy }}
-          resources:
-{{ toYaml .Values.proxy.nginx.resources | indent 12 }}
-          args:
-            - /nginx-ingress-controller
-            - --default-backend-service={{ .Release.Namespace }}/proxy-http
-            - --configmap={{ .Release.Namespace }}/nginx-proxy-config
-            - --ingress-class=jupyterhub-proxy-tls
-            - --watch-namespace={{ .Release.Namespace }}
-            {{- if .Values.debug.enabled }}
-            - --v=3
-            {{- end }}
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 10254
-              scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 10254
-              scheme: HTTP
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
-            - name: https
-              containerPort: 443
-              protocol: TCP
-        - name: kube-lego
-          image: "{{ .Values.proxy.lego.image.name }}:{{ .Values.proxy.lego.image.tag }}"
-          imagePullPolicy: {{ .Values.proxy.lego.image.pullPolicy }}
-          resources:
-{{ toYaml .Values.proxy.lego.resources | indent 12 }}
-          env:
-            - name: LEGO_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LEGO_WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: LEGO_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: LEGO_EMAIL
-              # {{ required "proxy.https.letsencrypt.contactEmail is a required field" .Values.proxy.https.letsencrypt.contactEmail }}
-              value: {{ .Values.proxy.https.letsencrypt.contactEmail | quote }}
-            - name: LEGO_SUPPORTED_INGRESS_PROVIDER
-              value: "nginx"
-            - name: LEGO_SUPPORTED_INGRESS_CLASS
-              value: "jupyterhub-proxy-tls,dummy"
-            - name: LEGO_DEFAULT_INGRESS_CLASS
-              value: "jupyterhub-proxy-tls"
-            - name: LEGO_KUBE_ANNOTATION
-              value: "hub.jupyter.org/tls-terminator"
-            - name: LEGO_URL
-              value: "https://acme-v01.api.letsencrypt.org/directory"
-          ports:
-            - containerPort: 8080
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
-        {{- end }}
         - name: chp
           image: {{ .Values.proxy.chp.image.name }}:{{ .Values.proxy.chp.image.tag }}
           {{- if .Values.proxy.chp.cmd }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -63,6 +63,9 @@ spec:
           {{ else }}
           - --port=8000
           {{ end }}
+          {{ if .Values.debug.enabled }}
+          - --log-level debug
+          {{ end }}
           resources:
           {{ if $manualHTTPS }}
           volumeMounts:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -1,3 +1,4 @@
+{{ $manualHTTPS := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual" ) ) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -38,13 +39,37 @@ spec:
                     - key: release
                       operator: In
                       values: [ {{ .Release.Name | quote }} ]
+      {{ if $manualHTTPS }}
+      volumes:
+      - name: tls-secret
+        secret:
+          secretName: manual-tls-proxy-{{ .Release.Name }}
+      {{ end }}
       containers:
         - name: chp
           image: {{ .Values.proxy.chp.image.name }}:{{ .Values.proxy.chp.image.tag }}
-          {{- if .Values.proxy.chp.cmd }}
-          command: {{ toJson .Values.proxy.chp.cmd }}
-          {{- end }}
+          command:
+          - configurable-http-proxy
+          - --ip=0.0.0.0
+          - --api-ip=0.0.0.0
+          - --api-port=8001
+          - --default-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
+          - --error-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)/hub/error
+          {{ if $manualHTTPS }}
+          - --port=8443
+          - --redirect-port=8000
+          - --ssl-key=/etc/chp/tls/tls.key
+          - --ssl-cert=/etc/chp/tls/tls.crt
+          {{ else }}
+          - --port=8000
+          {{ end }}
           resources:
+          {{ if $manualHTTPS }}
+          volumeMounts:
+          - name: tls-secret
+            mountPath: /etc/chp/tls
+            readOnly: true
+          {{ end }}
 {{ toYaml .Values.proxy.chp.resources | indent 12 }}
           env:
             - name: CONFIGPROXY_AUTH_TOKEN
@@ -54,6 +79,10 @@ spec:
                   key: proxy.token
           imagePullPolicy: {{ .Values.proxy.chp.image.pullPolicy }}
           ports:
+            {{ if $manualHTTPS }}
+            - containerPort: 8443
+              name: proxy-https
+            {{ end }}
             - containerPort: 8000
               name: proxy-public
             - containerPort: 8001

--- a/jupyterhub/templates/proxy/nginx-configmap.yaml
+++ b/jupyterhub/templates/proxy/nginx-configmap.yaml
@@ -1,6 +1,0 @@
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: nginx-proxy-config
-data:
-  proxy-body-size: "{{ .Values.proxy.nginx.proxyBodySize }}"

--- a/jupyterhub/templates/proxy/secret.yaml
+++ b/jupyterhub/templates/proxy/secret.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual") }}
+{{ $manualHTTPS := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual" ) ) }}
+{{- if $manualHTTPS }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -1,3 +1,4 @@
+{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,6 +12,7 @@ spec:
     - protocol: TCP
       port: 8001
       targetPort: 8001
+{{ if $HTTPS }}
 ---
 apiVersion: v1
 kind: Service
@@ -29,6 +31,7 @@ spec:
     - protocol: TCP
       port: 8000
       targetPort: 8000
+{{ end }}
 ---
 apiVersion: v1
 kind: Service
@@ -51,11 +54,16 @@ spec:
     - name: http
       port: 80
       protocol: TCP
+      {{ if $HTTPS }}
       targetPort: 80
+      {{ else }}
+      targetPort: 8000
+      {{ end }}
       # allow proxy.service.nodePort for http
       {{ if .Values.proxy.service.nodePorts.http -}}
       nodePort: {{ .Values.proxy.service.nodePorts.http }}
       {{- end }}
+    {{ if $HTTPS }}
     - name: https
       port: 443
       protocol: TCP
@@ -63,6 +71,7 @@ spec:
       {{ if .Values.proxy.service.nodePorts.https -}}
       nodePort: {{ .Values.proxy.service.nodePorts.https }}
       {{- end }}
+    {{ end }}
   selector:
     name: proxy
     component: proxy

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -1,4 +1,5 @@
 {{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
+{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,26 +13,6 @@ spec:
     - protocol: TCP
       port: 8001
       targetPort: 8001
-{{ if $HTTPS }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: proxy-http
-  # toYaml + indent seem a lot more unstable & error prone
-  annotations: {{ toJson .Values.proxy.service.annotations }}
-  labels: {{ toJson .Values.proxy.service.labels }}
-spec:
-  type: ClusterIP
-  selector:
-    name: proxy
-    component: proxy
-    release: {{ .Release.Name }}
-  ports:
-    - protocol: TCP
-      port: 8000
-      targetPort: 8000
-{{ end }}
 ---
 apiVersion: v1
 kind: Service
@@ -54,11 +35,11 @@ spec:
     - name: http
       port: 80
       protocol: TCP
-      {{ if $HTTPS }}
+      {{ if $autoHTTPS }}
       targetPort: 80
       {{ else }}
       targetPort: 8000
-      {{ end }}
+      {{ end}}
       # allow proxy.service.nodePort for http
       {{ if .Values.proxy.service.nodePorts.http -}}
       nodePort: {{ .Values.proxy.service.nodePorts.http }}
@@ -73,8 +54,11 @@ spec:
       {{- end }}
     {{ end }}
   selector:
-    name: proxy
+    {{ if $autoHTTPS}}
+    component: autohttps
+    {{ else }}
     component: proxy
+    {{ end }}
     release: {{ .Release.Name }}
   type: {{ .Values.proxy.service.type }}
   {{ if .Values.proxy.service.loadBalancerIP -}}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -1,5 +1,6 @@
 {{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
 {{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
+{{ $manualHTTPS := (and $HTTPS (eq .Values.proxy.https.type "manual" ) ) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -48,7 +49,11 @@ spec:
     - name: https
       port: 443
       protocol: TCP
+      {{ if $manualHTTPS }}
+      targetPort: 8443
+      {{ else }}
       targetPort: 443
+      {{ end }}
       {{ if .Values.proxy.service.nodePorts.https -}}
       nodePort: {{ .Values.proxy.service.nodePorts.https }}
       {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -63,15 +63,6 @@ proxy:
       name: jupyterhub/configurable-http-proxy
       tag: 3.0.0
       pullPolicy: IfNotPresent
-    cmd:
-      - configurable-http-proxy
-      - --ip=0.0.0.0
-      - --port=8000
-      - --api-ip=0.0.0.0
-      - --api-port=8001
-      - --default-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
-      - --error-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)/hub/error
-      - --log-level=debug
     resources:
       requests:
         cpu: 0.2


### PR DESCRIPTION
The extra network hop is worth the following advantages:

1. The code is much easier for us to understand and reason about.
2. We have pod affinity set up to try to place all three components
   (hub, proxy, autohttps) in the same node if possible. This
   should cut down on hops!
3. For users with at least one proxy in front of the hub,
   this is a much cleaner way to disable the extra nginx cost -
   both in terms of resources and extra processing overhead.

Longer term, we should build / use a proxy implementation that
can automatically get certificates from ACME and store them
in Kubernetes Secret objects.

We also terminate HTTPS in CHP when using manual HTTPS, avoiding
an extra hop unnecessarily. IIRC this means we lose http/2 when
using manual HTTPS, but that feels fine for now.

