### PR TITLE
Update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Zero to JupyterHub with Kubernetes
 
 [![Build Status](https://travis-ci.org/jupyterhub/zero-to-jupyterhub-k8s.svg?branch=master)](https://travis-ci.org/jupyterhub/zero-to-jupyterhub-k8s)
-[![Documentation Status](https://readthedocs.org/projects/zero-to-jupyterhub/badge/?version=latest)](https://z2jh.jupyter.org/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/zero-to-jupyterhub/badge/?version=stable)](https://zero-to-jupyterhub.readthedocs.io/en/stable/?badge=stable)
+                
 
 **This is under active development and subject to change.**
 
 This repo contains resources, such as **Helm charts** and the
-[**Zero to JupyterHub Guide**](https://z2jh.jupyter.org), which
+[**Zero to JupyterHub Guide**](https://zero-to-jupyterhub.readthedocs.io/en/stable/), which
 help you to deploy JupyterHub on Kubernetes.
 
 ## Zero to JupyterHub with Kubernetes Guide
 
-The [Zero to JupyterHub Guide](https://z2jh.jupyter.org) gives
+The [Zero to JupyterHub Guide](https://zero-to-jupyterhub.readthedocs.io/en/stable/) gives
 user-friendly steps to create a new JupyterHub deployment using Kubernetes.
 
 For additional information about JupyterHub, such as a technical overview,


### PR DESCRIPTION
The https://z2jh.jupyter.org was failing to redirect correctly. I'm changing the link to https://zero-to-jupyterhub.readthedocs.io/en/stable/ . Feel free to troubleshoot the jupyter link if preferred. For now, I am just going to merge this and get it working again.