### PR TITLE
Fix running multiple hubs in same cluster

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -215,7 +215,7 @@ data:
   {{- end }}
 
   {{- if .Values.scheduling.userScheduler.enabled }}
-  singleuser.scheduler-name: "user-scheduler"
+  singleuser.scheduler-name: "{{ .Release.Name }}-user-scheduler"
   {{- end }}
 
   {{- /* KubeSpawner */}}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           image: {{ include "jupyterhub.scheduler.image" . }}
           command:
             - /usr/local/bin/kube-scheduler
-            - --scheduler-name=user-scheduler
+            - --scheduler-name={{ .Release.Name }}-user-scheduler
             - --policy-configmap=user-scheduler
             - --policy-configmap-namespace={{ .Release.Namespace }}
             - --lock-object-name=user-scheduler

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: user-scheduler-base
+  name: {{ .Release.Name }}-user-scheduler-base
   labels:
     {{- $_ := merge (dict "componentSuffix" "-base") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
@@ -26,7 +26,7 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: user-scheduler-complementary
+  name: {{ .Release.Name }}-user-scheduler-complementary
   labels:
     {{- $_ := merge (dict "componentSuffix" "-complementary") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
@@ -44,7 +44,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: user-scheduler-complementary
+  name: {{ .Release.Name }}-user-scheduler-complementary
   labels:
     {{- $_ := merge (dict "componentSuffix" "-complementary") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
@@ -54,7 +54,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: user-scheduler-complementary
+  name: {{ .Release.Name }}-user-scheduler-complementary
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Cluster wide objects should be prefixed with the release name,
so we can have multiples hubs in the same cluster. For the
user-scheduler, this involves:

1. RBAC ClusterRoles & RoleBindings
2. Scheduler Name