### PR TITLE
jupyterhub 0.9.0b2

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -9,7 +9,7 @@ charts:
       hub:
         valuesPath: hub.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.9.0b1
+          JUPYTERHUB_VERSION: 0.9.0b2
       network-tools:
         valuesPath: singleuser.networkTools.image
       image-awaiter:
@@ -17,6 +17,6 @@ charts:
       singleuser-sample:
         valuesPath: singleuser.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.9.0b1
+          JUPYTERHUB_VERSION: 0.9.0b2
       pod-culler:
         valuesPath: cull.podCuller.image


### PR DESCRIPTION
fixes base_url regressions in 0.9b1, other small fixes