### PR TITLE
No more duplicates of puller pods

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -7,4 +7,4 @@ sources:
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
 icon: https://jupyter.org/assets/hublogo.svg
 kubeVersion: '>=1.8.0-0'
-tillerVersion: '>=2.7.0-0'
+tillerVersion: '>=2.9.1-0'

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -7,8 +7,7 @@ Returns an image-puller daemonset. Two daemonsets will be created like this.
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  {{- $label := print "-" .Release.Time.Seconds }}
-  name: {{ print .componentPrefix "image-puller" }}{{- if .hook }}{{ $label }}{{- end }}
+  name: {{ print .componentPrefix "image-puller" }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     {{- if .hook }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -20,7 +20,7 @@ metadata:
     Allows the daemonset to be deleted when the image-awaiter job is completed.
     */}}
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-10"
   {{- end }}
 spec:

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -33,7 +33,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 0

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -15,7 +15,7 @@ metadata:
     hub.jupyter.org/deletable: "true"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "10"
 spec:
   template:
@@ -26,7 +26,7 @@ spec:
     spec:
       restartPolicy: Never
       {{- if .Values.rbac.enabled }}
-      serviceAccountName: hook-image-awaiter-{{ .Release.Time.Seconds }}
+      serviceAccountName: hook-image-awaiter
       {{- end }}
       containers:
         - image: {{ .Values.prePuller.hook.image.name }}:{{ .Values.prePuller.hook.image.tag }}
@@ -38,5 +38,5 @@ spec:
             - -auth-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
             - -api-server-address=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
             - -namespace={{ .Release.Namespace }}
-            - -daemonset=hook-image-puller-{{ .Release.Time.Seconds }}
+            - -daemonset=hook-image-puller
 {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -9,7 +9,7 @@ command.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- /* Changes here will cause the Job to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -9,7 +9,7 @@ This service account...
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -24,7 +24,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -43,7 +43,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -53,11 +53,11 @@ metadata:
     "helm.sh/hook-weight": "0"
 subjects:
   - kind: ServiceAccount
-    name: hook-image-awaiter-{{ .Release.Time.Seconds }}
+    name: hook-image-awaiter
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: hook-image-awaiter-{{ .Release.Time.Seconds }}
+  name: hook-image-awaiter
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -15,7 +15,7 @@ metadata:
     hub.jupyter.org/deletable: "true"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "0"
 ---
 {{- /*
@@ -49,7 +49,7 @@ metadata:
     hub.jupyter.org/deletable: "true"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "0"
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
Thanks to the new `before-hook-creation` deletion policy, we can avoid the `object already exist` error as Helm would simply delete and recreate the resource instead if it found a resource with the same name. This means that we can use a single name for the puller daemonset and won't ever orphan a puller daemonsets after a failed upgrade followed by a successful upgrade.