### PR TITLE
Fix incorrect spelling of `description` in chart schema

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -132,7 +132,7 @@ properties:
                  Note that if you use this, you *must* also set `hub.cookieSecret`.
           pvc:
             type: object
-            descripton: |
+            description: |
               Customize the Persistent Volume Claim used when `hub.db.type` is `sqlite-pvc`.
             properties:
               annotations:


### PR DESCRIPTION
Fix wrong spelling of the word `description`.