### PR TITLE
[Part 4 of #758] Bump k8s resources to v1.9 available API

### DIFF
--- a/images/image-awaiter/Dockerfile
+++ b/images/image-awaiter/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=0 /go/image-awaiter /image-awaiter
 # > kubectl proxy --port=8080
 
 # 2. Try the API using the proxy...
-# > curl http://localhost:8080/apis/apps/v1beta2/namespaces/<namespace>/demonsets/hook-image-puller
+# > curl http://localhost:8080/apis/apps/v1/namespaces/<namespace>/demonsets/hook-image-puller
 
 # 3. Try the container using the proxy...
 # > docker build --tag <name:tag> .

--- a/images/image-awaiter/daemonset.go
+++ b/images/image-awaiter/daemonset.go
@@ -21,7 +21,7 @@ type DaemonSet struct {
 // Return a *DaemonSet and the relevant state its in
 func getDaemonSet(transportPtr *http.Transport, server string, headers map[string]string, namespace string, daemonSet string) (*DaemonSet, error) {
 	client := &http.Client{Transport: transportPtr}
-	url := server + "/apis/apps/v1beta2/namespaces/" + namespace + "/daemonsets/" + daemonSet
+	url := server + "/apis/apps/v1/namespaces/" + namespace + "/daemonsets/" + daemonSet
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/images/image-awaiter/main.go
+++ b/images/image-awaiter/main.go
@@ -4,7 +4,7 @@
 // started when this job starts. When all images are pulled, this job exits.
 
 /*
-K8s API options - currently using 1.8
+K8s API options - currently using 1.9
 - K8s 1.8 API: curl http://localhost:8080/apis/apps/v1beta2/namespaces/<ns>/demonsets/<ds>
 - K8s 1.9 API: curl http://localhost:8080/apis/apps/v1/namespaces/<ns>/demonsets/<ds>
 */

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -55,7 +55,7 @@
   ## Example usage
   ```yaml
   # Excerpt from proxy/autohttps/deployment.yaml
-  apiVersion: apps/v1beta2
+  apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: {{ include "jupyterhub.nameField" . }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hub
   labels:
@@ -21,7 +21,7 @@ rules:
     verbs: ["get", "watch", "list"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hub
   labels:

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -4,7 +4,7 @@ Returns an image-puller daemonset. Two daemonsets will be created like this.
 - continuous-image-puller: for newly added nodes image pulling
 */}}
 {{- define "jupyterhub.imagePuller.daemonset" -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ print .componentPrefix "image-puller" }}

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -22,7 +22,7 @@ metadata:
 ... will be used by this role...
 */}}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hook-image-awaiter
   labels:
@@ -41,7 +41,7 @@ rules:
 ... as declared by this binding.
 */}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hook-image-awaiter
   labels:

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- if $autoHTTPS -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: autohttps

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nginx-{{ .Release.Name }}
@@ -74,7 +74,7 @@ rules:
     verbs:
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-{{ .Release.Name }}
@@ -89,7 +89,7 @@ subjects:
     name: autohttps
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nginx
@@ -129,7 +129,7 @@ rules:
       - get
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kube-lego
@@ -166,7 +166,7 @@ rules:
   - create
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nginx
@@ -181,7 +181,7 @@ subjects:
     name: autohttps
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kube-lego

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $manualHTTPS := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual")) -}}
 {{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "secret")) -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: proxy


### PR DESCRIPTION
## About
Many k8s APIs previously in beta have become stable, this is a version bump of these APIs relating to how k8s resources are defined and behave.

## Changed `apiVersion`s
* Deployments  from `apps/v1beta2` to `apps/v1`
* DaemonSets changed `apiVersion` from `extensions/v1beta1` to `apps/v1`
* RBAC resources from `rbac.authorization.k8s.io/v1beta1` to `rbac.authorization.k8s.io/v1`