### PR TITLE
add h1 sidebar setting

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -67,6 +67,11 @@ img.logo {
 div.sphinxsidebarwrapper div {
     margin-bottom: .8em;
 }
+
+div.sphinxsidebar h1 {
+    font-size: 2.0rem;
+}
+
 div.sphinxsidebar h3 {
     font-size: 1.3em;
     padding-top: 0px;


### PR DESCRIPTION
Closes #847 

Bootstrap used by copybutton brought in a _type.scss file that was increasing the sidebar h1 setting. This PR sets `sphinxsidebar.h1` to a smaller value in our `custom.css`.

Rendered: https://test-zerotojh.readthedocs.io/en/adjust-sidebar/