### PR TITLE
user-scheduler: image locality priority added

### DIFF
--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -25,10 +25,11 @@ data:
         { "name": "MatchInterPodAffinity" }
       ],
       "priorities": [
-        { "name": "NodePreferAvoidPodsPriority",  "weight": 10000 },
-        { "name": "NodeAffinityPriority",         "weight": 1000 },
-        { "name": "InterPodAffinityPriority",     "weight": 100 },
-        { "name": "MostRequestedPriority",        "weight": 50 }
+        { "name": "NodePreferAvoidPodsPriority",  "weight": 161051 },
+        { "name": "NodeAffinityPriority",         "weight": 14641 },
+        { "name": "InterPodAffinityPriority",     "weight": 1331 },
+        { "name": "MostRequestedPriority",        "weight": 121 },
+        { "name": "ImageLocalityPriority",        "weight": 11}
       ],
       "hardPodAffinitySymmetricWeight" : 100,
       "alwaysCheckAllPredicates" : true
@@ -36,6 +37,13 @@ data:
 {{- end }}
 
 {{- /*
+# Notes about ranges
+ImageLocalityPriority       - ranges from 0-10 * 11
+MostRequestedPriority       - ranges from 0-10 * 11^2
+InterPodAffinityPriority    - ranges from 0-1  * 11^3 (i guess)
+NodeAffinityPriority        - ranges from 0-1  * 11^4 (i guess)
+NodePreferAvoidPodsPriority - ranges from 0-1  * 11^5 (i guess)
+
 # Notes about the GeneralPredicates
 The following predicates was not found by kube-scheduler 1.11.1-beta.0
 { "name": "CheckNodePIDPressure" },
@@ -69,5 +77,12 @@ capacity.
 
 Details: (cpu(10 * sum(requested) / capacity) + memory(10 * sum(requested) /
 capacity)) / 2
+
+ImageLocalityPriorityMap is a priority function that favors nodes that already
+have requested pod container's images. It will detect whether the requested
+images are present on a node, and then calculate a score ranging from 0 to 10
+based on the total size of those images. - If none of the images are present,
+this node will be given the lowest priority. - If some of the images are present
+on a node, the larger their sizes' sum, the higher the node's priority.
 
 */}}

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -32,7 +32,7 @@ data:
         { "name": "ImageLocalityPriority",        "weight": 11}
       ],
       "hardPodAffinitySymmetricWeight" : 100,
-      "alwaysCheckAllPredicates" : true
+      "alwaysCheckAllPredicates" : false
     }
 {{- end }}
 

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -15,7 +15,6 @@ spec:
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
-        hub.jupyter.org/pod-kind: "core"
       annotations:
         # This lets us autorestart when the configmap changes!
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}


### PR DESCRIPTION
This may be useful for mybinder.org's deployment. I've add a small image locality consideration into the mix for how the user-scheduler decides where a user pod should schedule. It will still prioritize the most requested node though.

In practice I suspect it may be of minor importance, but I imagine that when a few nodes are almost full, it may be that these are both at the same requested resource score (from 0-10), and then image locality can come into play to decide the final reason for scheduling.

---

I've also ensure that the weights are causing the final node-rating to be decided in order from the most important thing to the least important thing. For example, `InterPodAffinityPriority` always wins over `MostRequestedPriority` and that in turn always win over `ImageLocalityPriority`.

---

Setting `alwaysCheckAllPredicates` to false again. It was only set to true for my own debugging / learning purposes initially. It will improve the schedulers performance to have to false without any drawbacks though.

---

Removing the pod-kind label as well, as I figure we won't add those systematically.