### PR TITLE
Allow for imagePullSecret on hub image

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -38,6 +38,89 @@ properties:
 
           See the [Kubernetes docs](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
           for more info on what the values mean.
+      imagePullSecret:
+        type: object
+        description: |
+          Creates an image pull secret for you and makes the hub pod utilize
+          it, allowing it to pull images from private image registries.
+          
+          Using this configuration option automates the following steps that
+          normally is required to pull from private image registries.
+          
+          ```sh
+          # you won't need to run this manually...
+          kubectl create secret docker-registry hub-image-credentials \
+            --docker-server=<REGISTRY> \
+            --docker-username=<USERNAME> \
+            --docker-email=<EMAIL> \
+            --docker-password=<PASSWORD>
+          ```
+
+          ```yaml
+          # you won't need to specify this manually...
+          spec:
+            imagePullSecrets:
+              - name: hub-image-credentials
+          ```
+
+          To learn the username and password fields to access a gcr.io registry
+          from a Kubernetes cluster not associated with the same google cloud
+          credentials, look into [this
+          guide](http://docs.heptio.com/content/private-registries/pr-gcr.html)
+          and read the notes about the password.
+        properties:
+          enabled:
+            type: boolean
+            description: |
+              Enable the creation of a Kubernetes Secret containing credentials
+              to access a image registry. By enabling this, the hub pod will also be configured
+              to use these credentials when it pulls its container image.
+          registry:
+            type: string
+            description: |
+              Name of the private registry you want to create a credential set
+              for. It will default to Docker Hub's image registry.
+
+              Examples:
+                - https://index.docker.io/v1/
+                - quay.io
+                - eu.gcr.io
+                - alexmorreale.privatereg.net
+          username:
+            type: string
+            description: |
+              Name of the user you want to use to connect to your private
+              registry. For external gcr.io, you will use the `_json_key`.
+
+              Examples:
+                - alexmorreale
+                - alex@pfc.com
+                - _json_key
+          password:
+            type: string
+            description: |
+              Password of the user you want to use to connect to your private
+              registry.
+
+              Examples:
+                - plaintextpassword
+                - abc123SECRETzyx098
+
+              For gcr.io registries the password will be a big JSON blob for a
+              Google cloud service account, it should look something like below.
+                            
+              ```yaml
+              password: |-
+                {
+                  "type": "service_account",
+                  "project_id": "jupyter-se",
+                  "private_key_id": "f2ba09118a8d3123b3321bd9a7d6d0d9dc6fdb85",
+                  ...
+                }
+              ```
+
+              Learn more in [this
+              guide](http://docs.heptio.com/content/private-registries/pr-gcr.html).
       image:
         type: object
         description: |

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -56,6 +56,10 @@ spec:
       securityContext:
         runAsUser: {{ .Values.hub.uid }}
         fsGroup: {{ .Values.hub.fsGid }}
+      {{- if .Values.hub.imagePullSecret.enabled }}
+      imagePullSecrets:
+        - name: hub-image-credentials
+      {{- end }}  
       containers:
         {{- if .Values.hub.extraContainers }}
         {{- .Values.hub.extraContainers | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/jupyterhub/templates/hub/image-credentials-secret.yaml
+++ b/jupyterhub/templates/hub/image-credentials-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.hub.imagePullSecret.enabled }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: hub-image-credentials
+  labels:
+    {{- $_ := merge (dict "componentSuffix" "-image-credentials") . }}
+    {{- include "jupyterhub.labels" $_ | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ include "jupyterhub.dockerhubconfigjson" . }}
+{{- end }}

--- a/jupyterhub/templates/singleuser/image-credentials-secret.yaml
+++ b/jupyterhub/templates/singleuser/image-credentials-secret.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ include "jupyterhub.dockerconfigjson" . }}
+  .dockerconfigjson: {{ include "jupyterhub.dockersingleuserconfigjson" . }}
 {{- if .Values.prePuller.hook.enabled }}
 ---
 kind: Secret
@@ -25,6 +25,6 @@ metadata:
     "helm.sh/hook-weight": "-20"
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: {{ include "jupyterhub.dockerconfigjson" . }}
+  .dockerconfigjson: {{ include "jupyterhub.dockersingleuserconfigjson" . }}
 {{- end }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -48,6 +48,12 @@ hub:
       memory: 512Mi
   services: {}
   imagePullPolicy: IfNotPresent
+  imagePullSecret:
+    enabled: false
+    registry:
+    username:
+    email:
+    password:
   pdb:
     enabled: true
     minAvailable: 1


### PR DESCRIPTION
This makes it easier to provide credentials to a private docker repo for the hub image. This is mainly a cut-and-paste from the same feature for the singleuser repos. 
This addresses issue #945 