### PR TITLE
Helm upgrade error "... with the name ... not found" and how to handle it

### DIFF
--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,4 +1,9 @@
 {{ if .Values.rbac.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hub
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -23,9 +28,4 @@ roleRef:
   kind: Role
   name: hub
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: hub
 {{- end }}

--- a/jupyterhub/templates/image-puller/_helper.yaml
+++ b/jupyterhub/templates/image-puller/_helper.yaml
@@ -26,10 +26,10 @@ metadata:
 spec:
   selector:
     matchLabels:
-        app: jupyterhub
-        component: {{ .name }}
-        release: {{ .top.Release.Name }}
-        heritage: {{ .top.Release.Service }}
+      app: jupyterhub
+      component: {{ .name }}
+      release: {{ .top.Release.Name }}
+      heritage: {{ .top.Release.Service }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/jupyterhub/templates/pod-culler/rbac.yaml
+++ b/jupyterhub/templates/pod-culler/rbac.yaml
@@ -1,4 +1,10 @@
+{{ if and .Values.cull.enabled .Values.cull.maxAge }}
 {{ if .Values.rbac.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-culler
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -26,9 +32,5 @@ roleRef:
   kind: Role
   name: pod-culler
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: pod-culler
+{{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -93,9 +93,9 @@ roleRef:
   kind: ClusterRole
   name: nginx-{{ .Release.Name }}
 subjects:
-  - kind: ServiceAccount
-    name: autohttps
-    namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: autohttps
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
@@ -191,9 +191,9 @@ roleRef:
   kind: Role
   name: nginx
 subjects:
-  - kind: ServiceAccount
-    name: autohttps
-    namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: autohttps
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -208,8 +208,8 @@ roleRef:
   kind: Role
   name: kube-lego
 subjects:
-  - kind: ServiceAccount
-    name: autohttps
-    namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: autohttps
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 {{ end }}

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -5,6 +5,16 @@
 # This is way too many permissions, but apparently the nginx-controller
 # is written to sortof assume it is clusterwide ingress provider.
 # So we keep this as is, for now.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: jupyterhub
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: autohttps
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -201,15 +211,5 @@ subjects:
   - kind: ServiceAccount
     name: autohttps
     namespace: {{ .Release.Namespace }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app: jupyterhub
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: autohttps
 {{- end }}
 {{ end }}


### PR DESCRIPTION
# Update
This PR was supposed to fix #619, but became documentation on how to handle the errors encountered on helm upgrades. These are supposedly fixed in Helm 2.8.2 assuming a clean slate of helm release revisions.
```
Error: UPGRADE FAILED: <object type> with the name <object name> not found
```
- [Issue reproduced](https://github.com/kubernetes/helm/issues/2941#issuecomment-363537224)
- [Issue fixed](https://github.com/kubernetes/helm/pull/3539)

### Symptoms
You attempt to make a helm upgrade, but something like this hits you...
```
# Errors experienced by me
Error: UPGRADE FAILED: no ServiceAccount with the name "pod-culler" found
Error: UPGRADE FAILED: no Deployment with the name "hub" found
Error: UPGRADE FAILED: no ServiceAccount with the name "autohttps" found

# Error experienced by Yuvi
Error: UPGRADE FAILED: no DaemonSet with the name "continuous-image-puller" found
```

### Diagnosis
```
# Do you have multiple release revisions considered deployed?
kubectl get configmap --namespace kube-system --selector STATUS=DEPLOYED
# Do you have multiple release revisions pending upgrade?
kubectl get configmap --namespace kube-system --selector STATUS=PENDING_UPGRADE
```

### Cure
```
# Fix 1 (recommended) - no consequences as far as I understand it
kubectl get configmap --namespace kube-system --selector STATUS=DEPLOYED
kubectl delete configmap --namespace kube-system --selector STATUS=PENDING_UPGRADE
kubectl delete configmap --namespace kube-system <all configmaps except the latest deployed release revision>
# - optional cleanup...
kubectl delete configmap --namespace kube-system --selector STATUS=FAILED
kubectl delete configmap --namespace kube-system --selector STATUS=DELETED
kubectl delete configmap --namespace kube-system --selector STATUS=SUPERSEDED

# Fix 2 - invasive, you will loose the hub database of users etc. if you do this
helm delete <revision name> --purge
```

### Related
Helm 2.7 introduced the `--history-max` feature flag to `helm init` - this way you can limit helms memory of release revisions.

# Actual PR content
This ended up being quite irrelevant I think...
* I moved the ServiceAccount definition to the top of rbac.yaml files (hub, autohttps, pod-culler). The ServiceAccounts are standalone objects required by the objects below. I figured it could matters in certain situations, but I doubt that now.
* I added a conditional in the pod-culler rbac.yaml to not create ServiceAccount and roles etc when the culler wasn't used.

#### Very unimportant stuff also in PR
* Adjusted some indentation to make it in-file consistent.