### PR TITLE
Refreshed singleuser-sample

### DIFF
--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -6,4 +6,18 @@ FROM jupyter/base-notebook:8ccdfc1da8d5
 # The jupyter/docker-stacks images contains jupyterhub, jupyterlab and the
 # jupyterlab-hub extension already.
 
+# Example install of git and nbgitpuller.
+# NOTE: git is already available in the jupyter/minimal-notebook image.
+USER root
+RUN apt-get update && apt-get install --yes \
+    git \
+ && rm -rf /var/lib/apt/lists/*
+USER $NB_USER
+
+RUN pip install nbgitpuller && \
+    jupyter serverextension enable --py nbgitpuller --sys-prefix
+
+# Uncomment the line below to make nbgitpuller default to start up in JupyterLab
+#ENV NBGITPULLER_APP=lab
+
 # conda/pip/apt install additional packages here, if desired.

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,11 +1,9 @@
-FROM jupyter/base-notebook:177037d09156
+FROM jupyter/base-notebook:8ccdfc1da8d5
 # Built from... https://hub.docker.com/r/jupyter/base-notebook/
 #               https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile
-# Built from... Ubuntu 16.04
+# Built from... Ubuntu 18.04
+
+# The jupyter/docker-stacks images contains jupyterhub, jupyterlab and the
+# jupyterlab-hub extension already.
 
 # conda/pip/apt install additional packages here, if desired.
-
-# pin jupyterhub to match the Hub version
-# set via --build-arg in Chartpress
-ARG JUPYTERHUB_VERSION=0.9.*
-RUN pip install --no-cache jupyterhub==$JUPYTERHUB_VERSION

--- a/images/singleuser-sample/README.md
+++ b/images/singleuser-sample/README.md
@@ -1,26 +1,31 @@
-# Tiniest notebook stack #
+# The default user image
 
-This is the tiniest possible docker image that can run a Jupyter Notebook. It
-is primarily meant for demo purposes where speed of pulling is important.
+This Docker image is the Helm chart's default user image. It contains the
+fundamentals only so that it can get pulled quickly. It is based on the
+[base-notebook image](https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile)
+from Project Jupyter's [jupyter/docker-stacks repository](https://github.com/jupyter/docker-stacks)
+which also contains many other images suitable for use with the Helm chart. To
+help you choose another one see [the docker-stacks documentation on selecting a
+user image](http://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html).
 
-Not recommended for non-demo uses!
-
-## What it gives you
-
-It is based on [Alpine Linux](https://alpinelinux.org/). It uses pip to install
-both the notebook and jupyterhub packages - the latter allows us to use this
-image for single-user servers in Kubernetes / Docker spawners.
-
-You can use pip3 to install packages (with `pip3` or `apk`) as root. There
-are no non-root users provisioned.
+For a brief introduction to *Dockerfiles*, *images* and *containers*, see [the
+guide's summary about container technology.](https://z2jh.jupyter.org/en/latest/tools.html#container-technology).
 
 ## Basic usage
 
-You can run a notebook with:
+To quickly try out this Docker image on your computer:
 
-```
-sudo docker run  -it  --rm  -p 8888:8888 jupyter/tiniest-notebook
+```sh
+# with the classic UI
+docker run  -it  --rm  -p 8888:8888 jupyterhub/k8s-singleuser-sample:0.7.0
+
+# with JupyterLab
+docker run  -it  --rm  -p 8888:8888 -e JUPYTER_ENABLE_LAB=true jupyterhub/k8s-singleuser-sample:0.7.0
 ```
 
-The default command is `/usr/bin/jupyter` (not `/usr/local/bin/jupyth`). For
-use with jupyterhub, `/usr/bin/jupyterhub-singleuser` is also available.
+This image available tags can be found [here](https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/tags/).
+
+## In the base-notebook image
+- Ubuntu Linux - v18.04 aka. Bionic
+- JupyterHub - required by with Helm chart since KubeSpawner requires it
+- [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) and [JupyterLab-Hub extension](https://jupyterlab.readthedocs.io/en/stable/user/jupyterhub.html) - to activate it over the classical UI by default, see [the guide's instructions](https://z2jh.jupyter.org/en/latest/user-environment.html#use-jupyterlab-by-default).


### PR DESCRIPTION
The singleuser-sample image that we provide needed a refresh.

- I updated the README.md file next to it
- I removed an additional install of jupyterhub (docker-stacks images already has it)
- I added git and nbgitpuller
- The compressed image size went from about 230 to 260.