### PR TITLE
Hub default deployment strategy should be Recreate

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}
+  strategy:
+    {{- .Values.hub.deploymentStrategy | toYaml | trimSuffix "\n" | nindent 4 }}
   template:
     metadata:
       labels:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -11,6 +11,11 @@ hub:
   nodeSelector: {}
   concurrentSpawnLimit: 64
   activeServerLimit:
+  deploymentStrategy:
+    # sqlite-pvc backed hub requires Recreate strategy to work
+    type: Recreate
+    # This is required for upgrading to work
+    rollingUpdate: null
   db:
     type: sqlite-pvc
     upgrade:


### PR DESCRIPTION
Since the default storage backend is sqlite on pvc, we should be using the Recreate strategy as we bumped the deployment to apps/v1beta2. Otherwise upgrading will have new hub pod stuck in ContainerCreating state.

This is a regression caused by a84ad294. Detailed analysis can be found in #754.

Closes #754
Closes #757