### PR TITLE
correct error in documentation regarding singleuser.image.pullPolicy

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -336,17 +336,6 @@ properties:
               - "null"
             description: |
               Note that this field is referred to as *requests* by the Kubernetes API.
-      imagePullPolicy:
-        type: string
-        enum:
-          - IfNotPresent
-          - Always
-          - Never
-        description: |
-          Set the imagePullPolicy on the singleuser pods that are spun up by the hub.
-
-          See the [Kubernetes docs](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
-          for more info.
       imagePullSecret:
         type: object
         description: |
@@ -445,6 +434,17 @@ properties:
               The tag of the image to use.
 
               This is the value after the `:` in your full image name.
+          pullPolicy:
+            type: string
+            enum:
+              - IfNotPresent
+              - Always
+              - Never
+            description: |
+              Set the imagePullPolicy on the singleuser pods that are spun up by the hub.
+
+              See the [Kubernetes docs](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+              for more info.
       schedulerStrategy:
         type:
           - string


### PR DESCRIPTION
In the file `jupyterhub/templates/hub/configmap.yaml`, the `imagePullPolicy` for the `singleuser` pods is set with the line:

```
singleuser.image-pull-policy: {{ .Values.singleuser.image.pullPolicy | quote }}
```

I have corrected the docs to indicate this.

Thank you for creating this very useful project!
