### PR TITLE
Remove 'beta' requirement from gcloud command

### DIFF
--- a/doc/source/google/step-zero-gcp.rst
+++ b/doc/source/google/step-zero-gcp.rst
@@ -64,7 +64,7 @@ your google cloud account.
 
    .. code-block:: bash
 
-      gcloud beta container clusters create \
+      gcloud container clusters create \
         --machine-type n1-standard-2 \
         --num-nodes 2 \
         --zone us-central1-b \


### PR DESCRIPTION
I *think* all these work in the regular gcloud command,
without needing the beta version