### PR TITLE
install jupyterhub 0.9 beta

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -9,7 +9,7 @@ charts:
       hub:
         valuesPath: hub.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.8.1
+          JUPYTERHUB_VERSION: 0.9.0b1
       network-tools:
         valuesPath: singleuser.networkTools.image
       image-awaiter:
@@ -17,6 +17,6 @@ charts:
       singleuser-sample:
         valuesPath: singleuser.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.8.1
+          JUPYTERHUB_VERSION: 0.9.0b1
       pod-culler:
         valuesPath: cull.podCuller.image

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -26,7 +26,7 @@ RUN adduser --disabled-password \
     --force-badname \
     ${NB_USER}
 
-ARG JUPYTERHUB_VERSION=0.8.*
+ARG JUPYTERHUB_VERSION=0.9.*
 
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir \


### PR DESCRIPTION
We've discussed making an 0.7 release of this chart prior to jupyterhub 0.9 and then an 0.8 release with jupyterhub 0.9 shortly after. We can still do that, but the jupyterhub 0.9 beta is out now, so we might want to fold them together, since we aren't quite ready to make the helm chart release yet.