### PR TITLE
Dont trim whitespace before toYaml to avoid extra indentation

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -134,7 +134,7 @@ spec:
         {{ if .Values.hub.extraEnv -}}
         {{ $extraEnvType := typeOf .Values.hub.extraEnv -}}
         {{/* If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc. */}}
-        {{ if eq $extraEnvType "[]interface {}" -}}
+        {{ if eq $extraEnvType "[]interface {}" }}
 {{ toYaml .Values.hub.extraEnv | indent 8 }}
         {{ else if eq $extraEnvType "map[string]interface {}" -}}
         {{/* If we have a map, treat those as key-value pairs. */}}


### PR DESCRIPTION
The whitespace trim here causes newline to be removed, so the first line of the `toYaml` block receives the indent from the `if` line. This produces broken output when `extraEnv` of `[]` is present.