### PR TITLE
Missing = in configurable-http-proxy args

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           - --port=8000
           {{ end }}
           {{ if .Values.debug.enabled }}
-          - --log-level debug
+          - --log-level=debug
           {{ end }}
           resources:
           {{ if $manualHTTPS }}


### PR DESCRIPTION
Looks like there was a copy and paste error in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/592/files#diff-901145829b96bb9fea44682f2e1d3f83R67

```
$ kubectl get pods --selector=name=proxy
NAME                    READY     STATUS             RESTARTS   AGE
proxy-9564c448d-88qv8   0/1       CrashLoopBackOff   3          1m

$ kubectl logs --selector=name=proxy

  error: unknown option `--log-level debug'

```