### PR TITLE
small fix in docs - aythentication.rst

### DIFF
--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -284,7 +284,6 @@ This example is equivalent to that given in the
             filter: '({login_attr}={login})'
             user: 'ldap_search_user_technical_account'
             password: 'secret'
-            dnAttribute: 'cn'
           templates:
             - 'uid={username},ou=people,dc=wikimedia,dc=org'
             - 'uid={username},ou=developers,dc=wikimedia,dc=org'
@@ -292,6 +291,7 @@ This example is equivalent to that given in the
             searchBase: 'ou=people,dc=wikimedia,dc=org'
             escape: False
             attribute: 'sAMAccountName'
+            dnAttribute: 'cn'
         allowedGroups:
           - 'cn=researcher,ou=groups,dc=wikimedia,dc=org'
           - 'cn=operations,ou=groups,dc=wikimedia,dc=org'


### PR DESCRIPTION
Incorrect location of dnAttribute: 'cn'. 

According to images/hub/jupyterhub_config.py
    `set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_user_dn_attribute', 'auth.ldap.dn.user.dn-attribute')`
dn-attribute should be under dn.user.