### PR TITLE
templates' name and label fields fixed

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -11,7 +11,6 @@ spec:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      name: hub
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -13,7 +13,8 @@ spec:
     metadata:
       name: hub
       labels:
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-api: "true"
         hub.jupyter.org/network-access-proxy-http: "true"
         hub.jupyter.org/network-access-singleuser: "true"

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -34,7 +34,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -33,7 +33,6 @@ spec:
       maxUnavailable: 100%
   template:
     metadata:
-      name: {{ print .componentPrefix "image-puller" }}
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -7,7 +7,7 @@ Returns an image-puller daemonset. Two daemonsets will be created like this.
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  {{- $label := print "-" .Release.Name "-" .Release.Revision "-" .Release.Time.Seconds }}
+  {{- $label := print "-" .Release.Time.Seconds }}
   name: {{ print .componentPrefix "image-puller" }}{{- if .hook }}{{ $label }}{{- end }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
@@ -33,6 +33,7 @@ spec:
       maxUnavailable: 100%
   template:
     metadata:
+      name: {{ print .componentPrefix "image-puller" }}
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -9,7 +9,7 @@ command.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -20,17 +20,18 @@ metadata:
 spec:
   template:
     metadata:
+      name: hook-image-awaiter
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       {{- if .Values.rbac.enabled }}
-      serviceAccountName: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+      serviceAccountName: hook-image-awaiter-{{ .Release.Time.Seconds }}
       {{- end }}
       containers:
         - image: {{ .Values.prePuller.hook.image.name }}:{{ .Values.prePuller.hook.image.tag }}
-          name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+          name: hook-image-awaiter
           imagePullPolicy: IfNotPresent
           command:
             - /image-awaiter
@@ -38,5 +39,5 @@ spec:
             - -auth-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
             - -api-server-address=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
             - -namespace={{ .Release.Namespace }}
-            - -daemonset=hook-image-puller-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+            - -daemonset=hook-image-puller-{{ .Release.Time.Seconds }}
 {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -20,7 +20,6 @@ metadata:
 spec:
   template:
     metadata:
-      name: hook-image-awaiter
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -19,6 +19,10 @@ metadata:
     "helm.sh/hook-weight": "10"
 spec:
   template:
+    metadata:
+      labels:
+        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       {{- if .Values.rbac.enabled }}

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -9,7 +9,7 @@ This service account...
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -24,7 +24,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -43,7 +43,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -53,11 +53,11 @@ metadata:
     "helm.sh/hook-weight": "0"
 subjects:
   - kind: ServiceAccount
-    name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+    name: hook-image-awaiter-{{ .Release.Time.Seconds }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: hook-image-awaiter-{{ .Release.Name }}-{{ .Release.Revision }}-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}

--- a/jupyterhub/templates/pod-culler/deployment.yaml
+++ b/jupyterhub/templates/pod-culler/deployment.yaml
@@ -12,6 +12,7 @@ spec:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}
   template:
     metadata:
+      name: pod-culler
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/pod-culler/deployment.yaml
+++ b/jupyterhub/templates/pod-culler/deployment.yaml
@@ -13,7 +13,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: pod-culler

--- a/jupyterhub/templates/pod-culler/deployment.yaml
+++ b/jupyterhub/templates/pod-culler/deployment.yaml
@@ -12,7 +12,6 @@ spec:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      name: pod-culler
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       {{- include "jupyterhub.matchLabels" $_ | nindent 6 }}
   template:
     metadata:
+      name: autohttps
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -26,10 +26,10 @@ spec:
       {{- include "jupyterhub.matchLabels" $_ | nindent 6 }}
   template:
     metadata:
-      name: autohttps
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
-        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        {{- $_ := merge (dict "appLabel" "kube-lego") . }}
+        {{- include "jupyterhub.matchLabels" $_ | nindent 8 }}
         hub.jupyter.org/network-access-proxy-http: "true"
     spec:
       {{- if .Values.rbac.enabled }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -27,7 +27,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.labels" $_ | nindent 8 }}
+        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-http: "true"
     spec:
       {{- if .Values.rbac.enabled }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -14,7 +14,8 @@ spec:
     metadata:
       name: proxy
       labels:
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
         hub.jupyter.org/network-access-singleuser: "true"
         {{- if .Values.proxy.labels }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -12,7 +12,6 @@ spec:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      name: proxy
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
 spec:
   selector:
-    {{- include "jupyterhub.labels" . | nindent 4 }}
+    {{- include "jupyterhub.matchLabels" . | nindent 4 }}
   ports:
     - protocol: TCP
       port: 8001


### PR DESCRIPTION
@minrk realized that by setting the chart label containing the chart version systematically everywhere as was done in #625, some pods, like the hub and the proxy, were restarted without any good reason during helm chart upgrades.

### Selective removal of chart / heritage labels
This PR does not fully remove the chart label as #711 propose, but instead selectively removes the chart label and the heritage label for pods created by controllers using a PodTemplate. Such controlled pods will be restarted if the controller concludes that a new template is available, even if it is simply a change to the labeling.

### Removal of `spec.template.metadata.name` fields
In #625 I also systematically introduced a name field to controllers spec.template.metadata.name, but that field is overridden anyhow so I simply removed it again. For example the hub Deployment's pods will be named `hub-asdfasdf-1234` where `hub` is the name of the Deployment, `hub-asdfasdf` the name of the Deployment's ReplicaSet. It did not matter what I set the `spec.template.metadata.name` field of the Deployment to.