### PR TITLE
Add sqlite3 to hub image

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
       libcurl4-openssl-dev \
       libssl-dev \
       build-essential \
+      sqlite3 \
       && \
     apt-get purge && apt-get clean
 


### PR DESCRIPTION
The default configuration for the hub uses a sqlite database.
This package adds a commandline utility that makes it easier
to see the database contents when debugging.