### PR TITLE
Revert "bump kubespawner required revision"

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -10,4 +10,4 @@ mwoauth==0.3.2
 globus_sdk[jwt]==1.2.1
 oauthenticator==0.7.2
 cryptography==2.0.3
-https://github.com/jupyterhub/kubespawner/archive/085cb30.tar.gz
+https://github.com/jupyterhub/kubespawner/archive/86386e8.tar.gz


### PR DESCRIPTION
This reverts commit fad0f64936727ebafbdc8d55c68221627815de53.

Temporary fix because I think the event-monitoring is producing a memory leak on the Binder deployment.

Once confirmed on Binder, will start investigating in kubespawner.