### PR TITLE
remove `-network-policy` from network-policy names

### DIFF
--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: hub-network-policy
+  name: hub
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -6,7 +6,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: proxy-network-policy
+  name: proxy
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: singleuser-network-policy
+  name: singleuser
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
it's redundant to ask for `kubectl get networkpolicy hub-network-policy`.

In general: don't put resource type in resource names