### PR TITLE
Make it easier to build hub image with git commit hash.

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04
 
+ARG JUPYTERHUB_VERSION=0.9.*
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       git \
@@ -7,10 +9,12 @@ RUN apt-get update && \
       python3-dev \
       python3-pip \
       python3-setuptools \
-      libcurl4-openssl-dev \
-      libssl-dev \
+      python3-pycurl \
       build-essential \
       sqlite3 \
+      $(bash -c 'if [[ $JUPYTERHUB_VERSION == "git"* ]]; then \
+        echo npm; \
+      fi') \
       && \
     apt-get purge && apt-get clean
 
@@ -27,12 +31,14 @@ RUN adduser --disabled-password \
     --force-badname \
     ${NB_USER}
 
-ARG JUPYTERHUB_VERSION=0.9.*
-
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir \
-         jupyterhub==${JUPYTERHUB_VERSION} \
-         -r /tmp/requirements.txt
+         -r /tmp/requirements.txt \
+         $(bash -c 'if [[ $JUPYTERHUB_VERSION == "git"* ]]; then \
+            echo ${JUPYTERHUB_VERSION}; \
+          else \
+            echo jupyterhub==${JUPYTERHUB_VERSION}; \
+          fi')
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -8,7 +8,7 @@ nullauthenticator==1.0
 oauthenticator==0.8.0
 pymysql==0.9.2
 psycopg2==2.7.5
-pycurl==7.43.0.2
+pycurl==7.43.0.*
 statsd==3.2.2
 mwoauth==0.3.2
 globus_sdk[jwt]==1.5.0


### PR DESCRIPTION
Try to install from git if JUPYTERHUB_VERSION starts with git, such as:

    git+https://github.com/jupyterhub/jupyterhub.git@bbc2847530ccdb0f40a48f8e561415ea808a6561

Also switch to python3-pycurl so libcurl4-openssl-dev won't conflict with npm, which
is required by jupyterhub from git for lessc to work.