### PR TITLE
more hub image bumps

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -9,7 +9,7 @@ charts:
       hub:
         valuesPath: hub.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.9.1
+          JUPYTERHUB_VERSION: 0.9.2
       network-tools:
         valuesPath: singleuser.networkTools.image
       image-awaiter:
@@ -17,6 +17,6 @@ charts:
       singleuser-sample:
         valuesPath: singleuser.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.9.1
+          JUPYTERHUB_VERSION: 0.9.2
       pod-culler:
         valuesPath: cull.podCuller.image

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -28,6 +28,10 @@ c.JupyterHub.last_activity_interval = 60
 # Max number of servers that can be spawning at any one time
 c.JupyterHub.concurrent_spawn_limit = get_config('hub.concurrent-spawn-limit')
 
+# Max number of consecutive failures before the Hub restarts itself
+# requires jupyterhub 0.9.2
+c.Spawner.consecutive_failure_limit = get_config('hub.consecutive-failure-limit', 0)
+
 active_server_limit = get_config('hub.active-server-limit', None)
 if active_server_limit is not None:
     c.JupyterHub.active_server_limit = int(active_server_limit)

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -1,13 +1,14 @@
-statsd==3.2.2
+# jupyterhub version is defined in chartpress.yaml
 jupyterhub-dummyauthenticator==0.3.1
 jupyterhub-tmpauthenticator==0.5
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
 nullauthenticator==1.0
-oauthenticator==0.7.3
+oauthenticator==0.8.0
 pymysql==0.9.2
 psycopg2==2.7.5
 pycurl==7.43.0.2
+statsd==3.2.2
 mwoauth==0.3.2
 globus_sdk[jwt]==1.5.0
 cryptography==2.3

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -216,6 +216,7 @@ data:
   {{- /* Hub */}}
   hub.allow-named-servers: {{ .Values.hub.allowNamedServers | quote }}
   hub.concurrent-spawn-limit: {{ .Values.hub.concurrentSpawnLimit | quote }}
+  hub.consecutive-failure-limit: {{ .Values.hub.consecutiveFailureLimit | quote }}
   {{- if .Values.hub.activeServerLimit }}
   hub.active-server-limit: {{ .Values.hub.activeServerLimit | quote }}
   {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -10,6 +10,7 @@ hub:
   fsGid: 1000
   nodeSelector: {}
   concurrentSpawnLimit: 64
+  consecutiveFailureLimit: 5
   activeServerLimit:
   deploymentStrategy:
     # sqlite-pvc backed hub requires Recreate strategy to work


### PR DESCRIPTION
- jupyterhub 0.9.2
- oauthenticator 0.8.0

adds `hub.consecutiveFailureLimit` config with a default of 5. After 5 consecutive launch failures, the Hub will restart. This should get some self-healing when reflectors get stuck.

After this PR, 0.7 should only be waiting on KubeSpawner release (code-wise), which should come soon after the latest changes get some testing on mybinder.org tomorrow.