### PR TITLE
CI bump: k8s 1.9.0 / helm 2.9.1 / minikube 0.28.0

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -35,7 +35,7 @@ done
 kubectl get nodes
 
 echo "installing helm"
-curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz \
+curl -ssL https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
   | tar -xz -C bin --strip-components 1 linux-amd64/helm
 chmod +x bin/helm
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -24,7 +24,7 @@ chmod +x minikube
 mv minikube bin/
 
 echo "starting minikube with RBAC"
-sudo CHANGE_MINIKUBE_NONE_USER=true $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
+sudo CHANGE_MINIKUBE_NONE_USER=true $PWD/bin/minikube start --vm-driver=none --kubernetes-version=v${KUBE_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC --bootstrapper=localkube
 minikube update-context
 
 echo "waiting for kubernetes"

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -1,4 +1,4 @@
 export MINIKUBE_VERSION=0.28.0
-export KUBE_VERSION=1.11.0
+export KUBE_VERSION=1.9.0
 export HELM_VERSION=2.9.1
 export PATH="$PWD/bin:$PATH"

--- a/ci/minikube.env
+++ b/ci/minikube.env
@@ -1,3 +1,4 @@
-export MINIKUBE_VERSION=0.24.1
-export KUBE_VERSION=1.8.0
+export MINIKUBE_VERSION=0.28.0
+export KUBE_VERSION=1.11.0
+export HELM_VERSION=2.9.1
 export PATH="$PWD/bin:$PATH"


### PR DESCRIPTION
Bumping CI to use latest k8s/helm/minikube.

Currently #758 CI is failing to start because Helm 2.9.1 is required.

- [Minikube changelog](https://github.com/kubernetes/minikube/blob/v0.28.0/CHANGELOG.md)