### PR TITLE
Add AWS workshop material link to Step Zero

### DIFF
--- a/doc/source/amazon/step-zero-aws.rst
+++ b/doc/source/amazon/step-zero-aws.rst
@@ -3,15 +3,22 @@
 Step Zero: Kubernetes on Amazon Web Services (AWS)
 --------------------------------------------------
 
-AWS does not have native support for Kubernetes, however there are
-many organizations that have put together their own solutions and
-guides for setting up Kubernetes on AWS.
+AWS support for Kubernetes is evolving quickly. Therefore, you have several
+options for setting up a Kubernetes cluster using AWS.
 
-We like the `Heptio guide`_, and recommend using this for setting up your cluster for clusters
-that span short periods of time (a week long workshop, for example). However, if
-you are setting up a cluster that would need to run for much longer, we recommend you use
-[kops](https://kubernetes.io/docs/getting-started-guides/kops/). It is a bit more complex,
-but provides features (such as log collection & cluster upgrades) that are necessary to
+One option would be to follow the `Amazon AWS workshop for Kubernetes <https://github.com/aws-samples/aws-workshop-for-kubernetes>. 
+The workshop takes several hours to complete and helps guide you in setting up
+Kubernetes cluster on AWS. 
+
+Another option that we like is the `Heptio guide`_, and recommend using this 
+for setting up your cluster for clusters that span short periods of time
+(a week long workshop, for example). 
+
+If you are setting up a cluster that would need to run for much longer,
+we recommend you use the AWS workshop as a starting point or use `kops` following
+its guide for `getting started with kops <https://kubernetes.io/docs/getting-started-guides/kops/`_. 
+The `kops` approach is a bit more complex than the Heptio guide but provides
+features (such as log collection & cluster upgrades) that are necessary to
 run a longer term cluster.
 
 .. note::


### PR DESCRIPTION
It's been a while since we updated the AWS section, and AWS has posted workshop materials on GitHub.