### PR TITLE
Allow singleuser_image_pull_policy to be modified

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -45,6 +45,8 @@ c.KubeSpawner.start_timeout = get_config('singleuser.start-timeout')
 # Use env var for this, since we want hub to restart when this changes
 c.KubeSpawner.singleuser_image_spec = os.environ['SINGLEUSER_IMAGE']
 
+c.KubeSpawner.singleuser_image_pull_policy = get_config('singleuser.image-pull-policy')
+
 c.KubeSpawner.singleuser_extra_labels = get_config('singleuser.extra-labels', {})
 
 c.KubeSpawner.singleuser_uid = get_config('singleuser.uid')

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -93,6 +93,9 @@ data:
 {{ toYaml .Values.singleuser.cloudMetadata | indent 4 }}
 
   singleuser.start-timeout: {{ .Values.singleuser.startTimeout | quote }}
+
+  singleuser.image-pull-policy: {{ .Values.singleuser.image.pullPolicy | quote }}
+
   hub.concurrent-spawn-limit: {{ .Values.hub.concurrentSpawnLimit | quote }}
   {{ if .Values.hub.activeServerLimit }}
   hub.active-server-limit: {{ .Values.hub.activeServerLimit | quote }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -169,6 +169,7 @@ singleuser:
   image:
     name: jupyterhub/k8s-singleuser-sample
     tag: generated-by-chartpress
+    pullPolicy: IfNotPresent
   startTimeout: 300
   cpu:
     limit:


### PR DESCRIPTION
This is useful during development of singleuser images. Most other images in this chart already have a `pullPolicy` or `imagePullPolicy` property.