### PR TITLE
clarify log message

### DIFF
--- a/images/pod-culler/culler
+++ b/images/pod-culler/culler
@@ -161,7 +161,7 @@ class PodCuller:
                     name, self.namespace, client.V1DeleteOptions())
                 deleted_pods.append(name)
 
-        log.info(f'Deleted {len(deleted_pods)}/{len(self.pods)} pods')
+        log.info(f'Deleted {len(deleted_pods)} pods. Pod count={len(self.pods)}')
 
 
 REQUIRED = object()


### PR DESCRIPTION
The existing message log message can be misinterpreted to read that zero of 244 "scheduled for deletion" pods were deleted and implies that 244 more pods need deletion.

```
[I 2018-04-17 15:01:34 culler:143] Culling pods older than 06:00:00
[I 2018-04-17 15:01:34 culler:161] Deleted 0/244 pods
```

I understand that if one has context of the number of total pods then it may not be confusing. But if you don't know if there are 5000 pods or 244, it is easy to misinterpret. Recommend change:
```
[I 2018-04-17 15:01:34 culler:143] Culling pods older than 06:00:00
[I 2018-04-17 15:01:34 culler:161] Deleted 0 pods. Pod count=244
```