### PR TITLE
kubespawner 0.10

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -138,7 +138,7 @@ if image:
     if tag:
         image = "{}:{}".format(image, tag)
 
-    c.KubeSpawner.image_spec = image
+    c.KubeSpawner.image = image
 
 if get_config('singleuser.imagePullSecret.enabled'):
     c.KubeSpawner.image_pull_secrets = 'singleuser-image-credentials'

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -3,7 +3,7 @@ jupyterhub-dummyauthenticator==0.3.1
 jupyterhub-tmpauthenticator==0.5
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
-jupyterhub-kubespawner==0.9.0
+jupyterhub-kubespawner==0.10.0
 nullauthenticator==1.0
 oauthenticator==0.8.0
 pymysql==0.9.2

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -4,6 +4,7 @@ jupyterhub-tmpauthenticator==0.5
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
 jupyterhub-kubespawner==0.10.0
+kubernetes==8.0.*
 nullauthenticator==1.0
 oauthenticator==0.8.0
 pymysql==0.9.2

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -61,13 +61,15 @@ spec:
             - -c
             - echo "Pulling complete"
         {{- range $k, $container := .Values.singleuser.profileList }}
+        {{- if $container.kubespawner_override.image }}
         - name: image-pull-singleuser-profilelist-{{ $k }}
-          image: {{ $container.kubespawner_override.image_spec }} # Update to image on next kubespawner release!
+          image: {{ $container.kubespawner_override.image }}
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+        {{- end }}
         {{- end }}
         {{- if not .Values.singleuser.cloudMetadata.enabled }}
         - name: image-pull-metadata-block


### PR DESCRIPTION
- use KubeSpawner.image instead of deprecated .image_spec
- fix pre-puller with profiles when images are not defined

I didn't add backward-compatibility support for `.image_spec` in profileList prepuller since we haven't made a release with support for profileList yet and the consequence is only that profile images won't be pre-pulled if they use the deprecated name. They will still work.