### PR TITLE
kubeVersion in Charts.yaml works now

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -6,4 +6,5 @@ home: https://z2jh.jupyter.org
 sources:
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
 icon: https://jupyter.org/assets/hublogo.svg
-tillerVersion: ">=2.7.0"
+kubeVersion: ">=1.8.0-r0"
+tillerVersion: ">=2.7.0-r0"

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -6,5 +6,5 @@ home: https://z2jh.jupyter.org
 sources:
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
 icon: https://jupyter.org/assets/hublogo.svg
-kubeVersion: ">=1.8.0-r0"
-tillerVersion: ">=2.7.0-r0"
+kubeVersion: ">=1.8.0-0"
+tillerVersion: ">=2.7.0-0"


### PR DESCRIPTION
This works for now. I started some discussion on kubernetes/helm and  regarding the surprise I got when the ">=1.8.0" constraint failed to match "v1.9.4-gke.1".

For reference, see [kubernetes/helm issue #3810](https://github.com/kubernetes/helm/issues/3810) and [Masterminds/semver issue #69](https://github.com/Masterminds/semver/issues/69).