### PR TITLE
Add extra annotations option

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -57,6 +57,8 @@ c.KubeSpawner.image_pull_secrets = get_config('singleuser.image-pull-secret-name
 
 c.KubeSpawner.events_enabled = get_config('singleuser.events', False)
 
+c.KubeSpawner.extra_annotations = get_config('singleuser.extra-annotations', {})
+
 c.KubeSpawner.extra_labels = get_config('singleuser.extra-labels', {})
 
 c.KubeSpawner.uid = get_config('singleuser.uid')

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -195,6 +195,12 @@ data:
     {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
+  {{- if .Values.singleuser.extraAnnotations }}
+  singleuser.extra-annotations: |
+    {{- range $key, $value := .Values.singleuser.extraAnnotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   singleuser.extra-labels: |
     hub.jupyter.org/network-access-hub: "true"
     {{- range $key, $value := .Values.singleuser.extraLabels }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -157,6 +157,7 @@ singleuser:
               except:
                 - 169.254.169.254/32
   events: true
+  extraAnnotations: {}
   extraLabels: {}
   extraEnv: {}
   lifecycleHooks:


### PR DESCRIPTION
Kubespawner allows you to specify extra annotations for the singleuser notebook pods however there is no way to set this from the helm chart.

This PR adds some extra config to pass these values through.

Fixes #810