### PR TITLE
Clean-up tips section

### DIFF
--- a/doc/source/tips.rst
+++ b/doc/source/tips.rst
@@ -11,14 +11,14 @@ to be added to this page, please feel free to make a PR!
 
 Kubernetes has a helper script that allows you to auto-complete commands
 and references to objects when using ``kubectl``. This lets you
-``<TAB>``-complete and saves a lot of time.
+:kbd:`TAB`-complete and saves a lot of time.
 
 `Here are the instructions to install kubectl auto-completion <https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion>`_.
 
 ``helm`` autocompletion
 -----------------------
 
-Helm also has an auto-completion script that lets you ``<TAB>``-complete
+Helm also has an auto-completion script that lets you :kbd:`TAB`-complete
 your commands when using Helm.
 
 `Here are the instructions to install helm auto-completion <https://docs.helm.sh/helm/#helm-completion>`_.
@@ -34,10 +34,14 @@ kubernetes deployment you are referring to when you type ``kubectl get XXX``.
 To see a list of contexts currently available to you, use the following
 command:
 
+.. code-block:: bash
+
     kubectl config get-contexts
 
 This will list all of your Kubernetes contexts. You can select a particular
 context by entering:
+
+.. code-block:: bash
 
     kubectl config use-context <CONTEXT-NAME>
 
@@ -46,29 +50,35 @@ Specifying a default namespace for a context
 --------------------------------------------
 
 If you grow tired of typing ``namespace=XXX`` each time you type a kubernetes
-command, here's a snippet that will allow you set a _default_ namespace for
+command, here's a snippet that will allow you set a default namespace for
 a given Kubernetes context:
 
-    kubectl config set-context $(kubectl config current-context) --namespace=<YOUR-NAMESPACE>
+.. code-block:: bash
 
-The above command will only apply to the _currently active context_, and will
+    kubectl config set-context $(kubectl config current-context) \
+	    --namespace=<YOUR-NAMESPACE>
+
+The above command will only apply to the currently active context, and will
 allow you to skip the ``--namespace=`` part of your commands for this context.
 
 
 Using labels and selectors with ``kubectl``
 -------------------------------------------
 
-Sometimes it's useful to select an entire _class_ of Kubernetes objects rather
+Sometimes it's useful to select an entire class of Kubernetes objects rather
 than referring to them by their name. You can attach an arbitrary set of
-_labels_ to a Kubernetes object, and can then refer to those labels when
+labels to a Kubernetes object, and can then refer to those labels when
 searching with ``kubectl``.
 
 To search based on a label value, use the ``-l`` or ``--selector=`` keyword
 arguments. For example, JupyterHub creates a specific subset of labels for all
 user pods. You can search for all user pods with the following label query:
 
-    kubectl --namespace=<YOUR-NAMESPACE> get pod -l "component=singleuser-server"
-    
+.. code-block:: bash
+
+    kubectl --namespace=<YOUR-NAMESPACE> get pod \
+	    -l "component=singleuser-server"
+
 For more information, see the `Kubernetes labels and selectors page <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>`_.
 
 Asking for a more verbose or structured output
@@ -79,9 +89,10 @@ is not enough for your needs, or isn't structured the way you'd like. We
 recommend looking into the different kubernetes output options, which can be
 modified like so:
 
+.. code-block:: bash
+
     kubectl --namespace=<NAMESPACE> get pod -o <json|yaml|wide|name...>
-    
+
 You can find more information on what kinds of output you can generate at
 `the kubectl information page <https://kubernetes.io/docs/reference/kubectl/overview/>`_.
 (click and search for the text "Output Options")
-


### PR DESCRIPTION
- Provide a bash code-block directive for code blocks.
- Remove single underscores surrounding text: these were presumably
  meant for emphasis (as in Markdown), but incorrect for ReST and not
  necessary.
- Apply :kbd: role for TAB mention
- Remove trailing whitespace

Fixes #798 