### PR TITLE
adding copy buttons to code blocks

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -7,3 +7,4 @@ dependencies:
 - pip:
     - recommonmark==0.4.0
     - pyyaml
+    - sphinx-copybutton

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,7 +33,8 @@ from recommonmark.transform import AutoStructify
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax']
+extensions = ['sphinx.ext.mathjax',
+              'sphinx_copybutton']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This adds a couple small scripts that add a "copy" button to code blocks, so people don't have to manually copy/paste them. Here's an example!

https://predictablynoisy.com/zero-to-jupyterhub-k8s/google/step-zero-gcp.html