### PR TITLE
[Part 2 of #758] user-scheduler added

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -72,6 +72,7 @@ c.KubeSpawner.fs_gid = get_config('singleuser.fs-gid')
 service_account_name = get_config('singleuser.service-account-name', None)
 if service_account_name:
     c.KubeSpawner.service_account = service_account_name
+c.KubeSpawner.scheduler_name = get_config('singleuser.scheduler-name', "")
 
 c.KubeSpawner.node_selector = get_config('singleuser.node-selector')
 # Configure dynamically provisioning pvc

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -337,41 +337,6 @@ if not cloud_metadata.get('enabled', False):
 
     c.KubeSpawner.init_containers.append(ip_block_container)
 
-scheduler_strategy = get_config('singleuser.scheduler-strategy', 'spread')
-
-if scheduler_strategy == 'pack':
-    # FIXME: Support setting affinity directly in KubeSpawner
-    c.KubeSpawner.extra_pod_config = {
-        'affinity': {
-            'podAffinity': {
-                'preferredDuringSchedulingIgnoredDuringExecution': [{
-                    'weight': 50,
-                    'podAffinityTerm': {
-                        'labelSelector': {
-                            'matchExpressions': [{
-                                'key': 'component',
-                                'operator': 'In',
-                                'values': ['hub']
-                            }]
-                        },
-                        'topologyKey': 'kubernetes.io/hostname'
-                    }
-                }, {
-                    'weight': 5,
-                    'podAffinityTerm': {
-                        'labelSelector': {
-                            'matchExpressions': [{
-                                'key': 'component',
-                                'operator': 'In',
-                                'values': ['singleuser-server']
-                            }]
-                        },
-                        'topologyKey': 'kubernetes.io/hostname'
-                    }
-                }],
-            }
-        }
-    }
 
 if get_config('debug.enabled', False):
     c.JupyterHub.log_level = 'DEBUG'

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -452,3 +452,38 @@ properties:
         description: |
           Deprecated and no longer does anything. Use the user-scheduler instead
           in order to accomplish a good packing of the user pods.
+
+
+  scheduling:
+    type: object
+    description: |
+      Objects for customizing the scheduling of various pods on the nodes and
+      related labels.
+    properties:
+      userScheduler:
+        type: object
+        description: |
+          The user scheduler is making sure that user pods are scheduled
+          tight on nodes, this is useful for autoscaling of user node pools.
+        properties:
+          enabled:
+            type: boolean
+            description: |
+              Enables the user scheduler.
+          replicas:
+            type: integer
+            description: |
+              You can have multiple schedulers to share the workload or improve
+              availability on node failure.
+          image:
+            type: object
+            description: |
+              The image containing the [kube-scheduler
+              binary](https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/kube-scheduler-amd64).
+            properties:
+              name:
+                type: string
+              tag:
+                type:
+                  - string
+                  - "null"

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -150,9 +150,6 @@ data:
   singleuser.service-account-name: {{ .Values.singleuser.serviceAccountName | quote }}
   {{- end }}
   singleuser.node-selector: {{ toJson .Values.singleuser.nodeSelector | quote }}
-  {{- if .Values.singleuser.schedulerStrategy }}
-  singleuser.scheduler-strategy: {{ .Values.singleuser.schedulerStrategy | quote }}
-  {{- end }}
   singleuser.storage.type: {{ .Values.singleuser.storage.type | quote }}
   singleuser.storage.home_mount_path: {{ .Values.singleuser.storage.homeMountPath | quote }}
   singleuser.storage.extra-volumes: {{ toJson .Values.singleuser.storage.extraVolumes | quote }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -213,6 +213,9 @@ data:
     {{- end }}
   {{- end }}
 
+  {{- if .Values.scheduling.userScheduler.enabled }}
+  singleuser.scheduler-name: "user-scheduler"
+  {{- end }}
 
   {{- /* KubeSpawner */}}
   kubespawner.common-labels: |

--- a/jupyterhub/templates/scheduling/user-scheduler/_helpers.tpl
+++ b/jupyterhub/templates/scheduling/user-scheduler/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- /*
+Renders the kube-scheduler's image based on .Values.scheduling.userScheduler.name and
+optionally on .Values.scheduling.userScheduler.tag. The default tag is set to the clusters
+kubernetes version.
+*/}}
+{{- define "jupyterhub.scheduler.image" -}}
+{{- $name := .Values.scheduling.userScheduler.image.name -}}
+{{- $valuesVersion := .Values.scheduling.userScheduler.image.tag -}}
+{{- $clusterVersion := (split "-" .Capabilities.KubeVersion.GitVersion)._0 -}}
+{{- $tag := $valuesVersion | default $clusterVersion -}}
+{{ $name }}:{{ $tag }}
+{{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.scheduling.userScheduler.enabled -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: user-scheduler
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+data:
+  policy.cfg: |
+    {
+      "kind": "Policy",
+      "apiVersion": "v1",
+      "predicates": [
+        { "name": "PodFitsResources" },
+        { "name": "HostName" },
+        { "name": "PodFitsHostPorts" },
+        { "name": "MatchNodeSelector" },
+        { "name": "NoDiskConflict" },
+        { "name": "PodToleratesNodeTaints" },
+        { "name": "MaxEBSVolumeCount" },
+        { "name": "MaxGCEPDVolumeCount" },
+        { "name": "MaxAzureDiskVolumeCount" },
+        { "name": "CheckVolumeBinding" },
+        { "name": "NoVolumeZoneConflict" },
+        { "name": "MatchInterPodAffinity" }
+      ],
+      "priorities": [
+        { "name": "NodePreferAvoidPodsPriority",  "weight": 10000 },
+        { "name": "NodeAffinityPriority",         "weight": 1000 },
+        { "name": "InterPodAffinityPriority",     "weight": 100 },
+        { "name": "MostRequestedPriority",        "weight": 50 }
+      ],
+      "hardPodAffinitySymmetricWeight" : 100,
+      "alwaysCheckAllPredicates" : true
+    }
+{{- end }}
+
+{{- /*
+# Notes about the GeneralPredicates
+The following predicates was not found by kube-scheduler 1.11.1-beta.0
+{ "name": "CheckNodePIDPressure" },
+{ "name": "CheckNodeUnschedulable" },
+{ "name": "CheckNodeCondition" },
+{ "name": "General" },
+{ "name": "PodToleratesNodeNoExecuteTaints" },
+{ "name": "CheckNodeMemoryPressure" },
+{ "name": "CheckNodeDiskPressure" },
+
+# Notes about the priorities
+NodePreferAvoidPodsPriority: What does this really mean?
+HardPodAffinitySymmetricWeight: "It represents the weight of implicit
+PreferredDuringScheduling affinity rule." - preferred node affinity or preferred
+pod/anti-pod affinity or those affinities in general? How does this relate to
+the InterPodAffinityPriority and NodeAffinityPriority?
+
+AlwaysCheckAllPredicates: scheduler checks all the configured predicates even
+after one or more of them fails.
+
+GeneralPredicates checks whether noncriticalPredicates and EssentialPredicates
+pass. noncriticalPredicates are the predicates that only non-critical pods need
+and EssentialPredicates are the predicates that all pods, including critical
+pods, need
+
+MostRequestedPriority: Is using the default MostRequestedPriorityMap that is a
+priority function that favors nodes with most requested resources. It calculates
+the percentage of memory and CPU requested by pods scheduled on the node, and
+prioritizes based on the maximum of the average of the fraction of requested to
+capacity.
+
+Details: (cpu(10 * sum(requested) / capacity) + memory(10 * sum(requested) /
+capacity)) / 2
+
+*/}}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.scheduling.userScheduler.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-scheduler
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.scheduling.userScheduler.replicas }}
+  selector:
+    matchLabels:
+      {{- include "jupyterhub.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- /* Changes here will cause the Deployment to restart the pods. */}}
+        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        hub.jupyter.org/pod-kind: "core"
+      annotations:
+        # This lets us autorestart when the configmap changes!
+        checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
+    spec:
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: user-scheduler
+      {{- end }}
+      containers:
+        - name: user-scheduler
+          image: {{ include "jupyterhub.scheduler.image" . }}
+          command:
+            - /usr/local/bin/kube-scheduler
+            - --scheduler-name=user-scheduler
+            - --policy-configmap=user-scheduler
+            - --policy-configmap-namespace={{ .Release.Namespace }}
+            - --lock-object-name=user-scheduler
+            - --lock-object-namespace={{ .Release.Namespace }}
+            - --leader-elect-resource-lock=configmaps
+            - --v=100
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10251
+            initialDelaySeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 10251
+          resources:
+            requests:
+              cpu: 50m
+              memory: 512Mi
+{{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.scheduling.userScheduler.enabled -}}
+{{- if .Values.rbac.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: user-scheduler
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: user-scheduler-base
+  labels:
+    {{- $_ := merge (dict "componentSuffix" "-base") . }}
+    {{- include "jupyterhub.labels" $_ | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: user-scheduler
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: user-scheduler-complementary
+  labels:
+    {{- $_ := merge (dict "componentSuffix" "-complementary") . }}
+    {{- include "jupyterhub.labels" $_ | nindent 4 }}
+rules:
+  # Support leader elections
+  - apiGroups: [""]
+    resourceNames: ["user-scheduler"]
+    resources: ["configmaps"]
+    verbs: ["get", "update"]
+  # Workaround for missing permission in system:kube-scheduler as of k8s 1.10.4
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: user-scheduler-complementary
+  labels:
+    {{- $_ := merge (dict "componentSuffix" "-complementary") . }}
+    {{- include "jupyterhub.labels" $_ | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: user-scheduler
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: user-scheduler-complementary
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -205,6 +205,15 @@ singleuser:
   defaultUrl:
 
 
+scheduling:
+  userScheduler:
+    enabled: false
+    replicas: 1
+    image:
+      name: gcr.io/google_containers/kube-scheduler-amd64
+      tag: v1.11.2
+
+
 prePuller:
   hook:
     enabled: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -166,7 +166,6 @@ singleuser:
   uid: 1000
   fsGid: 100
   serviceAccountName:
-  schedulerStrategy:
   storage:
     type: dynamic
     extraVolumes: []

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -215,6 +215,15 @@ singleuser:
   defaultUrl: /
 
 
+scheduling:
+  userScheduler:
+    enabled: true
+    replicas: 1
+    image:
+      name: gcr.io/google_containers/kube-scheduler-amd64
+      tag: v1.11.2
+
+
 prePuller:
   hook:
     enabled: true


### PR DESCRIPTION
# About
The user-scheduler is great for use with a cluster autoscaler and bad 
without it. With the user-scheduler optionally enabled users will be 
packed to fill up one node at the time. This in turn tends to create 
totally unused nodes that are easy for a cluster autoscaler to scale 
down the unused node. Without a cluster autoscaler, it is just a waste 
of resources to get yourself unused nodes though, so only enable the 
user-scheduler if you have a cluster autoscaler.

NOTE: This works without k8s 1.11. Only *user-placeholder* utilizing *pod priority* and *pod preemption* require k8s 1.11.

## A code overview - useful for anyone reviewing this code
**IMPORTANT:** Everything inside this PR is *disabled by default*, and can be optionally enabled by config.yaml by passing `scheduling.userScheduler.enabled: true`. This means that the PR is very unintrusive and could perhaps be merged quite quickly for quicker feedback from curious users.

A Kubernetes Deployment called *user-scheduler* is added. This Deployment ensures one (or more) replica of a pod is running, and this pods runs a container based on an image and associated binary provided by Kubernetes called *kube-scheduler*. *kube-scheduler* is configured to run with different than-default settings found in a configmap, so anything it schedules will be scheduled to pack tight on a node that already consumes a lot of resources.

Our manually configured kube-scheduler will only schedule pods requesting to be scheduled by it. That is why this PR modifies the jupyterhub_config.py wherein kubespawner is configured to set the pods *spec.schedulerName* field to match the our specific scheduler and not the default one named *default*.

The RBAC requirements for the scheduler are the same as the ClusterRole called `system:kube-scheduler` but needs to be augmented slightly to access the configmap with the configuration we provide. We end up with a ServiceAccount coupled with two ClusterRoles (`system:kube-scheduler`, and the one with small additions) through two ClusterRoleBindings.

I'm also making the `singleuser.schedulerStrategy` Helm chart configuration meaningless. Note that there is still an entry about it in schema.yaml that sais it is now deprecated and that the user-scheduler should be used instead.

---

Fixes #542 