### PR TITLE
Set suitable defaults for provided tls-secret

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -119,8 +119,8 @@ proxy:
       cert:
     secret:
       name: ''
-      key: ''
-      crt: ''
+      key: 'tls.key'
+      crt: 'tls.crt'
     hosts: []
   networkPolicy:
     enabled: false


### PR DESCRIPTION
There is a predefined type for TLS secrets in k8s, and they can be
created with a kubectl command.

Notice `TYPE` in the example below:

```
$ kubectl get secrets -n jupyterhub
NAME                            TYPE                                  DATA      AGE
autohttps-token-99shm           kubernetes.io/service-account-token   3         1d
default-token-dbj5g             kubernetes.io/service-account-token   3		1d
hub-secret                      Opaque                                4		1d
hub-token-mdhg7                 kubernetes.io/service-account-token   3		1d
kube-lego-account               Opaque                                2		1d
kubelego-tls-proxy-jupyterhub   kubernetes.io/tls                     2		1d
user-scheduler-token-hltcf      kubernetes.io/service-account-token   3		1d
```

And how you can create a secret like this using the kubectl command.

```
Usage:
  kubectl create secret tls NAME --cert=path/to/cert/file --key=path/to/key/file [--dry-run] [options]
```

These TLS secrets have two entries, one named `tls.key` and one named
`tls.crt`. This PR makes these entry names the default for the provided
secret.