### PR TITLE
final (?) bugfix of hook-image-puller

### DIFF
--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -30,7 +30,7 @@ metadata:
     hub.jupyter.org/deletable: "true"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "0"
 rules:
   - apiGroups: ["apps"]       # "" indicates the core API group


### PR DESCRIPTION
Sigh I'm sorry @minrk I messed up... #854 was not free of errors, it did not change all the hook-delete-policy fields as it needed to do.

We must release a 0.7.0-beta.2 (or override beta.1) thanks to this, or it is not stable enough.