### PR TITLE
base hub image on 18.04 lts

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
just bumping the base image now that an LTS is available.