### PR TITLE
remove "v" prefix from versions

### DIFF
--- a/doc/source/extending-jupyterhub.rst
+++ b/doc/source/extending-jupyterhub.rst
@@ -19,7 +19,7 @@ The general method to modify your Kubernetes deployment is to:
 
      .. code-block:: bash
 
-        helm upgrade <YOUR_RELEASE_NAME> jupyterhub/jupyterhub --version=v0.6 -f config.yaml
+        helm upgrade <YOUR_RELEASE_NAME> jupyterhub/jupyterhub --version=0.7 -f config.yaml
 
    Where ``<YOUR_RELEASE_NAME>`` is the parameter you passed to ``--name`` when
    `installing jupyterhub <setup-jupyterhub.html#install-jupyterhub>`_ with

--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -85,7 +85,7 @@ Install JupyterHub
    .. code:: bash
 
       helm install jupyterhub/jupyterhub \
-          --version=v0.6 \
+          --version=0.7 \
           --name=<YOUR-RELEASE-NAME> \
           --namespace=<YOUR-NAMESPACE> \
           -f config.yaml

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,6 +1,6 @@
 name: jupyterhub
-version: v0.7-dev
-appVersion: v0.9.2
+version: 0.7-dev
+appVersion: 0.9.2
 description: Multi-user Jupyter installation
 home: https://z2jh.jupyter.org
 sources:


### PR DESCRIPTION
"v" may be used as a git tag prefix for versions, but isn't part of the version string itself