### PR TITLE
Support glob-matching ingress

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -767,6 +767,12 @@ properties:
         type: list
         description: |
           List of hosts to route requests to the proxy.
+      pathSuffix:
+        type: string
+        description: |
+          Suffix added to Ingress's routing path pattern.
+
+          Specify `*` if your ingress matches path by glob pattern.
       tls:
         description: |
           TLS configurations for Ingress.

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -744,6 +744,38 @@ properties:
                   ```
                   hub.jupyter.org/node-purpose=user
                   ```
+  ingress:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          Enable the creation of a Kubernetes Ingress to proxy-public service.
+
+          See [Advanced Topics — Zero to JupyterHub with Kubernetes 0.7.0 documentation]
+          (https://zero-to-jupyterhub.readthedocs.io/en/stable/advanced.html#ingress)
+          for more details.
+      annotations:
+        type: object
+        description: |
+          Annotations to apply to the Ingress.
+
+          See [the Kubernetes
+          documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+          for more details about annotations.
+      hosts:
+        type: list
+        description: |
+          List of hosts to route requests to the proxy.
+      tls:
+        description: |
+          TLS configurations for Ingress.
+
+          See [the Kubernetes
+          documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
+          for more details about annotations.
+
+
   custom:
     type: object
     description: |

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: {{ $.Values.hub.baseUrl }}
+          - path: {{ $.Values.hub.baseUrl }}{{ $.Values.ingress.pathSuffix }}
             backend:
               serviceName: proxy-public
               servicePort: 80

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -275,6 +275,7 @@ ingress:
   enabled: false
   annotations: {}
   hosts: []
+  pathSuffix: ''
   tls:
 
 


### PR DESCRIPTION
GKE's default ingress (ingress-gce) matches path by glob-pattern.
Therefore, path `/` doesn't match `/hub` etc.

To make this to work properly, I need to patch the path to `/*`.

Here, I introduced `pathSuffix` option to support these situation.