### PR TITLE
Add db.password option to enhance security

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -263,6 +263,12 @@ properties:
               Connection string when `hub.db.type` is mysql or postgres.
 
               See documentation for `hub.db.type` for more details on the format of this property.
+          password:
+            type:
+              - string
+              - "null"
+            description: |
+              Password for the database when `hub.db.type` is mysql or postgres.
       labels:
         type: object
         description: |

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -139,6 +139,21 @@ spec:
                   name: hub-secret
                   key: auth.state.crypto-key
             {{- end }}
+            {{- if .Values.hub.db.password }}
+            {{- if eq .Values.hub.db.type "mysql" }}
+            - name: MYSQL_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: hub-secret
+                  key: hub.db.password
+            {{- else if eq .Values.hub.db.type "postgres" }}
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hub-secret
+                  key: hub.db.password
+            {{- end }}
+            {{- end }}
             {{- if .Values.hub.extraEnv }}
             {{- $extraEnvType := typeOf .Values.hub.extraEnv }}
             {{- /* If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc. */}}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -10,6 +10,9 @@ data:
   {{- if .Values.hub.cookieSecret }}
   hub.cookie-secret: {{ .Values.hub.cookieSecret | b64enc | quote }}
   {{- end }}
+  {{- if .Values.hub.db.password }}
+  hub.db.password: {{ .Values.hub.db.password | b64enc | quote }}
+  {{- end }}
   {{- if .Values.auth.state.enabled }}
   auth.state.crypto-key: {{ (required "Encryption key is required for auth state to be persisted!" .Values.auth.state.cryptoKey) | b64enc | quote }}
   {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -32,6 +32,7 @@ hub:
       subPath:
       storageClassName:
     url:
+    password:
   labels: {}
   annotations:
     prometheus.io/scrape: 'true'


### PR DESCRIPTION
As I described [in this comment](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/996#issuecomment-434295589), database password should be concealed, but actually it resides in `db.url` which is not concealed.

To fix that, I propose to add `db.password`option and put it into Secret (N.B.; db.url is kept in ConfigMap, which might be useful and safe).

### Discussion point

Contrary to #996, I'm still wondering if this PR is actually a good practice.

Although this is useful, I have some reasons **NOT** to adopt this:

1. We already have a choice to deal with the situation: create Secret outside the chart and set it as env using `extraEnv` field).
2. Adopting this make the helm chart less "backend-agonistic". I feel it's not clean...

So feel free to decline the proposal.