### PR TITLE
default scheduler log-level to 4

### DIFF
--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - --lock-object-name=user-scheduler
             - --lock-object-namespace={{ .Release.Namespace }}
             - --leader-elect-resource-lock=configmaps
-            - --v=100
+            - --v={{ .Values.scheduling.userScheduler.logLevel | default 4 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -208,6 +208,7 @@ scheduling:
   userScheduler:
     enabled: false
     replicas: 1
+    logLevel: 4
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
       tag: v1.11.2

--- a/minikube-config.yaml
+++ b/minikube-config.yaml
@@ -19,3 +19,7 @@ singleuser:
 prePuller:
   hook:
     enabled: false
+
+scheduling:
+  userScheduler:
+    enabled: true


### PR DESCRIPTION
log-level 10 gets everything, including every byte of every request and reply made to the kube api. Unfortunately, scheduler decisions and every-request-byte are logged at the same level, so we can't debug scheduling decisions without also getting a truly massive amount of noise.