### PR TITLE
Funcionality : being able to give an already existing secret as SSL

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $manualHTTPS := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual")) -}}
+{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manualsecret")) -}}
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -44,6 +45,12 @@ spec:
                     - key: release
                       operator: In
                       values: [{{ .Release.Name | quote }}]
+      {{- if $manualHTTPSwithsecret }}
+      volumes:
+        - name: tls-secret
+          secret:
+            secretName: {{ .Values.proxy.https.secret }}
+      {{- end }}
       {{- if $manualHTTPS }}
       volumes:
         - name: tls-secret
@@ -65,13 +72,18 @@ spec:
             - --redirect-port=8000
             - --ssl-key=/etc/chp/tls/tls.key
             - --ssl-cert=/etc/chp/tls/tls.crt
+            {{- else if $manualHTTPSwithsecret }}
+            - --port=8443
+            - --redirect-port=8000
+            - --ssl-key=/etc/chp/tls/{{ .Values.proxy.https.keyname }}
+            - --ssl-cert=/etc/chp/tls/{{ .Values.proxy.https.crtname }}
             {{- else }}
             - --port=8000
             {{- end }}
             {{- if .Values.debug.enabled }}
             - --log-level=debug
             {{- end }}
-          {{- if $manualHTTPS }}
+          {{- if or $manualHTTPS $manualHTTPSwithsecret }}
           volumeMounts:
             - name: tls-secret
               mountPath: /etc/chp/tls
@@ -87,7 +99,7 @@ spec:
                   key: proxy.token
           imagePullPolicy: {{ .Values.proxy.chp.image.pullPolicy }}
           ports:
-            {{- if $manualHTTPS }}
+            {{- if or $manualHTTPS $manualHTTPSwithsecret }}
             - containerPort: 8443
               name: proxy-https
             {{- end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $manualHTTPS := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual")) -}}
-{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manualsecret")) -}}
+{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "secret")) -}}
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -49,7 +49,7 @@ spec:
       volumes:
         - name: tls-secret
           secret:
-            secretName: {{ .Values.proxy.https.secret }}
+            secretName: {{ .Values.proxy.https.secret.name }}
       {{- end }}
       {{- if $manualHTTPS }}
       volumes:
@@ -75,8 +75,8 @@ spec:
             {{- else if $manualHTTPSwithsecret }}
             - --port=8443
             - --redirect-port=8000
-            - --ssl-key=/etc/chp/tls/{{ .Values.proxy.https.keyname }}
-            - --ssl-cert=/etc/chp/tls/{{ .Values.proxy.https.crtname }}
+            - --ssl-key=/etc/chp/tls/{{ .Values.proxy.https.secret.key }}
+            - --ssl-cert=/etc/chp/tls/{{ .Values.proxy.https.secret.crt }}
             {{- else }}
             - --port=8000
             {{- end }}

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -1,7 +1,7 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- $manualHTTPS := (and $HTTPS (eq .Values.proxy.https.type "manual")) }}
-{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manualsecret")) -}}
+{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "secret")) -}}
 {{- if and .Values.proxy.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -1,6 +1,7 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- $manualHTTPS := (and $HTTPS (eq .Values.proxy.https.type "manual")) }}
+{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manualsecret")) -}}
 {{- if and .Values.proxy.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -25,7 +26,7 @@ spec:
       - protocol: TCP
         port: 8000
       {{- end }}
-      {{- if $manualHTTPS }}
+      {{- if or $manualHTTPS $manualHTTPSwithsecret}}
       - protocol: TCP
         port: 8443
       {{- end }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -1,6 +1,7 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- $manualHTTPS := (and $HTTPS (eq .Values.proxy.https.type "manual")) -}}
+{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manualsecret")) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -56,7 +57,7 @@ spec:
     - name: https
       port: 443
       protocol: TCP
-      {{- if $manualHTTPS }}
+      {{- if or $manualHTTPS $manualHTTPSwithsecret }}
       targetPort: 8443
       {{- else }}
       targetPort: 443

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -1,7 +1,7 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- $manualHTTPS := (and $HTTPS (eq .Values.proxy.https.type "manual")) -}}
-{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manualsecret")) -}}
+{{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "secret")) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -93,11 +93,15 @@ proxy:
   https:
     enabled: true
     type: letsencrypt
+    #type: manualsecret
     letsencrypt:
       contactEmail: ''
     manual:
       key:
       cert:
+    secret: ""
+    keyname: ""
+    crtname: ""
     hosts: []
   networkPolicy:
     enabled: false

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -93,15 +93,16 @@ proxy:
   https:
     enabled: true
     type: letsencrypt
-    #type: manualsecret
+    #type: letsencrypt, manual, secret
     letsencrypt:
       contactEmail: ''
     manual:
       key:
       cert:
-    secret: ""
-    keyname: ""
-    crtname: ""
+    secret:
+      name: ""
+      key: ""
+      crt: ""
     hosts: []
   networkPolicy:
     enabled: false


### PR DESCRIPTION
Hello,
I manage my certificates using an external tool (saltstack) that can put secrets into kubernetes, and I wanted for jupyterhub to be able to use an already-existing secret.
I've implemented this funcionality there, and tested it, it takes a secret name and the name of the certs in the secret
It's like one of my first PR ever, so pleas be kind, I'm open to any suggestion, like where to put the documentation, what to document
Thanks for all the work !