### PR TITLE
{# comments #} replaced with # comments

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -133,11 +133,11 @@ spec:
               key: proxy.token
         {{ if .Values.hub.extraEnv -}}
         {{ $extraEnvType := typeOf .Values.hub.extraEnv -}}
-        # If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc
+        {{/* If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc. */}}
         {{ if eq $extraEnvType "[]interface {}" -}}
 {{ toYaml .Values.hub.extraEnv | indent 8 }}
         {{ else if eq $extraEnvType "map[string]interface {}" -}}
-        # If we have a map, treat those as key-value pairs
+        {{/* If we have a map, treat those as key-value pairs. */}}
         {{ range $key, $value := .Values.hub.extraEnv }}
         - name: {{ $key | quote }}
           value: {{ $value | quote }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -133,11 +133,11 @@ spec:
               key: proxy.token
         {{ if .Values.hub.extraEnv -}}
         {{ $extraEnvType := typeOf .Values.hub.extraEnv -}}
-        {# If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc #}
+        # If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc
         {{ if eq $extraEnvType "[]interface {}" -}}
 {{ toYaml .Values.hub.extraEnv | indent 8 }}
         {{ else if eq $extraEnvType "map[string]interface {}" -}}
-        {# If we have a map, treat those as key-value pairs #}
+        # If we have a map, treat those as key-value pairs
         {{ range $key, $value := .Values.hub.extraEnv }}
         - name: {{ $key | quote }}
           value: {{ $value | quote }}


### PR DESCRIPTION
A simple syntax error with a simple fix - I think! In this PR I simply replaced `{# these types of comments #}` with `# these types of comments`. 

Perhaps `{# this comment syntax #}` is valid, but if so it seem to have caused some indentation errors. I got an error on my `helm upgrade ...` command that appears to be commonly associated with indentation issues.

```shell
Error:
  UPGRADE FAILED:
    YAML parse error on z2jh-extended/charts/jupyterhub/templates/hub/deployment.yaml:
      error converting YAML to JSON: yaml: line 111: could not find expected ':'
```

Ping #597 @mattjbray @yuvipanda