### PR TITLE
quote hosts in ingress rules

### DIFF
--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   rules:
     {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ $host | quote }}
       http:
         paths:
           - path: {{ $.Values.hub.baseUrl }}{{ $.Values.ingress.pathSuffix }}


### PR DESCRIPTION
since wildcards can start with `*` which is inerpreted as a yaml anchor

may close #1058