### PR TITLE
Conceal some auth values in hub-config

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -10,6 +10,13 @@ data:
 {{- /* make a copy of values.auth to avoid modifying the original */ -}}
 {{- $_ := set $values "auth" (merge dict .Values.auth) }}
 {{- $_ := set $values.auth "state" (omit $values.auth.state "cryptoKey") }}
+{{- range $key, $auth := .Values.auth }}
+  {{- if typeIs "map[string]interface {}" $auth }}
+    {{- if (or $auth.clientSecret $auth.password) }}
+      {{- $_ := set $values.auth $key (omit $auth "clientSecret" "password") }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- $_ := set $values "hub" (omit $values.hub "cookieSecret" "extraEnv" "extraConfigMap") -}}
 {{- $_ := set $values.hub "services" dict }}
 {{- range $key, $service := .Values.hub.services }}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -15,6 +15,14 @@ data:
   {{- end }}
   {{- $values := dict "hub" dict }}
   {{- /* pluck only needed secret values, preserving values.yaml structure */ -}}
+  {{- $_ := set $values "auth" dict }}
+  {{- range $key, $auth := .Values.auth }}
+    {{- if typeIs "map[string]interface {}" $auth }}
+      {{- if (or $auth.clientSecret $auth.password) }}
+        {{- $_ := set $values.auth $key (pick $auth "clientSecret" "password") }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
   {{- $_ := set $values.hub "services" dict }}
   {{- range $key, $service := .Values.hub.services }}
     {{- if $service.apiToken }}


### PR DESCRIPTION
There might be `clientSecret` or `password` in values from `auth` field.
They should not be exposed in plain ConfigMap but should be concealed in Secret.
I made it so.

Example:

`values.yaml`

```yaml
auth:
  type: github
  github:
    clientId: xxx
    clientSecret: yyy
    callbackUrl: https://example.com/hub/oauth_callback
```

Rendered (before)

```yaml
# Source: jupyterhub/templates/hub/configmap.yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: hub-config
  labels:
    # ...snip...
data:
  values.yaml: |
      # ...snip...
      github:
        callbackUrl: https://example.com/hub/oauth_callback
        clientId: xxx
        clientSecret: yyy
      type: github
      # ...snip...
```


Rendered (after)

```yaml
# Source: jupyterhub/templates/hub/configmap.yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: hub-config
  labels:
    # ...snip...
data:
  values.yaml: |
      # ...snip...
      github:
        callbackUrl: https://example.com/hub/oauth_callback
        clientId: xxx
      type: github
      # ...snip...
```