### PR TITLE
add pdb, nodeSelector for user-scheduler

### DIFF
--- a/jupyterhub/templates/hub/pdb.yaml
+++ b/jupyterhub/templates/hub/pdb.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.hub.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.hub.pdb.minAvailable }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  minAvailable: 1
+  minAvailable: {{ .Values.proxy.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.proxy.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.proxy.pdb.minAvailable }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: user-scheduler
       {{- end }}
+      nodeSelector: {{ toJson .Values.scheduling.userScheduler.nodeSelector }}
       containers:
         - name: user-scheduler
           image: {{ include "jupyterhub.scheduler.image" . }}

--- a/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.scheduling.userScheduler.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.scheduling.userScheduler.pdb.minAvailable }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.hub.pdb.enabled -}}
+{{- if .Values.scheduling.userScheduler.pdb.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: hub
+  name: user-scheduler
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.hub.pdb.minAvailable | default 1 }}
+  minAvailable: {{ .Values.scheduling.userScheduler.pdb.minAvailable | default 1 }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -50,6 +50,7 @@ hub:
   imagePullPolicy: IfNotPresent
   pdb:
     enabled: true
+    minAvailable: 1
   networkPolicy:
     enabled: false
     egress:
@@ -98,6 +99,7 @@ proxy:
   nodeSelector: {}
   pdb:
     enabled: true
+    minAvailable: 1
   https:
     enabled: true
     type: letsencrypt
@@ -214,6 +216,9 @@ scheduling:
       name: gcr.io/google_containers/kube-scheduler-amd64
       tag: v1.11.2
     nodeSelector: {}
+    pdb:
+      enabled: true
+      minAvailable: 1
 
 
 prePuller:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -213,6 +213,7 @@ scheduling:
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
       tag: v1.11.2
+    nodeSelector: {}
 
 
 prePuller:


### PR DESCRIPTION
to allow controlling where it runs, let it be disrupted for scale-down.

Additionally, `minAvailable` for other pdbs is configurable, so that it can be set to 0 to allow disruptions for scale-down.