### PR TITLE
Add wide output to public-proxy query

### DIFF
--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -153,7 +153,7 @@ Install JupyterHub
       If the IP for ``proxy-public`` is too long to fit into the window, you
       can find the longer version by calling::
 
-        kubectl --namespace=<YOUR-NAMESPACE> describe svc proxy-public
+        kubectl --namespace=<YOUR-NAMESPACE> describe svc proxy-public --output=wide
 
 5. To use JupyterHub, enter the external IP for the `proxy-public` service in
    to a browser. JupyterHub is running with a default *dummy* authenticator so


### PR DESCRIPTION
This helps on AWS when the ELB's dns entry is really long

Ex:
```
kubectl --namespace=splat-test get svc proxy-public -o wide
NAME           TYPE           CLUSTER-IP      EXTERNAL-IP                                                               PORT(S)                      AGE       SELECTOR
proxy-public   LoadBalancer   100.70.50.207   aef52d88a4a1911e899ba1253ff0cfc6-1410174889.us-east-1.elb.amazonaws.com   80:30917/TCP,443:30502/TCP   1h        component=proxy,name=proxy,release=splat-test
```