### PR TITLE
bump kubespawner version (actually commit hash)

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -10,5 +10,5 @@ mwoauth==0.3.2
 globus_sdk[jwt]==1.2.1
 oauthenticator==0.7.2
 cryptography==2.0.3
-https://github.com/jupyterhub/kubespawner/archive/cff7f01.tar.gz
+https://github.com/jupyterhub/kubespawner/archive/4d0221e.tar.gz
 https://github.com/jupyterhub/ldapauthenticator/archive/1bb93f3.tar.gz


### PR DESCRIPTION
This just bumps the version of kubespawner in the hub requirements file. Perhaps a proper release from kubespawner would be a better idea but in the short term, I'm working on propagating the changes in https://github.com/jupyterhub/kubespawner/pull/193 through to JupyterHub and Binder. 