### PR TITLE
kubespawner 0.10.1

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -3,7 +3,7 @@ jupyterhub-dummyauthenticator==0.3.1
 jupyterhub-tmpauthenticator==0.5
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
-jupyterhub-kubespawner==0.10.0
+jupyterhub-kubespawner==0.10.1
 kubernetes==8.0.*
 nullauthenticator==1.0
 oauthenticator==0.8.0


### PR DESCRIPTION
fixes deprecation of hub_connect_ip, which caused launch failures in #1053, #1055