### PR TITLE
Bump PriorityClass k8s API to beta from alpha

### DIFF
--- a/jupyterhub/templates/scheduling/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/priorityclass.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.scheduling.podPriority.enabled }}
-apiVersion: scheduling.k8s.io/v1alpha1
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
   name: {{ .Release.Name }}-default-priority

--- a/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.scheduling.podPriority.enabled }}
 {{- if .Values.scheduling.userPlaceholder.enabled -}}
-apiVersion: scheduling.k8s.io/v1alpha1
+apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
   name: {{ .Release.Name }}-user-placeholder-priority


### PR DESCRIPTION
Bumping the API to beta resolved an issue I got during a Helm
upgrade of the chart. I previously ran into the following error:

```
Update Complete. ⎈ Happy Helming!⎈
Error: UPGRADE FAILED: unable to recognize "": no matches for kind "PriorityClass" in version "scheduling.k8s.io/v1alpha1"
```

The API bump resolved it though.