### PR TITLE
[Part 5 of #758] Update outdated logic for hub restarts

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -50,8 +50,6 @@ set_config_if_not_none(c.KubeSpawner, 'common_labels', 'kubespawner.common-label
 
 c.KubeSpawner.namespace = os.environ.get('POD_NAMESPACE', 'default')
 
-# Use env var for this, since we want hub to restart when this changes
-c.KubeSpawner.image_spec = os.environ['SINGLEUSER_IMAGE']
 
 for trait, cfg_key in (
     ('start_timeout', 'start-timeout'),
@@ -68,6 +66,7 @@ for trait, cfg_key in (
 ):
     set_config_if_not_none(c.KubeSpawner, trait, 'singleuser.' + cfg_key)
 
+c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -137,6 +137,7 @@ data:
   singleuser.cloud-metadata: |
     {{- .Values.singleuser.cloudMetadata | toYaml | trimSuffix "\n" | nindent 4 }}
   singleuser.start-timeout: {{ .Values.singleuser.startTimeout | quote }}
+  singleuser.image-spec: {{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}
   singleuser.image-pull-policy: {{ .Values.singleuser.image.pullPolicy | quote }}
   {{- if .Values.singleuser.imagePullSecret.enabled }}
   singleuser.image-pull-secret-name: singleuser-image-credentials

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -118,9 +118,6 @@ spec:
             {{- .Values.hub.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           imagePullPolicy: {{ .Values.hub.imagePullPolicy }}
           env:
-            {{- /* Put this here directly so hub will restart when we change this */}}
-            - name: SINGLEUSER_IMAGE
-              value: "{{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}"
             {{- if .Values.hub.cookieSecret }}
             - name: JPY_COOKIE_SECRET
               valueFrom:


### PR DESCRIPTION
We are now using a trick to restart the hub whenever the hash of the
hub's configmap changes. This commit modernizes old logic from when
that trick wasn't in use and reduces the need for an inline explanation
of the code.

Note that this doesn't influence any behavior, it only reduces confusion for developers getting mixed messages about how things work.

---

PS: leaving all refactoring or best practice fixing of jupyterhub_config.py until the final PR where all those are fixed, in order to avoid a challenge of merging/rebasing etc with several PRs to come.