### PR TITLE
Chart.yaml - icon + kube & helm versions

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -2,9 +2,9 @@ name: jupyterhub
 version: v0.7-dev
 appVersion: v0.8.1
 description: Multi-user Jupyter installation
-home: https://zero-to-jupyterhub.readthedocs.io
+home: https://z2jh.jupyter.org
 sources:
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
-icon: http://jupyter.org/assets/hublogo.svg
+icon: https://jupyter.org/assets/hublogo.svg
 kubeVersion: ">1.8.0"
 tillerVersion: ">2.7.0"

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,4 +1,9 @@
-apiVersion: v1
-description: Multi-user Jupyter installation
 name: jupyterhub
 version: v0.7-dev
+description: Multi-user Jupyter installation
+home: https://zero-to-jupyterhub.readthedocs.io
+sources:
+  - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
+icon: http://jupyter.org/assets/hublogo.svg
+kubeVersion: ">1.8.0"
+tillerVersion: ">2.7.0"

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,5 +1,6 @@
 name: jupyterhub
 version: v0.7-dev
+appVersion: v0.8.1
 description: Multi-user Jupyter installation
 home: https://zero-to-jupyterhub.readthedocs.io
 sources:


### PR DESCRIPTION
I ran `helm lint` on the chart successfully, but was warned about a missing icon. This PR adds that icon.

PR based on reading up on what to be included in Chart.yaml [according to Helm](https://github.com/kubernetes/helm/blob/master/docs/charts.md#the-chartyaml-file) and [according to kubernetes/charts repo](https://github.com/kubernetes/charts/blob/master/test/circle/yaml-schemas/Chart.yaml) as well as by looking at charts published in kubernetes/charts.

I added required kubeVersion and tillerVersion to be 1.8+ (k8s daemonset API) and 2.7+ (helm delete annotations). See #502 for more details. Having Helm (tiller) 2.8.2 would avoid issues like described in #620 - but is not essential.