### PR TITLE
Pulling images from external private image repositories

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -381,16 +381,19 @@ properties:
           registry:
             type: string
             description: |
-              Name of the private registry you want to create a credential set for.
+              Name of the private registry you want to create a credential set
+              for. It will default to Docker Hub's image registry.
 
               Examples:
-                - private.jfrog.io
-                - alexmorreale.privatereg.net
+                - https://index.docker.io/v1/
+                - quay.io
                 - eu.gcr.io
+                - alexmorreale.privatereg.net
           username:
             type: string
             description: |
-              Name of the user you want to use to connect to your private registry.
+              Name of the user you want to use to connect to your private
+              registry. For external gcr.io, you will use the `_json_key`.
 
               Examples:
                 - alexmorreale
@@ -408,9 +411,7 @@ properties:
 
               For gcr.io registries the password will be a big JSON blob for a
               Google cloud service account, it should look something like below.
-
-              Learn more in [this guide](http://docs.heptio.com/content/private-registries/pr-gcr.html).
-              
+                            
               ```yaml
               password: |-
                 {
@@ -420,6 +421,9 @@ properties:
                   ...
                 }
               ```
+
+              Learn more in [this
+              guide](http://docs.heptio.com/content/private-registries/pr-gcr.html).
       image:
         type: object
         description: |

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -191,21 +191,16 @@ component: {{ include "jupyterhub.componentLabel" . }}
 {{- define "jupyterhub.dockerconfigjson.yaml" -}}
 {{- with .Values.singleuser.imagePullSecret -}}
 {
-  {{- /* */ -}}
-  "auths":{
-    {{- .registry | default "https://index.docker.io/v1/" | quote }}:{
-      {{- /* */ -}}
-      "username": {{- .username | quote }},
-      {{- /* */ -}}
-      "password": {{- .password | quote }},
-      {{- if .email -}}
-      "email": {{- .email | quote }},
-      {{- end -}}
-      "auth": {{- (print .username ":" .password) | b64enc | quote -}}
+  "auths": {
+    {{ .registry | default "https://index.docker.io/v1/" | quote }}: {
+      "username": {{ .username | quote }},
+      "password": {{ .password | quote }},
+      {{- if .email }}
+      "email": {{ .email | quote }},
+      {{- end }}
+      "auth": {{ (print .username ":" .password) | b64enc | quote }}
     }
-    {{- /* */ -}}
   }
-  {{- /* */ -}}
 }
 {{- end }}
 {{- end }}

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -189,7 +189,7 @@ component: {{ include "jupyterhub.componentLabel" . }}
 {{- end }}
 
 {{- define "jupyterhub.dockerconfigjson.yaml" -}}
-{{- with . -}}
+{{- with .Values.singleuser.imagePullSecret -}}
 {
   {{- /* */ -}}
   "auths":{

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -173,10 +173,39 @@ component: {{ include "jupyterhub.componentLabel" . }}
 {{ include "jupyterhub.matchLabels" $_ | replace ": " "=" | replace "\n" "," | quote }}
 {{- end }}
 
+
 {{- /*
-  singleuser.imagePullSecret:
-    allows creating a base64 encoded docker registry json blob
+  jupyterhub.dockerconfigjson:
+    Creates a base64 encoded docker registry json blob for use in a image pull
+    secret, just like the `kubectl create secret docker-registry` command does
+    for the generated secrets data.dockerconfigjson field. The output is
+    verified to be exactly the same even if you have a password spanning
+    multiple lines as you may need to use a private GCR registry.
+
+    - https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 */}}
-{{- define "singleuser.imagePullSecret" }}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.singleuser.imagePullSecret.registry (printf "%s:%s" .Values.singleuser.imagePullSecret.username .Values.singleuser.imagePullSecret.password | b64enc) | b64enc }}
+{{- define "jupyterhub.dockerconfigjson" -}}
+{{ include "jupyterhub.dockerconfigjson.yaml" . | b64enc }}
+{{- end }}
+
+{{- define "jupyterhub.dockerconfigjson.yaml" -}}
+{{- with . -}}
+{
+  {{- /* */ -}}
+  "auths":{
+    {{- .registry | default "https://index.docker.io/v1/" | quote }}:{
+      {{- /* */ -}}
+      "username": {{- .username | quote }},
+      {{- /* */ -}}
+      "password": {{- .password | quote }},
+      {{- if .email -}}
+      "email": {{- .email | quote }},
+      {{- end -}}
+      "auth": {{- (print .username ":" .password) | b64enc | quote -}}
+    }
+    {{- /* */ -}}
+  }
+  {{- /* */ -}}
+}
+{{- end }}
 {{- end }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -134,7 +134,7 @@ data:
     {{- .Values.singleuser.cloudMetadata | toYaml | trimSuffix "\n" | nindent 4 }}
   singleuser.start-timeout: {{ .Values.singleuser.startTimeout | quote }}
   singleuser.image-pull-policy: {{ .Values.singleuser.image.pullPolicy | quote }}
-  {{- if .Values.singleuser.imagePullSecret }}
+  {{- if .Values.singleuser.imagePullSecret.enabled }}
   singleuser.image-pull-secret-name: singleuser-image-credentials
   {{- end }}
   {{- if .Values.singleuser.cmd }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -40,7 +40,7 @@ spec:
       automountServiceAccountToken: false
       {{- if .Values.singleuser.imagePullSecret.enabled }}
       imagePullSecrets:
-        - name: singleuser-image-credentials
+        - name: {{ if .hook -}} hook- {{- end -}} singleuser-image-credentials
       {{- end }}
       initContainers:
         - name: image-pull-singleuser

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -38,6 +38,10 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
+      {{- if .Values.singleuser.imagePullSecret.enabled }}
+      imagePullSecrets:
+        - name: singleuser-image-credentials
+      {{- end }}
       initContainers:
         - name: image-pull-singleuser
           image: {{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}

--- a/jupyterhub/templates/singleuser/image-credentials-secret.yaml
+++ b/jupyterhub/templates/singleuser/image-credentials-secret.yaml
@@ -9,4 +9,22 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ include "jupyterhub.dockerconfigjson" . }}
+{{- if .Values.prePuller.hook.enabled }}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: hook-singleuser-image-credentials
+  labels:
+    {{- $_ := merge (dict "componentPrefix" "hook-" "componentSuffix" "-image-credentials") . }}
+    {{- include "jupyterhub.labels" $_ | nindent 4 }}
+    hub.jupyter.org/deletable: "true"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "-20"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ include "jupyterhub.dockerconfigjson" . }}
+{{- end }}
 {{- end }}

--- a/jupyterhub/templates/singleuser/image-credentials-secret.yaml
+++ b/jupyterhub/templates/singleuser/image-credentials-secret.yaml
@@ -21,7 +21,7 @@ metadata:
     hub.jupyter.org/deletable: "true"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-20"
 type: kubernetes.io/dockerconfigjson
 data:

--- a/jupyterhub/templates/singleuser/image-credentials-secret.yaml
+++ b/jupyterhub/templates/singleuser/image-credentials-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.singleuser.imagePullSecret }}
+{{- if .Values.singleuser.imagePullSecret.enabled }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -8,5 +8,5 @@ metadata:
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ include "singleuser.imagePullSecret" . }}
+  .dockerconfigjson: {{ include "jupyterhub.dockerconfigjson" . }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -185,6 +185,12 @@ singleuser:
     name: jupyterhub/k8s-singleuser-sample
     tag: generated-by-chartpress
     pullPolicy: IfNotPresent
+  imagePullSecret:
+    enabled: false
+    registry:
+    username:
+    email:
+    password:
   startTimeout: 300
   cpu:
     limit:


### PR DESCRIPTION
## TODO

- [x] Verify hook-pulling from private registries works as well.
- [x] Verify output is EXACTLY the same (as kubeclt create secret ...)  with a registry using symbols like `:/` in it as well

---

@AlexMorreale helped us use config.yaml to install a Kubernetes Secret which could be referenced by pods that want to pull from image registries that required some credentials - this is #801.

This PR complements Alex work by...
- Allowing for the email field to optionally be configured, which seem to be utilized by some registries but not all.
- Adds support for setting large JSON blobs in the password field, something that is required in order to pull from a private gcr.io registry from an external cluster.
- Ensures that the image puller DaemonSets, both `hook-` and `continuous-` have the same credentials to pull the images.

Fixes #871.

---

Note that with #844, this pr will ensure that the Helm template within `jupyterhub/templates/singleuser/image-credentials-secret.yaml` is valid and generated valid output which is a very important check for this PR.

Also note that the secret created with values in config.yaml, will have the *exact* same content as a secret created by kubectl's command if you provide a simple password or if you pass it a big JSON blob.
```
kubectl create secret docker-registry regcred --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email> 
```

See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-in-the-cluster-that-holds-your-authorization-token) for more details.