### PR TITLE
add prometheus annotations by default for hub pod

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -24,7 +24,9 @@ hub:
       storageClassName:
     url:
   labels: {}
-  annotations: {}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /hub/metrics
   extraConfig: {}
   extraConfigMap: {}
   extraEnv: {}


### PR DESCRIPTION
ensures prometheus annotations are registered for the hub pod by default