### PR TITLE
Fix ingress.tls's default value

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1009,6 +1009,7 @@ properties:
 
           Specify `*` if your ingress matches path by glob pattern.
       tls:
+        type: list
         description: |
           TLS configurations for Ingress.
 

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -282,7 +282,7 @@ ingress:
   annotations: {}
   hosts: []
   pathSuffix: ''
-  tls:
+  tls: []
 
 
 cull:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -303,7 +303,7 @@ ingress:
   annotations:
     mock: mock
   hosts: []
-  tls:
+  tls: []
 
 
 cull:


### PR DESCRIPTION
`.Values.ingress.tls` should default to a `[]` instead of `{}` to avoid:
```
2018/11/25 21:56:36 warning: cannot overwrite table with non table for tls (map[])
```

... when the following valid configuration is provided:

```yaml
ingress:
  tls:
    - secretName: hub-neurips-mybinder-org-tls
      hosts:
        - hub.neurips.mybinder.org
```