### PR TITLE
Tighten up hook-image-puller's image-awaiter jobs requested RBAC permissions

### DIFF
--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -14,7 +14,7 @@ metadata:
     "helm.sh/hook-weight": "0"
 ---
 # needs this role...
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
@@ -30,7 +30,7 @@ rules:
   verbs: ["get"]
 ---
 # and this part declares that service account to have that role.
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
@@ -45,7 +45,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
   name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
   apiGroup: rbac.authorization.k8s.io
 {{ end }}


### PR DESCRIPTION
The `image-awaiter` job used in conjunction with the `hook-image-puller` does not need a `ClusterRole` and a `ClusterRoleBinding` as it will no longer inspect the nodes in the cluster, but instead simply inspect a `DaemonSet` within the current namespace. This PR simply replaces `ClusterRole` with `Role`, and `ClusterRoleBinding` with `RoleBinding`.

* This PR is based on the insight of @manics and fixes #671.
* I think it will reduce but not fully fix the challenges for @gsemet (#178) who has a JupyterHub on a cluster but is limited to namespace-wide administrative permissions (Role) for the cluster rather than cluster-wide permissions (ClusterRole).