### PR TITLE
[Part 10 of #758] Added `scheduling.podPriority`

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -65,6 +65,7 @@ for trait, cfg_key in (
     ('node_selector', 'node-selector'),
 ):
     set_config_if_not_none(c.KubeSpawner, trait, 'singleuser.' + cfg_key)
+c.KubeSpawner.storage_extra_labels = get_config('singleuser.storage-extra-labels', {})
 
 c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
 # Configure dynamically provisioning pvc

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -68,6 +68,7 @@ for trait, cfg_key in (
 c.KubeSpawner.storage_extra_labels = get_config('singleuser.storage-extra-labels', {})
 
 c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
+c.KubeSpawner.tolerations.extend(get_config('singleuser.tolerations', []))
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -67,6 +67,8 @@ for trait, cfg_key in (
 c.KubeSpawner.storage_extra_labels = get_config('singleuser.storage-extra-labels', {})
 
 c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
+c.KubeSpawner.priority_class_name = get_config('singleuser.priority-class-name', "")
+
 c.KubeSpawner.tolerations.extend(get_config('singleuser.tolerations', []))
 c.KubeSpawner.node_selector.update(get_config('singleuser.node-selector', {}))
 c.KubeSpawner.node_affinity_required.extend(get_config('singleuser.node-affinity-required', []))

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -62,13 +62,19 @@ for trait, cfg_key in (
     ('fs_gid', 'fs-gid'),
     ('service_account', 'service-account-name'),
     ('scheduler_name', 'scheduler-name'),
-    ('node_selector', 'node-selector'),
 ):
     set_config_if_not_none(c.KubeSpawner, trait, 'singleuser.' + cfg_key)
 c.KubeSpawner.storage_extra_labels = get_config('singleuser.storage-extra-labels', {})
 
 c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
 c.KubeSpawner.tolerations.extend(get_config('singleuser.tolerations', []))
+c.KubeSpawner.node_selector.update(get_config('singleuser.node-selector', {}))
+c.KubeSpawner.node_affinity_required.extend(get_config('singleuser.node-affinity-required', []))
+c.KubeSpawner.node_affinity_preferred.extend(get_config('singleuser.node-affinity-preferred', []))
+c.KubeSpawner.pod_affinity_required.extend(get_config('singleuser.pod-affinity-required', []))
+c.KubeSpawner.pod_affinity_preferred.extend(get_config('singleuser.pod-affinity-preferred', []))
+c.KubeSpawner.pod_anti_affinity_required.extend(get_config('singleuser.pod-anti-affinity-required', []))
+c.KubeSpawner.pod_anti_affinity_preferred.extend(get_config('singleuser.pod-anti-affinity-preferred', []))
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -476,6 +476,65 @@ properties:
           Pass this field an array of
           [`Toleration`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core)
           objects.
+      extraNodeAffinity:
+        type: object
+        description: |
+          Affinities describe where pods prefer or require to be scheduled, they
+          may prefer or require a node where they are to be scheduled to have a
+          certain label (node affinity). They may also require to be scheduled
+          in proximity or with a lack of proximity to another pod (pod affinity
+          and anti pod affinity).
+          
+          See the [Kubernetes
+          docs](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
+          for more info.
+        properties:
+          required:
+            type: list
+            description: |
+              Pass this field an array of
+              [`NodeSelectorTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#nodeselectorterm-v1-core)
+              objects.
+          preferred:
+            type: list
+            description: |
+              Pass this field an array of
+              [`PreferredSchedulingTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#preferredschedulingterm-v1-core)
+              objects.
+      extraPodAffinity:
+        type: object
+        description: |
+          See the description of `singleuser.extraNodeAffinity`.
+        properties:
+          required:
+            type: list
+            description: |
+              Pass this field an array of
+              [`PodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podaffinityterm-v1-core)
+              objects.
+          preferred:
+            type: list
+            description: |
+              Pass this field an array of
+              [`WeightedPodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#weightedpodaffinityterm-v1-core)
+              objects.
+      extraPodAntiAffinity:
+        type: object
+        description: |
+          See the description of `singleuser.extraNodeAffinity`.
+        properties:
+          required:
+            type: list
+            description: |
+              Pass this field an array of
+              [`PodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podaffinityterm-v1-core)
+              objects.
+          preferred:
+            type: list
+            description: |
+              Pass this field an array of
+              [`WeightedPodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#weightedpodaffinityterm-v1-core)
+              objects.
 
 
   scheduling:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -570,3 +570,51 @@ properties:
                 type:
                   - string
                   - "null"
+      corePods:
+        type: object
+        description: |
+          These settings influence the core pods like the hub, proxy and
+          user-scheduler pods.
+        properties:
+          nodeAffinity:
+            type: object
+            description: |
+              Where should pods be scheduled? Perhaps on nodes with a certain
+              label is preferred or even required?
+            properties:
+              matchNodePurpose:
+                type: string
+                enum:
+                  - ignore
+                  - prefer
+                  - require
+                description: |
+                  Decide if core pods *ignore*, *prefer* or *require* to
+                  schedule on nodes with this label:
+                  ```
+                  hub.jupyter.org/node-purpose=core
+                  ```
+      userPods:
+        type: object
+        description: |
+          These settings influence the user pods like the user-placeholder,
+          user-dummy and actual user pods named like jupyter-someusername.
+        properties:
+          nodeAffinity:
+            type: object
+            description: |
+              Where should pods be scheduled? Perhaps on nodes with a certain
+              label is preferred or even required?
+            properties:
+              matchNodePurpose:
+                type: string
+                enum:
+                  - ignore
+                  - prefer
+                  - require
+                description: |
+                  Decide if user pods *ignore*, *prefer* or *require* to
+                  schedule on nodes with this label:
+                  ```
+                  hub.jupyter.org/node-purpose=user
+                  ```

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -570,6 +570,17 @@ properties:
                 type:
                   - string
                   - "null"
+      podPriority:
+        type: object
+        description: |
+          Generally available since Kubernetes 1.11, Pod Priority is used to
+          allow real users evict placeholder pods.
+        properties:
+          enabled:
+            type: bool
+            description: |
+              Generally available since Kubernetes 1.11, Pod Priority is used to
+              allow real users evict placeholder pods.
       corePods:
         type: object
         description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -460,6 +460,22 @@ properties:
         description: |
           Deprecated and no longer does anything. Use the user-scheduler instead
           in order to accomplish a good packing of the user pods.
+      extraTolerations:
+        type: list
+        description: |
+          Tolerations allow a pod to be scheduled on nodes with taints. These
+          are additional tolerations other than the user pods and core pods
+          default ones `hub.jupyter.org/dedicated=user:NoSchedule` or
+          `hub.jupyter.org/dedicated=core:NoSchedule`. Note that a duplicate set
+          of tolerations exist where `/` is replaced with `_` as the Google
+          cloud does not support the character `/` yet in the toleration.
+
+          See the [Kubernetes docs](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+          for more info.
+
+          Pass this field an array of
+          [`Toleration`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core)
+          objects.
 
 
   scheduling:

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -224,6 +224,31 @@ data:
   singleuser.tolerations: |
     {{- include "jupyterhub.userTolerations" . | nindent 4 }}
 
+  {{- if include "jupyterhub.userNodeAffinityRequired" . }}
+  singleuser.node-affinity-required: |
+    {{- include "jupyterhub.userNodeAffinityRequired" . | nindent 4 }}
+  {{- end }}
+  {{- if include "jupyterhub.userNodeAffinityPreferred" . }}
+  singleuser.node-affinity-preferred: |
+    {{- include "jupyterhub.userNodeAffinityPreferred" . | nindent 4 }}
+  {{- end }}
+  {{- if include "jupyterhub.userPodAffinityRequired" . }}
+  singleuser.pod-affinity-required: |
+    {{- include "jupyterhub.userPodAffinityRequired" . | nindent 4 }}
+  {{- end }}
+  {{- if include "jupyterhub.userPodAffinityPreferred" . }}
+  singleuser.pod-affinity-preferred: |
+    {{- include "jupyterhub.userPodAffinityPreferred" . | nindent 4 }}
+  {{- end }}
+  {{- if include "jupyterhub.userPodAntiAffinityRequired" . }}
+  singleuser.pod-anti-affinity-required: |
+    {{- include "jupyterhub.userPodAntiAffinityRequired" . | nindent 4 }}
+  {{- end }}
+  {{- if include "jupyterhub.userPodAntiAffinityPreferred" . }}
+  singleuser.pod-anti-affinity-preferred: |
+    {{- include "jupyterhub.userPodAntiAffinityPreferred" . | nindent 4 }}
+  {{- end }}
+
   {{- if .Values.scheduling.userScheduler.enabled }}
   singleuser.scheduler-name: "{{ .Release.Name }}-user-scheduler"
   {{- end }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -221,6 +221,9 @@ data:
     {{- end }}
   {{- end }}
 
+  singleuser.tolerations: |
+    {{- include "jupyterhub.userTolerations" . | nindent 4 }}
+
   {{- if .Values.scheduling.userScheduler.enabled }}
   singleuser.scheduler-name: "{{ .Release.Name }}-user-scheduler"
   {{- end }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -208,6 +208,12 @@ data:
     {{- range $key, $value := .Values.singleuser.extraLabels }}
     {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.singleuser.storage.extraLabels }}
+  singleuser.storage-extra-labels: |
+    {{- range $key, $value := .Values.singleuser.storage.extraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   {{- if .Values.singleuser.extraEnv }}
   singleuser.extra-env: |
     {{- range $key, $value := .Values.singleuser.extraEnv }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -252,6 +252,9 @@ data:
   {{- if .Values.scheduling.userScheduler.enabled }}
   singleuser.scheduler-name: "{{ .Release.Name }}-user-scheduler"
   {{- end }}
+  {{- if .Values.scheduling.podPriority.enabled }}
+  singleuser.priority_class_name: "{{ .Release.Name }}-default-priority"
+  {{- end }}
 
   {{- /* KubeSpawner */}}
   kubespawner.common-labels: |

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- .Values.hub.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.scheduling.podPriority.enabled }}
+      priorityClassName: {{ .Release.Name }}-default-priority
+      {{- end }}
       nodeSelector: {{ toJson .Values.hub.nodeSelector }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       volumes:

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -31,20 +31,7 @@ spec:
         {{- end }}
     spec:
       nodeSelector: {{ toJson .Values.hub.nodeSelector }}
-      affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: component
-                      operator: In
-                      values: ['proxy']
-                    - key: release
-                      operator: In
-                      values: [{{ .Release.Name | quote }}]
+      {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       volumes:
         - name: config
           configMap:

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -36,6 +36,8 @@ spec:
         {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
+      tolerations:
+        {{- include "jupyterhub.userTolerations" . | nindent 8 }}
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
       {{- if .Values.singleuser.imagePullSecret.enabled }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -38,6 +38,14 @@ spec:
     spec:
       tolerations:
         {{- include "jupyterhub.userTolerations" . | nindent 8 }}
+      nodeSelector: {{ toJson .Values.singleuser.nodeSelector }}
+      {{- if include "jupyterhub.userNodeAffinityRequired" . }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              {{- include "jupyterhub.userNodeAffinityRequired" . | nindent 14 }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
       {{- if .Values.singleuser.imagePullSecret.enabled }}
@@ -79,7 +87,6 @@ spec:
             - -c
             - echo "Pulling complete"
         {{- end }}
-      nodeSelector: {{ toJson .Values.singleuser.nodeSelector }}
       containers:
         - name: pause
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -35,22 +35,9 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: autohttps
       {{- end }}
-      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
       terminationGracePeriodSeconds: 60
-      affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: component
-                      operator: In
-                      values: ['hub']
-                    - key: release
-                      operator: In
-                      values: [{{ .Release.Name | quote }}]
+      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
+      {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       containers:
         - name: nginx
           image: "{{ .Values.proxy.nginx.image.name }}:{{ .Values.proxy.nginx.image.tag }}"

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -35,6 +35,9 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: autohttps
       {{- end }}
+      {{- if .Values.scheduling.podPriority.enabled }}
+      priorityClassName: {{ .Release.Name }}-default-priority
+      {{- end }}
       terminationGracePeriodSeconds: 60
       nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -29,22 +29,9 @@ spec:
         {{- .Values.proxy.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
-      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
       terminationGracePeriodSeconds: 60
-      affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: component
-                      operator: In
-                      values: ['hub']
-                    - key: release
-                      operator: In
-                      values: [{{ .Release.Name | quote }}]
+      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
+      {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       {{- if $manualHTTPSwithsecret }}
       volumes:
         - name: tls-secret

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 60
+      {{- if .Values.scheduling.podPriority.enabled }}
+      priorityClassName: {{ .Release.Name }}-default-priority
+      {{- end }}
       nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       {{- if $manualHTTPSwithsecret }}

--- a/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
+++ b/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
@@ -1,0 +1,17 @@
+{{- /*
+  jupyterhub.userTolerations
+    Lists the tolerations for node taints that the user pods should have
+*/}}
+{{- define "jupyterhub.userTolerations" -}}
+- key: hub.jupyter.org_dedicated
+  operator: Equal
+  value: user
+  effect: NoSchedule
+- key: hub.jupyter.org/dedicated
+  operator: Equal
+  value: user
+  effect: NoSchedule
+{{- if .Values.singleuser.extraTolerations }}
+{{- .Values.singleuser.extraTolerations | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
+++ b/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
@@ -15,3 +15,41 @@
 {{- .Values.singleuser.extraTolerations | toYaml | trimSuffix "\n" | nindent 0 }}
 {{- end }}
 {{- end }}
+
+
+
+{{- define "jupyterhub.userNodeAffinityRequired" -}}
+{{- if .Values.singleuser.extraNodeAffinity.required -}}
+{{ .Values.singleuser.extraNodeAffinity.required | toYaml | trimSuffix "\n" }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.userNodeAffinityPreferred" -}}
+{{- if .Values.singleuser.extraNodeAffinity.preferred -}}
+{{ .Values.singleuser.extraNodeAffinity.preferred | toYaml | trimSuffix "\n" }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.userPodAffinityRequired" -}}
+{{- if .Values.singleuser.extraPodAffinity.required -}}
+{{ .Values.singleuser.extraPodAffinity.required | toYaml | trimSuffix "\n" }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.userPodAffinityPreferred" -}}
+{{- if .Values.singleuser.extraPodAffinity.preferred -}}
+{{ .Values.singleuser.extraPodAffinity.preferred | toYaml | trimSuffix "\n" }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.userPodAntiAffinityRequired" -}}
+{{- if .Values.singleuser.extraPodAntiAffinity.required -}}
+{{ .Values.singleuser.extraPodAntiAffinity.required | toYaml | trimSuffix "\n" }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.userPodAntiAffinityPreferred" -}}
+{{- if .Values.singleuser.extraPodAntiAffinity.preferred -}}
+{{ .Values.singleuser.extraPodAntiAffinity.preferred | toYaml | trimSuffix "\n" }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/scheduling/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/priorityclass.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.scheduling.podPriority.enabled }}
+apiVersion: scheduling.k8s.io/v1alpha1
+kind: PriorityClass
+metadata:
+  name: {{ .Release.Name }}-default-priority
+  labels:
+    {{- $_ := merge (dict "componentLabel" "default-priority") . }}
+    {{- include "jupyterhub.labels" $_ | nindent 4 }}
+  annotations:
+    # The default PriorityClass must be added before the other resources.
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-100"
+value: 10
+globalDefault: false
+description: "A default priority higher than user placeholders priority."
+{{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       serviceAccountName: user-scheduler
       {{- end }}
       nodeSelector: {{ toJson .Values.scheduling.userScheduler.nodeSelector }}
+      {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       containers:
         - name: user-scheduler
           image: {{ include "jupyterhub.scheduler.image" . }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: user-scheduler
       {{- end }}
+      {{- if .Values.scheduling.podPriority.enabled }}
+      priorityClassName: {{ .Release.Name }}-default-priority
+      {{- end }}
       nodeSelector: {{ toJson .Values.scheduling.userScheduler.nodeSelector }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       containers:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -234,6 +234,8 @@ scheduling:
       requests:
         cpu: 50m
         memory: 256Mi
+  podPriority:
+    enabled: false
   corePods:
     nodeAffinity:
       matchNodePurpose: prefer

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -143,6 +143,16 @@ auth:
 
 singleuser:
   extraTolerations: []
+  nodeSelector: {}
+  extraNodeAffinity:
+    required: []
+    preferred: []
+  extraPodAffinity:
+    required: []
+    preferred: []
+  extraPodAntiAffinity:
+    required: []
+    preferred: []
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools
@@ -166,7 +176,6 @@ singleuser:
   lifecycleHooks:
   initContainers: []
   extraContainers: []
-  nodeSelector: {}
   uid: 1000
   fsGid: 100
   serviceAccountName:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -234,6 +234,12 @@ scheduling:
       requests:
         cpu: 50m
         memory: 256Mi
+  corePods:
+    nodeAffinity:
+      matchNodePurpose: prefer
+  userPods:
+    nodeAffinity:
+      matchNodePurpose: prefer
 
 
 prePuller:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -142,6 +142,7 @@ auth:
 
 
 singleuser:
+  extraTolerations: []
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -171,6 +171,7 @@ singleuser:
   serviceAccountName:
   storage:
     type: dynamic
+    extraLabels: {}
     extraVolumes: []
     extraVolumeMounts: []
     static:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -149,7 +149,11 @@ auth:
 singleuser:
   nodeSelector:
     mock-node-selector: mock
-  extraTolerations: []
+  extraTolerations:
+    - key: hub.jupyter.org/test
+      operator: Equal
+      value: test
+      effect: NoSchedule
   extraNodeAffinity:
     required: []
     preferred: []

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -272,6 +272,12 @@ scheduling:
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
       tag: v1.11.2
+  corePods:
+    nodeAffinity:
+      matchNodePurpose: require
+  userPods:
+    nodeAffinity:
+      matchNodePurpose: require
 
 
 prePuller:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -172,7 +172,6 @@ singleuser:
                 - 169.254.169.254/32
   events: true
   extraLabels: {}
-  storageExtraLabels: {}
   extraEnv: {}
   lifecycleHooks:
   initContainers:
@@ -188,6 +187,8 @@ singleuser:
   serviceAccountName:
   storage:
     type: dynamic
+    extraLabels:
+      mock-label: mock-value
     extraVolumes: []
     extraVolumeMounts: []
     static:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -105,7 +105,7 @@ proxy:
     enabled: true
   https:
     enabled: true
-    type: manual
+    type: letsencrypt
     #type: letsencrypt, manual, secret
     letsencrypt:
       contactEmail: 'e@domain.com'
@@ -155,14 +155,52 @@ singleuser:
       value: test
       effect: NoSchedule
   extraNodeAffinity:
-    required: []
-    preferred: []
+    required:
+      - matchExpressions:
+        - key: hub.jupyter.org/test-required-node
+          operator: In
+          values: [test]
+    preferred:
+      - weight: 10
+        preference:
+          matchExpressions:
+          - key: hub.jupyter.org/test-preferred-node
+            operator: In
+            values: [test]
   extraPodAffinity:
-    required: []
-    preferred: []
+    required:
+      - labelSelector:
+          matchExpressions:
+          - key: hub.jupyter.org/test-required-pod
+            operator: In
+            values: [test]
+        topologyKey: failure-domain.beta.kubernetes.io/zone
+    preferred:
+      - weight: 10
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: hub.jupyter.org/test-preferred-pod
+              operator: In
+              values: [test]
+          topologyKey: kubernetes.io/hostname
   extraPodAntiAffinity:
-    required: []
-    preferred: []
+    required:
+      - labelSelector:
+          matchExpressions:
+          - key: hub.jupyter.org/test-required-anti-pod
+            operator: In
+            values: [test]
+        topologyKey: failure-domain.beta.kubernetes.io/zone
+    preferred:
+      - weight: 10
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: hub.jupyter.org/test-preferred-anti-pod
+              operator: In
+              values: [test]
+          topologyKey: kubernetes.io/hostname
   cloudMetadata:
     enabled: true
     ip: 169.254.169.254

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -272,6 +272,8 @@ scheduling:
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
       tag: v1.11.2
+  podPriority:
+    enabled: true
   corePods:
     nodeAffinity:
       matchNodePurpose: require


### PR DESCRIPTION
## To review

- [**Added `scheduling.podPriority` option**](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/928/commits/e774b7dd271118fd5ee2d060fa8b1fccd7bfa0ab)

---

## TODO
- [x] Make `{{- if .Values.scheduling.podPriority }}` be `{{- if .Values.scheduling.podPriority.enabled }}` - thanks @minrk

## About

Pod priority requires k8s 1.11 and is a foundational functionality in order for us to use user-placeholder pods to create a headroom on nodes. This is also referred to as over provisioning. They can with a lower priority be evicted when a real user needs a place to be scheduled but cant fit on a node with them there, but at the same time when they are left unscheduled, will cause a node scaleup if an autoscaler is enabled.