### PR TITLE
bump chartpress to 0.2.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 PyGithub>=1
 python-dateutil>=2
-chartpress==0.2.0
+chartpress==0.2.1


### PR DESCRIPTION
Fixes #831 thanks to https://github.com/jupyterhub/chartpress/pull/17
merged and released with chartpress 0.2.1.