### PR TITLE
enable events by default

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -156,7 +156,7 @@ singleuser:
               cidr: 0.0.0.0/0
               except:
                 - 169.254.169.254/32
-  events: false
+  events: true
   extraLabels: {}
   extraEnv: {}
   lifecycleHooks:


### PR DESCRIPTION
The event reflector issues should be fixed in kubespawner, so let’s re-enable events by default so that the spawn progress page gets kube events