### PR TITLE
debug chartpress, disable shallow-clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 - ./ci/install.sh
 script:
 - chartpress --commit-range ${TRAVIS_COMMIT_RANGE}
+- git diff
 - ./ci/test.sh
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
 - 3.6
+git:
+  depth: false
 services:
 - docker
 install:

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -6,3 +6,4 @@ chmod 0400 travis
 docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 export GIT_SSH_COMMAND="ssh -i ${PWD}/travis"
 chartpress --commit-range "${TRAVIS_COMMIT_RANGE}" --push --publish-chart
+git diff

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 PyGithub>=1
 python-dateutil>=2
-https://github.com/jupyterhub/chartpress/archive/master.tar.gz
+https://github.com/jupyterhub/chartpress/archive/271c75e.tar.gz

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -43,8 +43,8 @@ hub:
     enabled: false
     egress:
       - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
+          - ipBlock:
+              cidr: 0.0.0.0/0
 
 rbac:
   enabled: true
@@ -98,8 +98,8 @@ proxy:
     enabled: false
     egress:
       - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
+          - ipBlock:
+              cidr: 0.0.0.0/0
 
 
 # Google OAuth secrets
@@ -130,10 +130,10 @@ singleuser:
     egress:
     # Required egress is handled by other rules so it's safe to modify this
       - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              - 169.254.169.254/32
+          - ipBlock:
+              cidr: 0.0.0.0/0
+              except:
+                - 169.254.169.254/32
   extraLabels: {}
   extraEnv: {}
   lifecycleHooks:
@@ -154,9 +154,9 @@ singleuser:
     homeMountPath: /home/jovyan
     dynamic:
       storageClass:
-      pvcNameTemplate: 'claim-{username}{servername}'
-      volumeNameTemplate: 'volume-{username}{servername}'
-      storageAccessModes: ['ReadWriteOnce']
+      pvcNameTemplate: claim-{username}{servername}
+      volumeNameTemplate: volume-{username}{servername}
+      storageAccessModes: [ReadWriteOnce]
   image:
     name: jupyterhub/k8s-singleuser-sample
     tag: generated-by-chartpress


### PR DESCRIPTION
- run `git diff` after chartpress to show changes, in case something suspicious is in values.yaml
- pin specific chartpress commit so that chartpress only changes explicitly (there's also a slight possibility of caching being responsible for the recent weird chartpress behavior in #612)
- rerender values.yaml with recent changes that deviated slightly in style to avoid churn when chartpress rerenders values.yaml

closes #612