### PR TITLE
Make sure image puller works with long repo names

### DIFF
--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -57,7 +57,7 @@ spec:
             - echo "Pulling complete"
         {{- end }}
         {{- range $k, $v := .Values.prePuller.extraImages }}
-        - name: image-pull-{{ $v.name }}
+        - name: image-pull-{{ $k }}
           image: {{ $v.name }}:{{ $v.tag }}
           imagePullPolicy: IfNotPresent
           command:


### PR DESCRIPTION
Currently this fails since container should be alphanum.

```
prePuller:
  extraImages:
    cpu:
      name: custom.registry-server/repo/image
      tag: latest
```