### PR TITLE
better output of lint errors

### DIFF
--- a/tools/templates/lint-and-validate.py
+++ b/tools/templates/lint-and-validate.py
@@ -82,7 +82,6 @@ def lint(yamllint_config, values, kubernetes_version, output_dir, debug):
             'kubeval', filename,
             '--kubernetes-version', kubernetes_version,
             '--strict',
-            '--schema-location', 'https://raw.githubusercontent.com/consideRatio'
         ])
 
     print()


### PR DESCRIPTION
rather than showing a `CalledProcessError` traceback, exit with a simple error message