### PR TITLE
[Part 9 of #758] Preset: `scheduling.nodeAffinity.matchNodePurpose`

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -65,6 +65,10 @@ for trait, cfg_key in (
     ('node_selector', 'node-selector'),
 ):
     set_config_if_not_none(c.KubeSpawner, trait, 'singleuser.' + cfg_key)
+c.KubeSpawner.storage_extra_labels = get_config('singleuser.storage-extra-labels', {})
+c.KubeSpawner.storage_extra_labels.update({
+    "hub.jupyter.org/storage-kind": "user"
+})
 
 c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
 # Configure dynamically provisioning pvc

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -50,8 +50,6 @@ set_config_if_not_none(c.KubeSpawner, 'common_labels', 'kubespawner.common-label
 
 c.KubeSpawner.namespace = os.environ.get('POD_NAMESPACE', 'default')
 
-# Use env var for this, since we want hub to restart when this changes
-c.KubeSpawner.image_spec = os.environ['SINGLEUSER_IMAGE']
 
 for trait, cfg_key in (
     ('start_timeout', 'start-timeout'),
@@ -68,6 +66,7 @@ for trait, cfg_key in (
 ):
     set_config_if_not_none(c.KubeSpawner, trait, 'singleuser.' + cfg_key)
 
+c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -74,6 +74,7 @@ c.KubeSpawner.storage_extra_labels.update({
 })
 
 c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
+c.KubeSpawner.tolerations.extend(get_config('singleuser.tolerations', []))
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -45,6 +45,10 @@ c.JupyterHub.port = int(os.environ['PROXY_PUBLIC_SERVICE_PORT'])
 
 # the hub should listen on all interfaces, so the proxy can access it
 c.JupyterHub.hub_ip = '0.0.0.0'
+c.KubeSpawner.extra_labels = get_config('singleuser.extra-labels', {})
+c.KubeSpawner.extra_labels.update({
+    "hub.jupyter.org/pod-kind": "user"
+})
 
 set_config_if_not_none(c.KubeSpawner, 'common_labels', 'kubespawner.common-labels')
 
@@ -56,7 +60,6 @@ for trait, cfg_key in (
     ('image_pull_policy', 'image-pull-policy'),
     ('image_pull_secrets', 'image-pull-secret-name'),
     ('events_enabled', 'events'),
-    ('extra_labels', 'extra-labels'),
     ('extra_annotations', 'extra-annotations'),
     ('uid', 'uid'),
     ('fs_gid', 'fs-gid'),

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -65,7 +65,6 @@ for trait, cfg_key in (
     ('fs_gid', 'fs-gid'),
     ('service_account', 'service-account-name'),
     ('scheduler_name', 'scheduler-name'),
-    ('node_selector', 'node-selector'),
 ):
     set_config_if_not_none(c.KubeSpawner, trait, 'singleuser.' + cfg_key)
 c.KubeSpawner.storage_extra_labels = get_config('singleuser.storage-extra-labels', {})
@@ -75,6 +74,13 @@ c.KubeSpawner.storage_extra_labels.update({
 
 c.KubeSpawner.image_spec = get_config('singleuser.image-spec')
 c.KubeSpawner.tolerations.extend(get_config('singleuser.tolerations', []))
+c.KubeSpawner.node_selector.update(get_config('singleuser.node-selector', {}))
+c.KubeSpawner.node_affinity_required.extend(get_config('singleuser.node-affinity-required', []))
+c.KubeSpawner.node_affinity_preferred.extend(get_config('singleuser.node-affinity-preferred', []))
+c.KubeSpawner.pod_affinity_required.extend(get_config('singleuser.pod-affinity-required', []))
+c.KubeSpawner.pod_affinity_preferred.extend(get_config('singleuser.pod-affinity-preferred', []))
+c.KubeSpawner.pod_anti_affinity_required.extend(get_config('singleuser.pod-anti-affinity-required', []))
+c.KubeSpawner.pod_anti_affinity_preferred.extend(get_config('singleuser.pod-anti-affinity-preferred', []))
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -476,6 +476,65 @@ properties:
           Pass this field an array of
           [`Toleration`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core)
           objects.
+      extraNodeAffinity:
+        type: object
+        description: |
+          Affinities describe where pods prefer or require to be scheduled, they
+          may prefer or require a node where they are to be scheduled to have a
+          certain label (node affinity). They may also require to be scheduled
+          in proximity or with a lack of proximity to another pod (pod affinity
+          and anti pod affinity).
+          
+          See the [Kubernetes
+          docs](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
+          for more info.
+        properties:
+          required:
+            type: list
+            description: |
+              Pass this field an array of
+              [`NodeSelectorTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#nodeselectorterm-v1-core)
+              objects.
+          preferred:
+            type: list
+            description: |
+              Pass this field an array of
+              [`PreferredSchedulingTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#preferredschedulingterm-v1-core)
+              objects.
+      extraPodAffinity:
+        type: object
+        description: |
+          See the description of `singleuser.extraNodeAffinity`.
+        properties:
+          required:
+            type: list
+            description: |
+              Pass this field an array of
+              [`PodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podaffinityterm-v1-core)
+              objects.
+          preferred:
+            type: list
+            description: |
+              Pass this field an array of
+              [`WeightedPodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#weightedpodaffinityterm-v1-core)
+              objects.
+      extraPodAntiAffinity:
+        type: object
+        description: |
+          See the description of `singleuser.extraNodeAffinity`.
+        properties:
+          required:
+            type: list
+            description: |
+              Pass this field an array of
+              [`PodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podaffinityterm-v1-core)
+              objects.
+          preferred:
+            type: list
+            description: |
+              Pass this field an array of
+              [`WeightedPodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#weightedpodaffinityterm-v1-core)
+              objects.
 
 
   scheduling:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -460,6 +460,22 @@ properties:
         description: |
           Deprecated and no longer does anything. Use the user-scheduler instead
           in order to accomplish a good packing of the user pods.
+      tolerations:
+        type: list
+        description: |
+          Tolerations allow a pod to be scheduled on nodes with taints. These
+          are additional tolerations other than the user pods and core pods
+          default ones `hub.jupyter.org/dedicated=user:NoSchedule` or
+          `hub.jupyter.org/dedicated=core:NoSchedule`. Note that a duplicate set
+          of tolerations exist where `/` is replaced with `_` as the Google
+          cloud does not support the character `/` yet in the toleration.
+
+          See the [Kubernetes docs](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+          for more info.
+
+          Pass this field an array of
+          [`Toleration`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core)
+          objects.
 
 
   scheduling:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -570,3 +570,51 @@ properties:
                 type:
                   - string
                   - "null"
+      corePods:
+        type: object
+        description: |
+          These settings influence the core pods like the hub, proxy and
+          user-scheduler pods.
+        properties:
+          nodeAffinity:
+            type: object
+            description: |
+              Where should pods be scheduled? Perhaps on nodes with a certain
+              label is preferred or even required?
+            properties:
+              matchNodePurpose:
+                type: string
+                enum:
+                  - ignore
+                  - prefer
+                  - require
+                description: |
+                  Decide if core pods *ignore*, *prefer* or *require* to
+                  schedule on nodes with this label:
+                  ```
+                  hub.jupyter.org/node-purpose=core
+                  ```
+      userPods:
+        type: object
+        description: |
+          These settings influence the user pods like the user-placeholder,
+          user-dummy and actual user pods named like jupyter-someusername.
+        properties:
+          nodeAffinity:
+            type: object
+            description: |
+              Where should pods be scheduled? Perhaps on nodes with a certain
+              label is preferred or even required?
+            properties:
+              matchNodePurpose:
+                type: string
+                enum:
+                  - ignore
+                  - prefer
+                  - require
+                description: |
+                  Decide if user pods *ignore*, *prefer* or *require* to
+                  schedule on nodes with this label:
+                  ```
+                  hub.jupyter.org/node-purpose=user
+                  ```

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -221,6 +221,13 @@ data:
     {{- end }}
   {{- end }}
 
+  {{- $_ := merge (dict "podKind" "user") . }}
+  {{- include "jupyterhub.prepareScope" $_ }}
+  {{- if $_.hasTolerations }}
+  singleuser.tolerations: |
+    {{- $_.tolerationsList | nindent 4 }}
+  {{- end }}
+
   {{- if .Values.scheduling.userScheduler.enabled }}
   singleuser.scheduler-name: "{{ .Release.Name }}-user-scheduler"
   {{- end }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -227,6 +227,30 @@ data:
   singleuser.tolerations: |
     {{- $_.tolerationsList | nindent 4 }}
   {{- end }}
+  {{- if $_.nodeAffinityRequired }}
+  singleuser.node-affinity-required: |
+    {{- $_.nodeAffinityRequired | nindent 4 }}
+  {{- end }}
+  {{- if $_.nodeAffinityPreferred }}
+  singleuser.node-affinity-preferred: |
+    {{- $_.nodeAffinityPreferred | nindent 4 }}
+  {{- end }}
+  {{- if $_.podAffinityRequired }}
+  singleuser.pod-affinity-required: |
+    {{- $_.podAffinityRequired | nindent 4 }}
+  {{- end }}
+  {{- if $_.podAffinityPreferred }}
+  singleuser.pod-affinity-preferred: |
+    {{- $_.podAffinityPreferred | nindent 4 }}
+  {{- end }}
+  {{- if $_.podAntiAffinityRequired }}
+  singleuser.pod-anti-affinity-required: |
+    {{- $_.podAntiAffinityRequired | nindent 4 }}
+  {{- end }}
+  {{- if $_.podAntiAffinityPreferred }}
+  singleuser.pod-anti-affinity-preferred: |
+    {{- $_.podAntiAffinityPreferred | nindent 4 }}
+  {{- end }}
 
   {{- if .Values.scheduling.userScheduler.enabled }}
   singleuser.scheduler-name: "{{ .Release.Name }}-user-scheduler"

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -208,6 +208,12 @@ data:
     {{- range $key, $value := .Values.singleuser.extraLabels }}
     {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.singleuser.storageExtraLabels }}
+  singleuser.storage-extra-labels: |
+    {{- range $key, $value := .Values.singleuser.storageExtraLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   {{- if .Values.singleuser.extraEnv }}
   singleuser.extra-env: |
     {{- range $key, $value := .Values.singleuser.extraEnv }}

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -137,6 +137,7 @@ data:
   singleuser.cloud-metadata: |
     {{- .Values.singleuser.cloudMetadata | toYaml | trimSuffix "\n" | nindent 4 }}
   singleuser.start-timeout: {{ .Values.singleuser.startTimeout | quote }}
+  singleuser.image-spec: {{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}
   singleuser.image-pull-policy: {{ .Values.singleuser.image.pullPolicy | quote }}
   {{- if .Values.singleuser.imagePullSecret.enabled }}
   singleuser.image-pull-secret-name: singleuser-image-credentials

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -118,9 +118,6 @@ spec:
             {{- .Values.hub.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           imagePullPolicy: {{ .Values.hub.imagePullPolicy }}
           env:
-            {{- /* Put this here directly so hub will restart when we change this */}}
-            - name: SINGLEUSER_IMAGE
-              value: "{{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}"
             {{- if .Values.hub.cookieSecret }}
             - name: JPY_COOKIE_SECRET
               valueFrom:

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -31,25 +31,14 @@ spec:
         {{- .Values.hub.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
-      nodeSelector: {{ toJson .Values.hub.nodeSelector }}
-      affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: component
-                      operator: In
-                      values: ['proxy']
-                    - key: release
-                      operator: In
-                      values: [{{ .Release.Name | quote }}]
       {{- $_ := merge (dict "podKind" "core") . }}
       {{- $dummy := include "jupyterhub.prepareScope" $_ }}
       {{- if $_.hasTolerations }}
       {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
+      {{- end }}
+      nodeSelector: {{ toJson .Values.hub.nodeSelector }}
+      {{- if $_.hasAffinity }}
+      {{- include "jupyterhub.affinity" $_ | nindent 6 }}
       {{- end }}
       volumes:
         - name: config

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        hub.jupyter.org/pod-kind: "core"
         hub.jupyter.org/network-access-proxy-api: "true"
         hub.jupyter.org/network-access-proxy-http: "true"
         hub.jupyter.org/network-access-singleuser: "true"

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -46,6 +46,11 @@ spec:
                     - key: release
                       operator: In
                       values: [{{ .Release.Name | quote }}]
+      {{- $_ := merge (dict "podKind" "core") . }}
+      {{- $dummy := include "jupyterhub.prepareScope" $_ }}
+      {{- if $_.hasTolerations }}
+      {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
+      {{- end }}
       volumes:
         - name: config
           configMap:

--- a/jupyterhub/templates/hub/pvc.yaml
+++ b/jupyterhub/templates/hub/pvc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: hub-db-dir
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+    hub.jupyter.org/storage-kind: "core"
   {{- if .Values.hub.db.pvc.annotations }}
   annotations:
     {{- .Values.hub.db.pvc.annotations | toYaml | trimSuffix "\n" | nindent 4 }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -41,6 +41,14 @@ spec:
       {{- if $_.hasTolerations }}
       {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
       {{- end }}
+      nodeSelector: {{ toJson .Values.singleuser.nodeSelector }}
+      {{- if $_.nodeAffinityRequired }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              {{- $_.nodeAffinityRequired | nindent 14 }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
       {{- if .Values.singleuser.imagePullSecret.enabled }}
@@ -82,7 +90,6 @@ spec:
             - -c
             - echo "Pulling complete"
         {{- end }}
-      nodeSelector: {{ toJson .Values.singleuser.nodeSelector }}
       containers:
         - name: pause
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -36,6 +36,11 @@ spec:
         {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
+      {{- $_ := merge (dict "podKind" "user" "daemonSet" true) . }}
+      {{- $dummy := include "jupyterhub.prepareScope" $_ }}
+      {{- if $_.hasTolerations }}
+      {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
+      {{- end }}
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
       {{- if .Values.singleuser.imagePullSecret.enabled }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- $_ := merge (dict "appLabel" "kube-lego") . }}
         {{- include "jupyterhub.matchLabels" $_ | nindent 8 }}
+        hub.jupyter.org/pod-kind: "core"
         hub.jupyter.org/network-access-proxy-http: "true"
     spec:
       {{- if .Values.rbac.enabled }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -52,6 +52,11 @@ spec:
                     - key: release
                       operator: In
                       values: [{{ .Release.Name | quote }}]
+      {{- $_ := merge (dict "podKind" "core") . }}
+      {{- $dummy := include "jupyterhub.prepareScope" $_ }}
+      {{- if $_.hasTolerations }}
+      {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
+      {{- end }}
       containers:
         - name: nginx
           image: "{{ .Values.proxy.nginx.image.name }}:{{ .Values.proxy.nginx.image.tag }}"

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -36,26 +36,15 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: autohttps
       {{- end }}
-      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
       terminationGracePeriodSeconds: 60
-      affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: component
-                      operator: In
-                      values: ['hub']
-                    - key: release
-                      operator: In
-                      values: [{{ .Release.Name | quote }}]
       {{- $_ := merge (dict "podKind" "core") . }}
       {{- $dummy := include "jupyterhub.prepareScope" $_ }}
       {{- if $_.hasTolerations }}
       {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
+      {{- end }}
+      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
+      {{- if $_.hasAffinity }}
+      {{- include "jupyterhub.affinity" $_ | nindent 6 }}
       {{- end }}
       containers:
         - name: nginx

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        hub.jupyter.org/pod-kind: "core"
         hub.jupyter.org/network-access-hub: "true"
         hub.jupyter.org/network-access-singleuser: "true"
         {{- if .Values.proxy.labels }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -30,26 +30,15 @@ spec:
         {{- .Values.proxy.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
-      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
       terminationGracePeriodSeconds: 60
-      affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                    - key: component
-                      operator: In
-                      values: ['hub']
-                    - key: release
-                      operator: In
-                      values: [{{ .Release.Name | quote }}]
       {{- $_ := merge (dict "podKind" "core") . }}
       {{- $dummy := include "jupyterhub.prepareScope" $_ }}
       {{- if $_.hasTolerations }}
       {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
+      {{- end }}
+      nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
+      {{- if $_.hasAffinity }}
+      {{- include "jupyterhub.affinity" $_ | nindent 6 }}
       {{- end }}
       {{- if $manualHTTPSwithsecret }}
       volumes:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -46,6 +46,11 @@ spec:
                     - key: release
                       operator: In
                       values: [{{ .Release.Name | quote }}]
+      {{- $_ := merge (dict "podKind" "core") . }}
+      {{- $dummy := include "jupyterhub.prepareScope" $_ }}
+      {{- if $_.hasTolerations }}
+      {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
+      {{- end }}
       {{- if $manualHTTPSwithsecret }}
       volumes:
         - name: tls-secret

--- a/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
+++ b/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
@@ -14,6 +14,17 @@
 {{- $dummy := set . "tolerationsList" (include "jupyterhub.tolerationsList" .) }}
 {{- $dummy := set . "tolerations" (include "jupyterhub.tolerations" .) }}
 {{- $dummy := set . "hasTolerations" .tolerations }}
+
+{{- $dummy := set . "nodeAffinityRequired" (include "jupyterhub.nodeAffinityRequired" .) }}
+{{- $dummy := set . "podAffinityRequired" (include "jupyterhub.podAffinityRequired" .) }}
+{{- $dummy := set . "podAntiAffinityRequired" (include "jupyterhub.podAntiAffinityRequired" .) }}
+{{- $dummy := set . "nodeAffinityPreferred" (include "jupyterhub.nodeAffinityPreferred" .) }}
+{{- $dummy := set . "podAffinityPreferred" (include "jupyterhub.podAffinityPreferred" .) }}
+{{- $dummy := set . "podAntiAffinityPreferred" (include "jupyterhub.podAntiAffinityPreferred" .) }}
+{{- $dummy := set . "hasNodeAffinity" (or .nodeAffinityRequired .nodeAffinityPreferred) }}
+{{- $dummy := set . "hasPodAffinity" (or .podAffinityRequired .podAffinityPreferred) }}
+{{- $dummy := set . "hasPodAntiAffinity" (or .podAntiAffinityRequired .podAntiAffinityPreferred) }}
+{{- $dummy := set . "hasAffinity" (or .hasNodeAffinity .hasPodAffinity .hasPodAntiAffinity) }}
 {{- end }}
 
 
@@ -43,5 +54,105 @@ tolerations:
 {{- if .Values.singleuser.extraTolerations -}}
 {{- .Values.singleuser.extraTolerations | toYaml | trimSuffix "\n" | nindent 0 }}
 {{- end }}
+{{- end }}
+{{- end }}
+
+
+
+{{- define "jupyterhub.nodeAffinityRequired" -}}
+{{- if .Values.singleuser.extraNodeAffinity.required -}}
+{{- .Values.singleuser.extraNodeAffinity.required | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.nodeAffinityPreferred" -}}
+{{- if .Values.singleuser.extraNodeAffinity.preferred -}}
+{{- .Values.singleuser.extraNodeAffinity.preferred | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.podAffinityRequired" -}}
+{{- if eq .podKind "core" -}}
+{{- else if eq .podKind "user" -}}
+{{- if .Values.singleuser.extraPodAffinity.required }}
+{{- .Values.singleuser.extraPodAffinity.required | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.podAffinityPreferred" -}}
+{{- if eq .podKind "core" -}}
+{{- else if eq .podKind "user" -}}
+{{- if .Values.singleuser.extraPodAffinity.preferred -}}
+{{- .Values.singleuser.extraPodAffinity.preferred | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.podAntiAffinityRequired" -}}
+{{- if eq .podKind "core" -}}
+{{- else if eq .podKind "user" -}}
+{{- if .Values.singleuser.extraPodAntiAffinity.required -}}
+{{- .Values.singleuser.extraPodAntiAffinity.required | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.podAntiAffinityPreferred" -}}
+{{- if eq .podKind "core" -}}
+{{- else if eq .podKind "user" -}}
+{{- if .Values.singleuser.extraPodAntiAffinity.preferred -}}
+{{- .Values.singleuser.extraPodAntiAffinity.preferred | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+
+{{- /*
+  input: podKind
+*/}}
+{{- define "jupyterhub.affinity" -}}
+{{- if .hasAffinity -}}
+affinity:
+  {{- if .hasNodeAffinity }}
+  nodeAffinity:
+    {{- if .nodeAffinityRequired }}
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        {{- .nodeAffinityRequired | nindent 8 }}
+    {{- end }}
+
+    {{- if .nodeAffinityPreferred }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+      {{- .nodeAffinityPreferred | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if .hasPodAffinity }}
+  podAffinity:
+    {{- if .podAffinityRequired }}
+    requiredDuringSchedulingIgnoredDuringExecution:
+      {{- .podAffinityRequired | nindent 6 }}
+    {{- end }}
+
+    {{- if .podAffinityPreferred }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+      {{- .podAffinityPreferred | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if .hasPodAntiAffinity }}
+  podAntiAffinity:
+    {{- if .podAntiAffinityRequired }}
+    requiredDuringSchedulingIgnoredDuringExecution:
+      {{- .podAntiAffinityRequired | nindent 6 }}
+    {{- end }}
+
+    {{- if .podAntiAffinityPreferred }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+      {{- .podAntiAffinityPreferred | nindent 6 }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
+++ b/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
@@ -1,0 +1,47 @@
+{{- /*
+  jupyterhub.prepareScope
+    Requires the .podKind field.
+
+    prepareScope sets fields on the scope to be used by the
+    jupyterhub.tolerations and jupyterhub.affinity helm template functions
+    below.
+*/}}
+{{- define "jupyterhub.prepareScope" -}}
+{{- /* Update the copied scope */}}
+{{- $dummy := set . "component" (include "jupyterhub.componentLabel" .) }}
+
+{{- /* Fetch relevant information */}}
+{{- $dummy := set . "tolerationsList" (include "jupyterhub.tolerationsList" .) }}
+{{- $dummy := set . "tolerations" (include "jupyterhub.tolerations" .) }}
+{{- $dummy := set . "hasTolerations" .tolerations }}
+{{- end }}
+
+
+
+{{- /*
+  jupyterhub.tolerations
+    Refactors the setting of the user pods tolerations field.
+*/}}
+{{- define "jupyterhub.tolerations" -}}
+{{- if .tolerationsList -}}
+tolerations:
+  {{- .tolerationsList | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "jupyterhub.tolerationsList" -}}
+{{- if eq .podKind "core" -}}
+{{- else if eq .podKind "user" -}}
+- key: hub.jupyter.org_dedicated
+  operator: Equal
+  value: user
+  effect: NoSchedule
+- key: hub.jupyter.org/dedicated
+  operator: Equal
+  value: user
+  effect: NoSchedule
+{{- if .Values.singleuser.extraTolerations -}}
+{{- .Values.singleuser.extraTolerations | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -23,6 +23,11 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: user-scheduler
       {{- end }}
+      {{- $_ := merge (dict "podKind" "core") . }}
+      {{- $dummy := include "jupyterhub.prepareScope" $_ }}
+      {{- if $_.hasTolerations }}
+      {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
+      {{- end }}
       nodeSelector: {{ toJson .Values.scheduling.userScheduler.nodeSelector }}
       containers:
         - name: user-scheduler

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       {{- include "jupyterhub.tolerations" $_ | nindent 6 }}
       {{- end }}
       nodeSelector: {{ toJson .Values.scheduling.userScheduler.nodeSelector }}
+      {{- if $_.hasAffinity }}
+      {{- include "jupyterhub.affinity" $_ | nindent 6 }}
+      {{- end }}
       containers:
         - name: user-scheduler
           image: {{ include "jupyterhub.scheduler.image" . }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -230,6 +230,12 @@ scheduling:
     pdb:
       enabled: true
       minAvailable: 1
+  corePods:
+    nodeAffinity:
+      matchNodePurpose: prefer
+  userPods:
+    nodeAffinity:
+      matchNodePurpose: prefer
 
 
 prePuller:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -161,6 +161,7 @@ singleuser:
   events: true
   extraAnnotations: {}
   extraLabels: {}
+  storageExtraLabels: {}
   extraEnv: {}
   lifecycleHooks:
   initContainers: []

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -142,6 +142,7 @@ auth:
 
 
 singleuser:
+  extraTolerations: []
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -143,6 +143,16 @@ auth:
 
 singleuser:
   extraTolerations: []
+  nodeSelector: {}
+  extraNodeAffinity:
+    required: []
+    preferred: []
+  extraPodAffinity:
+    required: []
+    preferred: []
+  extraPodAntiAffinity:
+    required: []
+    preferred: []
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools
@@ -167,7 +177,6 @@ singleuser:
   lifecycleHooks:
   initContainers: []
   extraContainers: []
-  nodeSelector: {}
   uid: 1000
   fsGid: 100
   serviceAccountName:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -105,7 +105,7 @@ proxy:
     enabled: true
   https:
     enabled: true
-    type: manual
+    type: letsencrypt
     #type: letsencrypt, manual, secret
     letsencrypt:
       contactEmail: 'e@domain.com'
@@ -229,6 +229,12 @@ scheduling:
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
       tag: v1.11.2
+  corePods:
+    nodeAffinity:
+      matchNodePurpose: require
+  userPods:
+    nodeAffinity:
+      matchNodePurpose: require
 
 
 prePuller:


### PR DESCRIPTION
## Warning

Needs rebase before merge. Actual content in PR are:

- [**Preset: `scheduling.nodeAffinity.matchNodePurpose`**](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/commit/61ea865aa20200898195dc98dc5b4e132033100f)

--- 

## About

This preset makes pods of `user | core` kind either `prefer` `require` or `ignore` a scheduling on a node with a matching label for `hub.jupyter.org/node-purpose: user | core`.