### PR TITLE
correct step numbers in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ development.
 2. [Download & install helm](https://github.com/helm/helm#install).
 
    You may install Helm using one of the following steps:
-   
+
    * With the following curl command:
-   
+
      ```
      curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
      ```
@@ -93,16 +93,16 @@ development.
    ```bash
    minikube service --namespace=hub proxy-public
    ```
-  
+
    Navigate to the URL in your browser. You should now have JupyterHub running
    on minikube.
-  
-11. Make the changes you want. 
+
+11. Make the changes you want.
 
     To view your changes on the running development instance of JupyterHub:
 
-    - Re-run step 6 if you changed anything under the `images` directory
-    - Re-run step 8 if you changed things only under the `jupyterhub` directory.
+    - Re-run step 7 if you changed anything under the `images` directory
+    - Re-run step 9 if you changed things only under the `jupyterhub` directory.
 
 ---
 


### PR DESCRIPTION
Hey y'all! 

I was working through the contributing docs and spotted this minor mistake. The step numbers in the following documentation should be change from:

```
- Re-run step 6 if you changed anything under the `images` directory
- Re-run step 8 if you changed things only under the `jupyterhub` directory.
```
to:

```
- Re-run step 7 if you changed anything under the `images` directory
- Re-run step 9 if you changed things only under the `jupyterhub` directory.
```

I think a step was added in a previous commit that shifted the step numbers by one. 
