### PR TITLE
Configure liveness/readinessProbe

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -170,3 +170,11 @@ spec:
           ports:
             - containerPort: 8081
               name: hub
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: hub
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: hub

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -96,3 +96,11 @@ spec:
               name: proxy-public
             - containerPort: 8001
               name: api
+          livenessProbe:
+            httpGet:
+              path: /_chp_healthz
+              port: proxy-public
+          readinessProbe:
+            httpGet:
+              path: /health # Wait until hub is ready (this is proxied to hub)
+              port: proxy-public

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -102,5 +102,5 @@ spec:
               port: proxy-public
           readinessProbe:
             httpGet:
-              path: /health # Wait until hub is ready (this is proxied to hub)
+              path: /health  # Wait until hub is ready (this is proxied to hub)
               port: proxy-public


### PR DESCRIPTION
I configured liveness/readinessProbe for both proxy and hub.

With this, they will be more robust against failures.

In addition to that, when deployed on GKE with Ingress, health check is configured properly (GKE Ingress's health check is configured automatically by following readinessProbe, or against `/` if not set).

## Ref:

- https://github.com/jupyterhub/configurable-http-proxy/pull/181
- https://github.com/jupyterhub/jupyterhub/pull/2257

⚠️  I believe this works, but not tested yet. I shall take time soon.