### PR TITLE
Revert k8s-versioning constraint

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -6,5 +6,4 @@ home: https://z2jh.jupyter.org
 sources:
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
 icon: https://jupyter.org/assets/hublogo.svg
-kubeVersion: ">1.8.0"
-tillerVersion: ">2.7.0"
+tillerVersion: ">=2.7.0"


### PR DESCRIPTION
An issue arised with comparing ">=1.8.0" with "v1.9.4-gke.1", due to the -gke.1 appendix. This commit reverts the usage of the contraint for now.

### For reference
* [This is an online SemVer checker](http://jubianchi.github.io/semver-check/), it is supposed to be able to handle `+` something, but not `-`.
* [This is the line it fails on in the comparision](https://github.com/kubernetes/helm/blob/master/pkg/tiller/release_server.go#L260).
* [This is the referenced function called IsCompatibleRange](https://github.com/kubernetes/helm/blob/58e4b6ac61938fe056037826225dd19562c0ed9f/pkg/version/compatible.go#L48-L61)
