### PR TITLE
Added documentation for `hub.service`, `proxy.service` and `proxy.https` in `schema.yaml`.

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -337,6 +337,49 @@ properties:
 
           Defaults to 1000, which is the gid of the `jovyan` user that is present in the
           default hub image.
+      service:
+        type: object
+        description: |
+          Object to configure the service the JupyterHub will be exposed on by the Kubernetes server.
+        properties:
+          type:
+            type: string
+            enum:
+              - ClusterIP
+              - NodePort
+              - LoadBalancer
+              - ExternalName
+            description: |
+              The Kubernetes ServiceType to be used.
+
+              The default type is `ClusterIP`.
+              See the [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+              to learn more about service types.
+          loadBalancerIP:
+            type: string
+            description: |
+              The public IP address the hub service should be exposed on.
+
+              This sets the IP address that should be used by the LoadBalancer for exposing the hub service.
+              Set this if you want the hub service to be provided with a fixed external IP address instead of a dynamically acquired one.
+              Useful to ensure a stable IP to access to the hub with, for example if you have reserved an IP address in your network to communicate with the JupyterHub.
+              
+              To be provided like:
+              ```
+              hub: 
+                service:
+                  loadBalancerIP: xxx.xxx.xxx.xxx
+              ```
+          ports:
+            type: object
+            description: |
+              Object to configure the ports the hub service will be deployed on.
+            properties:
+              nodePort:
+                type: integer
+                description: |
+                  The nodePort to deploy the hub service on.
+                  
   proxy:
     type: object
     properties:
@@ -354,6 +397,56 @@ properties:
           Changing this value will cause the proxy and hub pods to restart. It is good security
           practice to rotate these values over time. If this secret leaks, *immediately* change
           it to something else, or user data can be compromised
+      service:
+        type: object
+        description: |
+          Object to configure the service the JupyterHub's proxy will be exposed on by the Kubernetes server.
+        properties:
+          type: 
+            type: string
+            enum:
+              - ClusterIP
+              - NodePort
+              - LoadBalancer
+              - ExternalName
+            description: |
+              See `hub.service.type`.
+          labels:
+            type: object
+            description: |
+              Extra labels to add to the proxy service.
+
+              See the [Kubernetes docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+              to learn more about labels.
+          annotations:
+            type: object
+            description: |
+              Annotations to apply to the service that is exposing the proxy.
+
+              See [the Kubernetes
+              documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+              for more details about annotations.
+          nodePorts:
+            type: object
+            description: |
+              Object to set NodePorts to expose the service on for http and https.
+
+              See [the Kubernetes
+              documentation](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
+              for more details about NodePorts.
+            properties:
+              http:
+                type: integer
+                description: |
+                  The HTTP port the proxy-public service should be exposed on.
+              https:
+                type: integer
+                description: |
+                  The HTTPS port the proxy-public service should be exposed on.
+          loadBalancerIP:
+            type: string
+            description: |
+              See `hub.service.loadBalancerIP`
     required:
       - secretToken
 

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -447,9 +447,96 @@ properties:
             type: string
             description: |
               See `hub.service.loadBalancerIP`
+      https:
+        type: object
+        description: |
+          Object for customizing the settings for HTTPS used by the JupyterHub's proxy.
+          For more information on configuring HTTPS for your JupyterHub, see the [HTTPS section in our security guide](https://zero-to-jupyterhub.readthedocs.io/en/stable/security.html?highlight=security#https)
+        properties:
+          enabled:
+            type: boolean
+            description: |
+              Indicator to set whether HTTPS should be enabled or not on the proxy. Defaults to `true` if the https object is provided.
+          type:
+            type: string
+            enum:
+              - letsencrypt
+              - manual
+              - offload
+              - secret
+            description: |
+              The type of HTTPS encryption that is used.
+              Decides on which ports and network policies are used for communication via HTTPS. Setting this to `secret` sets the type to manual HTTPS with a secret that has to be provided in the `https.secret` object.
+              Defaults to `letsencrypt`.
+          letsencrypt:
+            type: object
+            properties:
+              contactEmail:
+                type: string
+                description: |
+                  The contact email to be used for automatically provisioned HTTPS certificates by Let's Encrypt. For more information see [Set up automatic HTTPS](https://zero-to-jupyterhub.readthedocs.io/en/stable/security.html?highlight=security#set-up-automatic-https).
+                  Required for automatic HTTPS.
+          manual:
+            type: object
+            description: |
+              Object for providing own certificates for manual HTTPS configuration. To be provided when setting `https.type` to `manual`.
+              See [Set up manual HTTPS](https://zero-to-jupyterhub.readthedocs.io/en/stable/security.html?highlight=security#set-up-manual-https)
+            properties:
+              key:
+                type: string
+                description: |
+                  The RSA private key to be used for HTTPS.
+                  To be provided in the form of
+
+                  ```
+                  key: |
+                    -----BEGIN RSA PRIVATE KEY-----
+                    ...
+                    -----END RSA PRIVATE KEY-----
+                  ```
+              cert:
+                type: string
+                description: |
+                  The certificate to be used for HTTPS.
+                  To be provided in the form of
+
+                  ```
+                  cert: |
+                    -----BEGIN CERTIFICATE-----
+                    ...
+                    -----END CERTIFICATE-----
+                  ```
+          secret:
+            type: object
+            description: |
+              Secret to be provided when setting `https.type` to `secret`.
+            properties:
+              name:
+                type: string
+                description: |
+                  Name of the secret
+              key:
+                type: string
+                description: |
+                  Path to the private key to be used for HTTPS. 
+                  Example: `'tls.key'`
+              crt:
+                type: string
+                description: |
+                  Path to the certificate to be used for HTTPS. 
+                  Example: `'tls.crt'`
+          hosts:
+            type: list
+            description: |
+              You domain in list form.
+              Required for automatic HTTPS. See [Set up automatic HTTPS](https://zero-to-jupyterhub.readthedocs.io/en/stable/security.html?highlight=security#set-up-automatic-https).
+              To be provided like:
+              ```
+              hosts:
+                - <your-domain-name>
+              ```   
     required:
       - secretToken
-
   auth:
     type: object
     properties:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -5,6 +5,7 @@ hub:
     type: ClusterIP
     ports:
       nodePort:
+    loadBalancerIP:
   baseUrl: /
   cookieSecret:
   publicURL:
@@ -81,6 +82,7 @@ proxy:
     nodePorts:
       http:
       https:
+    loadBalancerIP:
   chp:
     image:
       name: jupyterhub/configurable-http-proxy

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -113,7 +113,7 @@ proxy:
   https:
     enabled: true
     type: letsencrypt
-    #type: letsencrypt, manual, secret
+    #type: letsencrypt, manual, offload, secret
     letsencrypt:
       contactEmail: ''
     manual:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -106,7 +106,7 @@ proxy:
   https:
     enabled: true
     type: letsencrypt
-    #type: letsencrypt, manual, secret
+    #type: letsencrypt, manual, offload, secret
     letsencrypt:
       contactEmail: 'e@domain.com'
     manual:


### PR DESCRIPTION
Following https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/748 i added some documentation on the `hub.service` object as well as the `proxy.service` object in the `schema.yaml`.

While already on that, I also added documentation for the `proxy.https` object too.

I hope this can be of help to you and others using jupyterhub, feel free to request changes.
I'd be happy to adapt the descriptions if they don't fit well enough or you have more elaborate input on them.