### PR TITLE
Allow manual set of service account

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -326,3 +326,18 @@ properties:
               The tag of the image to use.
 
               This is the value after the `:` in your full image name.
+
+  rbac:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        description: enable RBAC configuration
+      customServiceAccount:
+        type: string
+        description: |
+            Allow to force the service account to use for the puller, culler and https proxy.
+            If let to the default value (empty string), the service account will be automatically
+            created.
+            Please note it does not impact the singleuser pod
+            (see `singleuser.serviceAccountName`).

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -57,7 +57,11 @@ spec:
           claimName: hub-db-dir
       {{- end }}
       {{- if .Values.rbac.enabled }}
+      {{- if eq .Values.rbac.customServiceAccount "" }}
       serviceAccountName: hub
+      {{ else }}
+      serviceAccountName: {{ .Values.rbac.customServiceAccount }}
+      {{- end }}
       {{- end }}
       securityContext:
         runAsUser: {{ .Values.hub.uid }}

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.rbac.enabled -}}
+{{ if eq .Values.rbac.customServiceAccount "" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -28,4 +29,5 @@ roleRef:
   kind: Role
   name: hub
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -1,5 +1,5 @@
 # This job has a part to play in a helm upgrade process. It simply waits for the
-# hook-image-puller daemonset which is started slightly before this job to get 
+# hook-image-puller daemonset which is started slightly before this job to get
 # its' pods running. If all those pods are running they must have pulled all the
 # required images on all nodes as they are used as init containers with a dummy
 # command.
@@ -19,7 +19,11 @@ spec:
     spec:
       restartPolicy: Never
       {{ if .Values.rbac.enabled }}
+      {{- if eq .Values.rbac.customServiceAccount "" }}
       serviceAccountName: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+      {{ else }}
+      serviceAccountName: {{ .Values.rbac.customServiceAccount }}
+      {{- end }}
       {{- end }}
       containers:
         - image: {{ .Values.prePuller.hook.image.name }}:{{ .Values.prePuller.hook.image.tag }}

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -1,6 +1,7 @@
 # Setup of permissions to be used by the hook-image-awaiter job
 {{ if .Values.prePuller.hook.enabled }}
 {{ if .Values.rbac.enabled }}
+{{ if eq .Values.rbac.customServiceAccount "" }}
 # This service account...
 apiVersion: v1
 kind: ServiceAccount
@@ -48,5 +49,6 @@ roleRef:
   kind: ClusterRole
   name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
   apiGroup: rbac.authorization.k8s.io
+{{ end }}
 {{ end }}
 {{ end }}

--- a/jupyterhub/templates/pod-culler/deployment.yaml
+++ b/jupyterhub/templates/pod-culler/deployment.yaml
@@ -18,7 +18,11 @@ spec:
         heritage: {{ .Release.Service }}
     spec:
       {{ if .Values.rbac.enabled }}
+      {{- if eq .Values.rbac.customServiceAccount "" }}
       serviceAccountName: pod-culler
+      {{ else }}
+      serviceAccountName: {{ .Values.rbac.customServiceAccount }}
+      {{- end }}
       {{- end }}
       containers:
         - name: culler

--- a/jupyterhub/templates/pod-culler/rbac.yaml
+++ b/jupyterhub/templates/pod-culler/rbac.yaml
@@ -1,5 +1,6 @@
 {{ if and .Values.cull.enabled .Values.cull.maxAge }}
 {{ if .Values.rbac.enabled -}}
+{{ if eq .Values.rbac.customServiceAccount "" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -32,5 +33,6 @@ roleRef:
   kind: Role
   name: pod-culler
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -51,7 +51,7 @@ hub:
 
 rbac:
   enabled: true
-
+  customServiceAccount: ''
 
 proxy:
   secretToken: ''


### PR DESCRIPTION
This allows to disable the automatic creation of the service account (that requires clusterbinding priviledge) and define the service account for jupyter (hub and proxy) to use

Signed-off-by: Gaetan Semet <gaetan@xeberon.net>