### PR TITLE
fix prometheus annotations on the hub service

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -369,10 +369,10 @@ properties:
               This sets the IP address that should be used by the LoadBalancer for exposing the hub service.
               Set this if you want the hub service to be provided with a fixed external IP address instead of a dynamically acquired one.
               Useful to ensure a stable IP to access to the hub with, for example if you have reserved an IP address in your network to communicate with the JupyterHub.
-              
+
               To be provided like:
               ```
-              hub: 
+              hub:
                 service:
                   loadBalancerIP: xxx.xxx.xxx.xxx
               ```
@@ -385,7 +385,11 @@ properties:
                 type: integer
                 description: |
                   The nodePort to deploy the hub service on.
-                  
+          annotations:
+            type: object
+            description: |
+              Kuberentes annotations to apply to the hub service.
+
   proxy:
     type: object
     properties:

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: hub
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.hub.service.annotations }}
+    {{- .Values.hub.service.annotations | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.hub.service.type }}
   {{- if .Values.hub.service.loadBalancerIP }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -3,6 +3,9 @@ custom: {}
 hub:
   service:
     type: ClusterIP
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: /hub/metrics
     ports:
       nodePort:
     loadBalancerIP:
@@ -34,9 +37,7 @@ hub:
     url:
     password:
   labels: {}
-  annotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/path: /hub/metrics
+  annotations: {}
   extraConfig: {}
   extraConfigMap: {}
   extraEnv: {}


### PR DESCRIPTION
prometheus annotations go on the service, not the pod

adds hub.service.annotations field and enables prometheus annotations by default