### PR TITLE
update requirements for docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           name: Install doc dependencies
           command: |
             pip install --upgrade pip setuptools
-            pip install -r doc/doc-requirements.txt
+            pip install --user -r doc/doc-requirements.txt
 
       # Build the docs
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,10 @@ jobs:
           keys:
             - cache-pip
       - run:
-          - pip install --upgrade pip setuptools
-          - pip install -r doc/doc-requirements.txt
+          name: Install doc dependencies
+          command: |
+            pip install --upgrade pip setuptools
+            pip install -r doc/doc-requirements.txt
       - save_cache:
           key: cache-pip
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,18 +10,11 @@ jobs:
       # Python env
       - run: echo "export PATH=~/.local/bin:$PATH" >> $BASH_ENV
 
-      - restore_cache:
-          keys:
-            - cache-pip
       - run:
           name: Install doc dependencies
           command: |
             pip install --upgrade pip setuptools
             pip install -r doc/doc-requirements.txt
-      - save_cache:
-          key: cache-pip
-          paths:
-            - ~/.cache/pip
 
       # Build the docs
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ jobs:
       - restore_cache:
           keys:
             - cache-pip
-      - run: pip install --user -r doc/doc-requirements.txt
+      - run:
+          - pip install --upgrade pip setuptools
+          - pip install -r doc/doc-requirements.txt
       - save_cache:
           key: cache-pip
           paths:
@@ -29,7 +31,6 @@ jobs:
       - store_artifacts:
           path: doc/build/html/
           destination: html
-
 
 workflows:
   version: 2

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,6 +1,5 @@
+sphinx>=1.7
 recommonmark==0.4.0
 pyyaml
 sphinx-copybutton
-alabaster
 alabaster_jupyterhub
-sphinx

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,0 @@
-Sphinx>=1.7
-recommonmark==0.4.0
-pyyaml
-sphinx-copybutton

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,5 @@
 name: jhubk8s
 type: sphinx
-requirements_file: doc/requirements.txt
+requirements_file: doc/doc-requirements.txt
 python:
   version: 3


### PR DESCRIPTION
The following corrects the failing doc build:
- sync naming across files for doc build requirements
- minor edits to circleci.yml
- remove caching as we are only building docs