### PR TITLE
Add nodePort option helm chart for hub

### DIFF
--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -13,3 +13,6 @@ spec:
     - protocol: TCP
       port: 8081
       targetPort: 8081
+      {{ if .Values.hub.service.ports.nodePort -}}
+      nodePort: {{ .Values.hub.service.ports.nodePort }}
+      {{- end }}


### PR DESCRIPTION
The hub section of the helm chart permits the assigning of type to the Service for hub. By default this is ClusterIP. However, it may be desirable for the hub to be exposed so that an external load balancer can be used. Overriding the type to "NodePort" through a config.yaml file does work. However, without the ability to configure the nodePort specifically Kubernetes selects a random port between 30000 and 32767. For an external load balancer it is desirable to keep this port fixed.