### PR TITLE
[MRG] values.yaml: extraEnv and extraImages

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -26,7 +26,7 @@ hub:
   labels: {}
   extraConfig: {}
   extraConfigMap: {}
-  extraEnv: []
+  extraEnv: {}
   extraContainers: []
   extraVolumes: []
   extraVolumeMounts: []
@@ -48,8 +48,10 @@ hub:
           - ipBlock:
               cidr: 0.0.0.0/0
 
+
 rbac:
   enabled: true
+
 
 proxy:
   secretToken: ''
@@ -104,7 +106,6 @@ proxy:
               cidr: 0.0.0.0/0
 
 
-# Google OAuth secrets
 auth:
   type: dummy
   whitelist:
@@ -173,6 +174,7 @@ singleuser:
   cmd: jupyterhub-singleuser
   defaultUrl:
 
+
 prePuller:
   hook:
     enabled: true
@@ -182,10 +184,12 @@ prePuller:
       tag: generated-by-chartpress
   continuous:
     enabled: false
+  extraImages: []
   pause:
     image:
       name: gcr.io/google_containers/pause
       tag: '3.0'
+
 
 ingress:
   enabled: false
@@ -193,17 +197,18 @@ ingress:
   hosts: []
   tls:
 
+
 cull:
   enabled: true
   users: false
   timeout: 3600
   every: 600
   maxAge: 0
-
   podCuller:
     image:
       name: jupyterhub/k8s-pod-culler
       tag: generated-by-chartpress
+
 
 debug:
   enabled: false


### PR DESCRIPTION
- hub.extraEnv's default value now {}, before it was [].
- prePuller.extraImages was referenced in the image-puller daemonsets, and now has an empty placeholder.
- I also made some spacing consistent throughout the file.

[@manics wrote](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/597#issuecomment-378667725):
> I thought I'd mention a use case for keeping the backwards compatibility in future too. If extraEnv is a dict you can easily merge a public config in a git repo with private variables set on the command line during, e.g.
>
>```yaml
> hub:
>   extraEnv:
>     OAUTH2_AUTHORIZE_URL: "https://login.elixir-czech.org/oidc/authorize"
>     OAUTH2_TOKEN_URL: "https://login.elixir-czech.org/oidc/token"
>     OAUTH_CALLBACK_URL: https://example.org/hub/oauth_callback
>     OAUTH_CLIENT_ID: xxx
>```
> and set the private variables separately during deployment: --set hub.extraEnv.OAUTH_CLIENT_SECRET=XXX, but to my knowledge you can't do this when extraEnv is a list.

@manics / @yuvipanda --- will changing extraEnv from [] to {} cause more trouble than future benefit?

I can imagine someone having assumed it to be an array rather a dict, and that could cause issues. At the same time I'd like to encourage people to use it as an dictionary due to benefits described by @manics in the comment above.

__Update 1__
I realized that the default value of extraEnv was changed from a dict to a list in #597 very recently, so changing it back should be super safe.