### PR TITLE
style toctree heading in body

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -97,3 +97,10 @@ div.relations ul {
 div#searchbox form {
     margin-left: 0px !important;
 }
+
+/* body elements */
+.toctree-wrapper span.caption-text {
+    color: #767676;
+    font-style: italic;
+    font-weight: 300;
+}


### PR DESCRIPTION
Follow up to #594 

- Style the toctree-heading caption CSS to be less prominent

<img width="766" alt="screenshot 2018-03-21 17 26 51" src="https://user-images.githubusercontent.com/2680980/37744678-bb3d8a10-2d2d-11e8-8140-3191df88f264.png">
