### PR TITLE
MRG after 0.8.0 - Tune image-pullers pull policies

### DIFF
--- a/doc/source/advanced.md
+++ b/doc/source/advanced.md
@@ -296,7 +296,6 @@ prePuller:
      ubuntu-xenial:
        name: ubuntu
        tag: 16.04
-       policy: IfNotPresent
 ```
 
 This snippet will pre-pull the `ubuntu:16.04` image on all nodes, for example. You can

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -110,7 +110,9 @@ spec:
             {{- end }}
           resources:
             {{- .Values.hub.resources | toYaml | trimSuffix "\n" | nindent 12 }}
-          imagePullPolicy: {{ .Values.hub.imagePullPolicy }}
+          {{- with .Values.hub.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           env:
             - name: PYTHONUNBUFFERED
               value: "1"

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -55,7 +55,9 @@ spec:
       initContainers:
         - name: image-pull-singleuser
           image: {{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}
-          imagePullPolicy: IfNotPresent
+          {{- with .Values.singleuser.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           command:
             - /bin/sh
             - -c
@@ -65,7 +67,6 @@ spec:
         {{- if $container.kubespawner_override.image }}
         - name: image-pull-singleuser-profilelist-{{ $k }}
           image: {{ $container.kubespawner_override.image }}
-          imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
             - -c
@@ -76,7 +77,9 @@ spec:
         {{- if not .Values.singleuser.cloudMetadata.enabled }}
         - name: image-pull-metadata-block
           image: {{ .Values.singleuser.networkTools.image.name }}:{{ .Values.singleuser.networkTools.image.tag }}
-          imagePullPolicy: IfNotPresent
+          {{- with .Values.singleuser.networkTools.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           command:
             - /bin/sh
             - -c
@@ -85,7 +88,9 @@ spec:
         {{- range $k, $v := .Values.prePuller.extraImages }}
         - name: image-pull-{{ $k }}
           image: {{ $v.name }}:{{ $v.tag }}
-          imagePullPolicy: {{ $v.policy | default "IfNotPresent" }}
+          {{- with $v.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           command:
             - /bin/sh
             - -c
@@ -94,7 +99,9 @@ spec:
         {{- range $k, $container := .Values.singleuser.extraContainers }}
         - name: image-pull-singleuser-extra-container-{{ $k }}
           image: {{ $container.image }}
-          imagePullPolicy: IfNotPresent
+          {{- with $container.imagePullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           command:
             - /bin/sh
             - -c

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -44,7 +44,9 @@ spec:
       containers:
         - name: nginx
           image: "{{ .Values.proxy.nginx.image.name }}:{{ .Values.proxy.nginx.image.tag }}"
-          imagePullPolicy: {{ .Values.proxy.nginx.image.pullPolicy }}
+          {{- with .Values.proxy.nginx.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           resources:
             {{- .Values.proxy.nginx.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           args:
@@ -86,7 +88,9 @@ spec:
               protocol: TCP
         - name: kube-lego
           image: "{{ .Values.proxy.lego.image.name }}:{{ .Values.proxy.lego.image.tag }}"
-          imagePullPolicy: {{ .Values.proxy.lego.image.pullPolicy }}
+          {{- with .Values.proxy.lego.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           resources:
             {{- .Values.proxy.lego.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           env:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -86,7 +86,9 @@ spec:
                 secretKeyRef:
                   name: hub-secret
                   key: proxy.token
-          imagePullPolicy: {{ .Values.proxy.chp.image.pullPolicy }}
+          {{- with .Values.proxy.chp.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           ports:
             {{- if or $manualHTTPS $manualHTTPSwithsecret }}
             - containerPort: 8443

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -50,7 +50,6 @@ hub:
       cpu: 200m
       memory: 512Mi
   services: {}
-  imagePullPolicy: IfNotPresent
   imagePullSecret:
     enabled: false
     registry:
@@ -87,7 +86,6 @@ proxy:
     image:
       name: jupyterhub/configurable-http-proxy
       tag: 3.0.0
-      pullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 200m
@@ -96,14 +94,12 @@ proxy:
     image:
       name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
       tag: 0.15.0
-      pullPolicy: IfNotPresent
     proxyBodySize: 64m
     resources: {}
   lego:
     image:
       name: jetstack/kube-lego
       tag: 0.1.7
-      pullPolicy: IfNotPresent
     resources: {}
   labels: {}
   nodeSelector: {}


### PR DESCRIPTION
If the image pull policy is left out, it will act as "IfNotPresent"
almost always. The difference is that the default is to make an
adjustment if the tag is "latest", then it will become "Always".

So, hardcoding it makes little sense, and this would help us if we have
a hook-image-puller and we make an upgrade using an image with "latest" tag because we are actively developing the image... Hmmm...

Well, perhaps by submitting this commit in a PR, we can conclude whats
best to do about it.