### PR TITLE
extraImages is a dict

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -262,7 +262,7 @@ prePuller:
       tag: generated-by-chartpress
   continuous:
     enabled: false
-  extraImages: []
+  extraImages: {}
   pause:
     image:
       name: gcr.io/google_containers/pause


### PR DESCRIPTION
not a list.

Having a list here results in a (harmless, but misleading) warning when users define prePuller.extraImages:

> `warning: destination for extraImages is a table. Ignoring non-table value []`