### PR TITLE
cull.maxAge ignored bugfix

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -12,6 +12,7 @@ data:
   cull.timeout: {{ .Values.cull.timeout | quote }}
   cull.every: {{ .Values.cull.every | quote }}
   cull.concurrency: {{ .Values.cull.concurrency | quote }}
+  cull.max-age: {{ .Values.cull.maxAge | quote }}
   {{- end }}
 
 


### PR DESCRIPTION
The config entry cull.maxAge was previously never consumed by the
jupyterhub_config.py as it reads from its configmap where the entry
cull.max-age was never set. This affected maxAge based cullings on
JupyterHub 0.9+ to never cull due to exceeding a set maxAge.