### PR TITLE
Change travis setup to only deploy once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ deploy:
   skip_cleanup: true
   script: ./ci/deploy.sh
   on:
+    env: KUBE_VERSION=1.10.0
     branch:
     - master
     - v0.7-dev


### PR DESCRIPTION
Follow up #762 

Since adding a build matrix testing several kubernetes versions we are
deploying twice, once for each kube version. This changes our deploy
setup so it only deploys once.