### PR TITLE
JupyterHub 0.9.* for the singleuser image also

### DIFF
--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,8 +1,11 @@
-FROM jupyter/base-notebook:27ba57364579
+FROM jupyter/base-notebook:c7d997f2db86
+# Built from... https://hub.docker.com/r/jupyter/base-notebook/
+#               https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile
+# Built from... Ubuntu 16.04
 
 # conda/pip/apt install additional packages here, if desired.
 
 # pin jupyterhub to match the Hub version
 # set via --build-arg in Makefile
-ARG JUPYTERHUB_VERSION=0.8
+ARG JUPYTERHUB_VERSION=0.9.*
 RUN pip install --no-cache jupyterhub==$JUPYTERHUB_VERSION


### PR DESCRIPTION
Complementing #694 by bumping the singleuser image to jupyterhub 0.9.* as well.