### PR TITLE
[Part 6 of #758] Storage labels: configurable extras

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -65,6 +65,7 @@ for trait, cfg_key in (
     ('node_selector', 'node-selector'),
 ):
     set_config_if_not_none(c.KubeSpawner, trait, 'singleuser.' + cfg_key)
+c.KubeSpawner.storage_extra_labels = get_config('singleuser.storage-extra-labels', {})
 
 c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
 # Configure dynamically provisioning pvc

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -208,6 +208,12 @@ data:
     {{- range $key, $value := .Values.singleuser.extraLabels }}
     {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.singleuser.storage.extraLabels }}
+  singleuser.storage-extra-labels: |
+    {{- range $key, $value := .Values.singleuser.storage.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   {{- if .Values.singleuser.extraEnv }}
   singleuser.extra-env: |
     {{- range $key, $value := .Values.singleuser.extraEnv }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -171,6 +171,7 @@ singleuser:
   serviceAccountName:
   storage:
     type: dynamic
+    extraLabels: {}
     extraVolumes: []
     extraVolumeMounts: []
     static:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -172,7 +172,6 @@ singleuser:
                 - 169.254.169.254/32
   events: true
   extraLabels: {}
-  storageExtraLabels: {}
   extraEnv: {}
   lifecycleHooks:
   initContainers:
@@ -188,6 +187,8 @@ singleuser:
   serviceAccountName:
   storage:
     type: dynamic
+    extraLabels:
+      mock-label: mock-value
     extraVolumes: []
     extraVolumeMounts: []
     static:


### PR DESCRIPTION
## To review
- [**Storage labels: configurable extras**](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/924/commits/a95873b17309c5ca71642b68b34fa6a3698e61e1)

## TODO:
- [x] Change to storage.extraLabels

---

## TODO
- [x] Delete storage-kind label, it is not needed with other labels in place such as `component: hub` on the hub-db-dir PVC and `component: singleuser-storage` on the user PVCs.