### PR TITLE
Remove setting node labels in gcloud container create

### DIFF
--- a/doc/source/google/step-zero-gcp.rst
+++ b/doc/source/google/step-zero-gcp.rst
@@ -69,7 +69,6 @@ your google cloud account.
         --num-nodes 2 \
         --zone us-central1-b \
         --cluster-version latest \
-        --node-labels hub.jupyter.org/node-purpose=core \
         <CLUSTERNAME>
       
    * Replace `<CLUSTERNAME>` with a name that can be used to refer to this cluster


### PR DESCRIPTION
This is only needed if you are setting up multiple node
pools - which isn't a common case. Even then, you can create
an additional nodepool for your core then - and you most likely
want to, since it should be sized differently. Removing it
makes the initial setup page fully explainable.