### PR TITLE
Instantly redirect to the progress page

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -28,6 +28,11 @@ c.JupyterHub.last_activity_interval = 60
 # Max number of servers that can be spawning at any one time
 c.JupyterHub.concurrent_spawn_limit = get_config('hub.concurrent-spawn-limit')
 
+# Don't wait at all before redirecting a spawning user to the progress page
+c.JupyterHub.tornado_settings = {
+    'slow_spawn_timeout': 0,
+}
+
 # Max number of consecutive failures before the Hub restarts itself
 # requires jupyterhub 0.9.2
 c.Spawner.consecutive_failure_limit = get_config('hub.consecutive-failure-limit', 0)


### PR DESCRIPTION
@minrk pointed out that the slow redirection to the progress page is
related to the hub is waiting for the spawning to complete before it
redirects, as that may happen very quickly sometimes. But, on
kubernetes and clouds, we won't be able to insta-spawn a pod as we can
insta-spawn a process, so always redirecting to the progress page right
away makes sense.