### PR TITLE
Add a newline as temporary fix to trigger chartpress rebuild

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -26,6 +26,7 @@ RUN adduser --disabled-password \
     --force-badname \
     ${NB_USER}
 
+
 ARG JUPYTERHUB_VERSION=0.9.*
 
 ADD requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
chartpress currently does not consider the chartpress.yml itself when
deciding if an image needs rebuilding. As a result the hub image has
not been rebuilt recently. Touching the Dockerfile is a temporary
fix till chartpress has been updated.

Will self-merge this after discussing with Min on gitter.