### PR TITLE
expose KubeSpawner.events_enabled as singleuser.events

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -48,6 +48,8 @@ c.KubeSpawner.image_spec = os.environ['SINGLEUSER_IMAGE']
 
 c.KubeSpawner.image_pull_policy = get_config('singleuser.image-pull-policy')
 
+c.KubeSpawner.events_enabled = get_config('singleuser.events', False)
+
 c.KubeSpawner.extra_labels = get_config('singleuser.extra-labels', {})
 
 c.KubeSpawner.uid = get_config('singleuser.uid')

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -10,5 +10,5 @@ mwoauth==0.3.2
 globus_sdk[jwt]==1.2.1
 oauthenticator==0.7.2
 cryptography==2.0.3
-https://github.com/jupyterhub/kubespawner/archive/fd2ff67.tar.gz
+https://github.com/jupyterhub/kubespawner/archive/7ae9900.tar.gz
 https://github.com/jupyterhub/ldapauthenticator/archive/1bb93f3.tar.gz

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -139,6 +139,7 @@ data:
   {{- if .Values.singleuser.defaultUrl }}
   singleuser.default-url: {{ .Values.singleuser.defaultUrl | quote }}
   {{- end }}
+  singleuser.events: {{ .Values.singleuser.events | quote }}
   singleuser.uid: {{ .Values.singleuser.uid | quote }}
   singleuser.fs-gid: {{ .Values.singleuser.fsGid | quote }}
   {{- if .Values.singleuser.serviceAccountName }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -143,6 +143,7 @@ singleuser:
               cidr: 0.0.0.0/0
               except:
                 - 169.254.169.254/32
+  events: false
   extraLabels: {}
   extraEnv: {}
   lifecycleHooks:


### PR DESCRIPTION
Deploys and exposes https://github.com/jupyterhub/kubespawner/pull/213

events are disabled by default due to recent issues, but should be enabled by default when they are fixed.