### PR TITLE
Support offloading SSL to the proxy service

### DIFF
--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -1,5 +1,6 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
+{{- $offloadHTTPS := (and $HTTPS (eq .Values.proxy.https.type "offload")) }}
 {{- $manualHTTPS := (and $HTTPS (eq .Values.proxy.https.type "manual")) -}}
 apiVersion: v1
 kind: Service
@@ -58,6 +59,8 @@ spec:
       protocol: TCP
       {{- if $manualHTTPS }}
       targetPort: 8443
+      {{- else if $offloadHTTPS }}
+      targetPort: 8000
       {{- else }}
       targetPort: 443
       {{- end }}


### PR DESCRIPTION
Rather than always having different target ports for the HTTP and HTTPS frontends, setting proxy.https.type to offload will tell the service to route ports 443 and 80 both to port 80 on the backend.

For this to work, annotations need to be added to proxy.service.annotations to attach certificates to the load balancer.