### PR TITLE
Point links back to z2jh.jupyter.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 **This is under active development and subject to change.**
 
 This repo contains resources, such as **Helm charts** and the
-[**Zero to JupyterHub Guide**](https://zero-to-jupyterhub.readthedocs.io/en/stable/), which
+[**Zero to JupyterHub Guide**](https://z2jh.jupyter.org), which
 help you to deploy JupyterHub on Kubernetes.
 
 ## Zero to JupyterHub with Kubernetes Guide
 
-The [Zero to JupyterHub Guide](https://zero-to-jupyterhub.readthedocs.io/en/stable/) gives
+The [Zero to JupyterHub Guide](https://z2jh.jupyter.org) gives
 user-friendly steps to create a new JupyterHub deployment using Kubernetes.
 
 For additional information about JupyterHub, such as a technical overview,


### PR DESCRIPTION
Partially reverts jupyterhub/zero-to-jupyterhub-k8s#977

It works now, with https://docs.readthedocs.io/en/latest/alternate_domains.html.
This gives us direct serving from z2jh.jupyter.org and 
HTTPS. 

Leaves the switch from pointing to latest to stable in.