### PR TITLE
Bump jupyterhub-tmpauthenticator to 0.5

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -1,6 +1,6 @@
 statsd==3.2.1
 jupyterhub-dummyauthenticator==0.3.1
-jupyterhub-tmpauthenticator==0.4
+jupyterhub-tmpauthenticator==0.5
 jupyterhub-ltiauthenticator==0.2
 nullauthenticator==1.0
 pymysql==0.7.11


### PR DESCRIPTION
Updates tmpauthenticator to the latest release. Includes useful improvements such as automatically starting a server when a user visits `/`, previously only `/tmplogin` would create a server.