### PR TITLE
Repo2docker needs jovyan username

### DIFF
--- a/doc/source/user-environment.rst
+++ b/doc/source/user-environment.rst
@@ -142,7 +142,7 @@ how to configure JupyterHub to build off of this image:
 
    .. code-block:: bash
 
-      jupyter-repo2docker <YOUR-GITHUB-REPOSITORY> --image=gcr.io/<PROJECT-NAME>/<IMAGE-NAME>:<TAG> --no-run
+      jupyter-repo2docker <YOUR-GITHUB-REPOSITORY> --user-name=jovyan --image=gcr.io/<PROJECT-NAME>/<IMAGE-NAME>:<TAG> --no-run
 
    This tells ``repo2docker`` to fetch ``master`` of the GitHub repository,
    and uses heuristics to build a docker image of it.

--- a/doc/source/user-environment.rst
+++ b/doc/source/user-environment.rst
@@ -134,9 +134,13 @@ how to configure JupyterHub to build off of this image:
 
    .. code-block:: bash
 
+      jupyterhub==0.8.*
       numpy==1.12.1
       scipy==0.19.0
       matplotlib==2.0
+
+   As noted above, the requirements must include ``jupyterhub``, pinned to a
+   version compatible with the version of JupyterHub used by Helm chart.
 
 4. **Use repo2docker to build a Docker image.**
 


### PR DESCRIPTION
During my first attempt at using a custom Docker image in a k8s JupyterHub deployment, I think I found a documentation bug.

An image built using `repo2docker` without the `--user-name=jovyan` argument embeds my local `$USER` in the Docker image, which causes the single-user server pods to fail (details below).

In a separate commit, I also thought it might not hurt to reiterate the important detail that `jupyterhub` must be specified as a dependency in the image, as I missed that on my first, admittedly hasty reading. If you decide reiteration is unnecessary, feel free to blow that commit away and just keep the one with `--user-name`.

<details>

```
Traceback (most recent call last):
  File "/srv/venv/lib/python3.6/site-packages/traitlets/traitlets.py", line 528, in get
    value = obj._trait_values[self.name]
KeyError: 'runtime_dir'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/srv/venv/bin/jupyterhub-singleuser", line 6, in <module>
    main()
  File "/srv/venv/lib/python3.6/site-packages/jupyterhub/singleuser.py", line 455, in main
    return SingleUserNotebookApp.launch_instance(argv)
  File "/srv/venv/lib/python3.6/site-packages/jupyter_core/application.py", line 266, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/srv/venv/lib/python3.6/site-packages/traitlets/config/application.py", line 657, in launch_instance
    app.initialize(argv)
  File "<decorator-gen-7>", line 2, in initialize
  File "/srv/venv/lib/python3.6/site-packages/traitlets/config/application.py", line 87, in catch_config_error
    return method(app, *args, **kwargs)
  File "/srv/venv/lib/python3.6/site-packages/notebook/notebookapp.py", line 1366, in initialize
    self.init_configurables()
  File "/srv/venv/lib/python3.6/site-packages/notebook/notebookapp.py", line 1100, in init_configurables
    connection_dir=self.runtime_dir,
  File "/srv/venv/lib/python3.6/site-packages/traitlets/traitlets.py", line 556, in __get__
    return self.get(obj, cls)
  File "/srv/venv/lib/python3.6/site-packages/traitlets/traitlets.py", line 535, in get
    value = self._validate(obj, dynamic_default())
  File "/srv/venv/lib/python3.6/site-packages/jupyter_core/application.py", line 99, in _runtime_dir_default
    ensure_dir_exists(rd, mode=0o700)
  File "/srv/venv/lib/python3.6/site-packages/jupyter_core/utils/__init__.py", line 13, in ensure_dir_exists
    os.makedirs(path, mode=mode)
  File "/usr/lib/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/home/dallan/.local'
```

</details> 