### PR TITLE
NetworkPolicy access to proxy 8000 / 8443

### DIFF
--- a/jupyterhub/templates/proxy/netpol-proxy.yaml
+++ b/jupyterhub/templates/proxy/netpol-proxy.yaml
@@ -1,3 +1,5 @@
+{{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
+{{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
 {{- if and .Values.proxy.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -17,9 +19,10 @@ spec:
       port: 80
     - protocol: TCP
       port: 443
-    # Required if no HTTPS
+    {{- if not $autoHTTPS }}
     - protocol: TCP
       port: 8000
+    {{- end }}
     # kube-lego /healthz
     - protocol: TCP
       port: 8080

--- a/jupyterhub/templates/proxy/netpol-proxy.yaml
+++ b/jupyterhub/templates/proxy/netpol-proxy.yaml
@@ -1,5 +1,6 @@
 {{ $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled ) }}
 {{ $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt" ) ) }}
+{{ $manualHTTPS := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual" ) ) }}
 {{- if and .Values.proxy.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -22,6 +23,10 @@ spec:
     {{- if not $autoHTTPS }}
     - protocol: TCP
       port: 8000
+    {{- end }}
+    {{- if $manualHTTPS }}
+    - protocol: TCP
+      port: 8443
     {{- end }}
     # kube-lego /healthz
     - protocol: TCP

--- a/jupyterhub/templates/proxy/netpol-proxy.yaml
+++ b/jupyterhub/templates/proxy/netpol-proxy.yaml
@@ -17,6 +17,9 @@ spec:
       port: 80
     - protocol: TCP
       port: 443
+    # Required if no HTTPS
+    - protocol: TCP
+      port: 8000
     # kube-lego /healthz
     - protocol: TCP
       port: 8080


### PR DESCRIPTION
I think https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/592 means direct access to port 8000 on the proxy may be required. Without it I get a 504 gateway error from my external K8s ingress.

I'm not sure if this port needs to be always open, or only if the internal HTTPS ingress is disabled