### PR TITLE
Change schema of hub.extraEnv to allow use of `valueFrom`

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -169,13 +169,12 @@ properties:
           See [the kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
           to learn more about labels.
       extraEnv:
-        type: object
+        type: list
         description: |
           Extra environment variables that should be set for the hub pod.
 
-          A dictionary of key value pairs (both strings), where the key is the name of the
-          environment value and the value is the value of the environment variable that should
-          be set on the hub pod.
+          A list of [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#envvar-v1-core)
+          objects.
 
           These are usually used in two circumstances:
             - Passing parameters to some custom code specified with `extraConfig`

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -128,10 +128,9 @@ spec:
             secretKeyRef:
               name: hub-secret
               key: proxy.token
-        {{ range $key, $value := .Values.hub.extraEnv -}}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
-        {{ end -}}
+{{- if .Values.hub.extraEnv }}
+{{ toYaml .Values.hub.extraEnv | indent 8 }}
+{{- end }}
         {{ if .Values.auth.state.enabled }}
         - name: JUPYTERHUB_CRYPT_KEY
           valueFrom:

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -128,17 +128,19 @@ spec:
             secretKeyRef:
               name: hub-secret
               key: proxy.token
-{{ if .Values.hub.extraEnv -}}
-{{ $extraEnvType := typeOf .Values.hub.extraEnv -}}
-{{ if eq $extraEnvType "[]interface {}" -}}
+        {{ if .Values.hub.extraEnv -}}
+        {{ $extraEnvType := typeOf .Values.hub.extraEnv -}}
+        {# If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc #}
+        {{ if eq $extraEnvType "[]interface {}" -}}
 {{ toYaml .Values.hub.extraEnv | indent 8 }}
-{{ else if eq $extraEnvType "map[string]interface {}" -}}
+        {{ else if eq $extraEnvType "map[string]interface {}" -}}
+        {# If we have a map, treat those as key-value pairs #}
         {{ range $key, $value := .Values.hub.extraEnv }}
         - name: {{ $key | quote }}
           value: {{ $value | quote }}
         {{- end }}
-{{- end }}
-{{- end }}
+        {{- end }}
+        {{- end }}
         {{ if .Values.auth.state.enabled }}
         - name: JUPYTERHUB_CRYPT_KEY
           valueFrom:

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -128,8 +128,16 @@ spec:
             secretKeyRef:
               name: hub-secret
               key: proxy.token
-{{- if .Values.hub.extraEnv }}
+{{ if .Values.hub.extraEnv -}}
+{{ $extraEnvType := typeOf .Values.hub.extraEnv -}}
+{{ if eq $extraEnvType "[]interface {}" -}}
 {{ toYaml .Values.hub.extraEnv | indent 8 }}
+{{ else if eq $extraEnvType "map[string]interface {}" -}}
+        {{ range $key, $value := .Values.hub.extraEnv }}
+        - name: {{ $key | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
+{{- end }}
 {{- end }}
         {{ if .Values.auth.state.enabled }}
         - name: JUPYTERHUB_CRYPT_KEY

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -24,7 +24,7 @@ hub:
   labels: {}
   extraConfig: {}
   extraConfigMap: {}
-  extraEnv: {}
+  extraEnv: []
   extraContainers: []
   extraVolumes: []
   extraVolumeMounts: []


### PR DESCRIPTION
This was discussed back in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/228, but was not done because of difficulties with `toYaml`. It looks like `indent` hadn't been discovered then.

Motivation: I'm adding tracing to the `hub` component, and I need to use `valueFrom` to access the downward API.