### PR TITLE
Support LDAP login (LDAPAuthenticator)

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -3,7 +3,7 @@ import glob
 from tornado.httpclient import AsyncHTTPClient
 from kubernetes import client
 
-from z2jh import get_config, get_secret
+from z2jh import get_config, get_secret, set_config_if_not_none
 
 # Configure JupyterHub to use the curl backend for making HTTP requests,
 # rather than the pure-python implementations. The default one starts

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -186,7 +186,7 @@ elif auth_type == 'ldap':
     set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_filter', 'auth.ldap.dn.search.filter')
     set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_user', 'auth.ldap.dn.search.user')
     set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_password', 'auth.ldap.dn.search.password')
-    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_user_dn_attribute', 'auth.ldap.dn.user-dn-attribute')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_user_dn_attribute', 'auth.ldap.dn.user.dn-attribute')
     set_config_if_not_none(c.LDAPAuthenticator, 'escape_userdn', 'auth.ldap.dn.user.escape')
     set_config_if_not_none(c.LDAPAuthenticator, 'valid_username_regex', 'auth.ldap.dn.user.valid-regex')
     set_config_if_not_none(c.LDAPAuthenticator, 'user_search_base', 'auth.ldap.dn.user.search-base')

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -190,7 +190,7 @@ elif auth_type == 'ldap':
     set_config_if_not_none(c.LDAPAuthenticator, 'escape_userdn', 'auth.ldap.dn.user.escape')
     set_config_if_not_none(c.LDAPAuthenticator, 'valid_username_regex', 'auth.ldap.dn.user.valid-regex')
     set_config_if_not_none(c.LDAPAuthenticator, 'user_search_base', 'auth.ldap.dn.user.search-base')
-    set_config_if_not_none(c.LDAPAuthenticator, 'user_attribute', 'auth.ldap.user.attribute')
+    set_config_if_not_none(c.LDAPAuthenticator, 'user_attribute', 'auth.ldap.dn.user.attribute')
 elif auth_type == 'custom':
     # full_class_name looks like "myauthenticator.MyAuthenticator".
     # To create a docker image with this class availabe, you can just have the

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -175,6 +175,22 @@ elif auth_type == 'tmp':
 elif auth_type == 'lti':
     c.JupyterHub.authenticator_class = 'ltiauthenticator.LTIAuthenticator'
     c.LTIAuthenticator.consumers = get_config('auth.lti.consumers')
+elif auth_type == 'ldap':
+    c.JupyterHub.authenticator_class = 'ldapauthenticator.LDAPAuthenticator'
+    c.LDAPAuthenticator.server_address = get_config('auth.ldap.server.address')
+    set_config_if_not_none(c.LDAPAuthenticator, 'server_port', 'auth.ldap.server.port')
+    set_config_if_not_none(c.LDAPAuthenticator, 'use_ssl', 'auth.ldap.server.ssl')
+    set_config_if_not_none(c.LDAPAuthenticator, 'allowed_groups', 'auth.ldap.allowed-groups')
+    c.LDAPAuthenticator.bind_dn_template = get_config('auth.ldap.dn.templates')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn', 'auth.ldap.dn.lookup')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_filter', 'auth.ldap.dn.search.filter')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_user', 'auth.ldap.dn.search.user')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_password', 'auth.ldap.dn.search.password')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_user_dn_attribute', 'auth.ldap.dn.user-dn-attribute')
+    set_config_if_not_none(c.LDAPAuthenticator, 'escape_userdn', 'auth.ldap.dn.user.escape')
+    set_config_if_not_none(c.LDAPAuthenticator, 'valid_username_regex', 'auth.ldap.dn.user.valid-regex')
+    set_config_if_not_none(c.LDAPAuthenticator, 'user_search_base', 'auth.ldap.dn.user.search-base')
+    set_config_if_not_none(c.LDAPAuthenticator, 'user_attribute', 'auth.ldap.user.attribute')
 elif auth_type == 'custom':
     # full_class_name looks like "myauthenticator.MyAuthenticator".
     # To create a docker image with this class availabe, you can just have the

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -11,3 +11,4 @@ globus_sdk[jwt]==1.2.1
 oauthenticator==0.7.2
 cryptography==2.0.3
 https://github.com/jupyterhub/kubespawner/archive/085cb30.tar.gz
+https://github.com/jupyterhub/ldapauthenticator/archive/1bb93f3.tar.gz

--- a/images/hub/z2jh.py
+++ b/images/hub/z2jh.py
@@ -29,3 +29,12 @@ def get_secret(key, default=None):
             return f.read().strip()
     except FileNotFoundError:
         return default
+
+def set_config_if_not_none(cparent, name, key):
+    """
+    Find a config item of a given name, set the corresponding Jupyter
+    configuration item if not None
+    """
+    data = get_config(key)
+    if data is not None:
+        setattr(cparent, name, data)

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -56,6 +56,28 @@ data:
   auth.lti.consumers: |
 {{ toYaml .Values.auth.lti.consumers | indent 4 }}
   {{- end }}
+  {{ if eq .Values.auth.type "ldap" -}}
+  auth.ldap.server.address: {{ .Values.auth.ldap.server.address | quote }}
+  auth.ldap.server.port: {{ .Values.auth.ldap.server.port | quote }}
+  auth.ldap.server.ssl: {{ .Values.auth.ldap.server.ssl | quote }}
+  {{ if .Values.auth.ldap.allowedGroups -}}
+  auth.ldap.allowed-groups: |
+{{ toYaml .Values.auth.ldap.allowedGroups | indent 4 }}
+  {{- end }}
+  {{ if .Values.auth.ldap.dn.templates -}}
+  auth.ldap.dn.templates: |
+{{ toYaml .Values.auth.ldap.dn.templates | indent 4 }}
+  {{- end }}
+  auth.ldap.dn.lookup: {{ .Values.auth.ldap.dn.lookup }}
+  auth.ldap.dn.search.filter: {{ .Values.auth.ldap.dn.search.filter }}
+  auth.ldap.dn.search.user: {{ .Values.auth.ldap.dn.search.user }}
+  auth.ldap.dn.search.password: {{ .Values.auth.ldap.dn.search.password }}
+  auth.ldap.dn.user-dn-attribute: {{ .Values.auth.ldap.dn.userDnAttribute }}
+  auth.ldap.dn.user.escape: {{ .Values.auth.ldap.dn.user.escape }}
+  auth.ldap.dn.user.valid-regex: {{ .Values.auth.ldap.dn.user.validRegex }}
+  auth.ldap.dn.user.search-base: {{ .Values.auth.ldap.dn.user.searchBase }}
+  auth.ldap.user.attribute: {{ .Values.auth.ldap.user.attribute }}
+  {{- end }}
 
   {{ if .Values.auth.whitelist.users -}}
   auth.whitelist.users: |

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -76,7 +76,7 @@ data:
   auth.ldap.dn.user.escape: {{ .Values.auth.ldap.dn.user.escape }}
   auth.ldap.dn.user.valid-regex: {{ .Values.auth.ldap.dn.user.validRegex }}
   auth.ldap.dn.user.search-base: {{ .Values.auth.ldap.dn.user.searchBase }}
-  auth.ldap.user.attribute: {{ .Values.auth.ldap.user.attribute }}
+  auth.ldap.dn.user.attribute: {{ .Values.auth.ldap.dn.user.attribute }}
   {{- end }}
 
   {{ if .Values.auth.whitelist.users -}}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -72,7 +72,7 @@ data:
   auth.ldap.dn.search.filter: {{ .Values.auth.ldap.dn.search.filter }}
   auth.ldap.dn.search.user: {{ .Values.auth.ldap.dn.search.user }}
   auth.ldap.dn.search.password: {{ .Values.auth.ldap.dn.search.password }}
-  auth.ldap.dn.user-dn-attribute: {{ .Values.auth.ldap.dn.userDnAttribute }}
+  auth.ldap.dn.user.dn-attribute: {{ .Values.auth.ldap.dn.user.dnAttribute }}
   auth.ldap.dn.user.escape: {{ .Values.auth.ldap.dn.user.escape }}
   auth.ldap.dn.user.valid-regex: {{ .Values.auth.ldap.dn.user.validRegex }}
   auth.ldap.dn.user.search-base: {{ .Values.auth.ldap.dn.user.searchBase }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -115,6 +115,11 @@ auth:
     users:
   dummy:
     password:
+  ldap:
+    dn:
+      search: {}
+      user: {}
+    user: {}
   state:
     enabled: false
     cryptoKey:


### PR DESCRIPTION
Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/264

Based on https://github.com/jupyterhub/ldapauthenticator/blob/1bb93f3ad258fdcc464c5e5c88f36005ae579ce0/README.md
I've tried to follow the general pattern in `jupyterhub_config.py` when naming LDAP parameters but not everything is clear to me.

LDAPAuthenticator seems to have many more parameters than the other auth providers, so I added a new function `set_config_if_not_none` in z2jh.py to make it easier to keep the built-in defaults from LDAPAuthenticator when a value isn't overridden.

I've only tested this with my own setup:
```yaml
auth:
  type: ldap
  ldap:
    server:
      address: ldap.EXAMPLE.org
      port: 389
      ssl: False
    dn:
      templates:
        - 'cn={username},ou=edir,ou=people,ou=EXAMPLE-UNIT,o=EXAMPLE'
    allowedGroups:
      - 'cn=example-group,ou=groups,ou=EXAMPLE-UNIT,o=EXAMPLE'
```

Warning: I have **not tested** the other parameters, in particular the active directory setup from https://github.com/jupyterhub/ldapauthenticator/blob/1bb93f3ad258fdcc464c5e5c88f36005ae579ce0/README.md#active-directory-integration is untested by me.