### PR TITLE
Explicitly set namespace on all resources

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -2,6 +2,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: hub-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 data:

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
@@ -59,7 +60,7 @@ spec:
       {{- if .Values.hub.imagePullSecret.enabled }}
       imagePullSecrets:
         - name: hub-image-credentials
-      {{- end }}  
+      {{- end }}
       containers:
         {{- if .Values.hub.extraContainers }}
         {{- .Values.hub.extraContainers | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/jupyterhub/templates/hub/image-credentials-secret.yaml
+++ b/jupyterhub/templates/hub/image-credentials-secret.yaml
@@ -3,6 +3,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: hub-image-credentials
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- $_ := merge (dict "componentSuffix" "-image-credentials") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: hub
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/hub/pdb.yaml
+++ b/jupyterhub/templates/hub/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: hub
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/hub/pvc.yaml
+++ b/jupyterhub/templates/hub/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: hub-db-dir
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   {{- if .Values.hub.db.pvc.annotations }}

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -24,6 +24,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hub
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 subjects:

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -2,6 +2,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: hub-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 type: Opaque

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hub
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   annotations:

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -6,6 +6,7 @@ Returns an image-puller daemonset. Two daemonsets will be created like this.
 {{- define "jupyterhub.imagePuller.daemonset" -}}
 apiVersion: apps/v1
 kind: DaemonSet
+namespace: {{ .Release.Namespace }}
 metadata:
   name: {{ print .componentPrefix "image-puller" }}
   labels:

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -10,6 +10,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: hook-image-awaiter
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -10,6 +10,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: hook-image-awaiter
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -44,6 +45,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hook-image-awaiter
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: jupyterhub
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   {{- if .Values.ingress.annotations }}

--- a/jupyterhub/templates/proxy/autohttps/configmap-nginx.yaml
+++ b/jupyterhub/templates/proxy/autohttps/configmap-nginx.yaml
@@ -5,6 +5,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: nginx-proxy-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 data:

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: autohttps
+  namespace: {{ .Release.Namespace }}
   labels:
       {{- /*
         NOTE: The deployment's own app label does not have to deviate like it's

--- a/jupyterhub/templates/proxy/autohttps/ingress-internal.yaml
+++ b/jupyterhub/templates/proxy/autohttps/ingress-internal.yaml
@@ -6,6 +6,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: jupyterhub-internal
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   annotations:

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: autohttps
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---

--- a/jupyterhub/templates/proxy/autohttps/service.yaml
+++ b/jupyterhub/templates/proxy/autohttps/service.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: proxy-http
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     {{- range $key, $value := .Values.proxy.service.labels }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -7,6 +7,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/proxy/secret.yaml
+++ b/jupyterhub/templates/proxy/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: proxy-manual-tls
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 type: kubernetes.io/tls

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: proxy-api
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- $_ := merge (dict "componentSuffix" "-api") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
@@ -22,6 +23,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: proxy-public
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- $_ := merge (dict "componentSuffix" "-public") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}

--- a/jupyterhub/templates/scheduling/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/priorityclass.yaml
@@ -3,6 +3,7 @@ apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
   name: {{ .Release.Name }}-default-priority
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- $_ := merge (dict "componentLabel" "default-priority") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}

--- a/jupyterhub/templates/scheduling/user-placeholder/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/pdb.yaml
@@ -7,6 +7,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: user-placeholder
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
@@ -4,6 +4,7 @@ apiVersion: scheduling.k8s.io/v1beta1
 kind: PriorityClass
 metadata:
   name: {{ .Release.Name }}-user-placeholder-priority
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   annotations:

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -12,6 +12,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: user-placeholder
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: user-scheduler
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 data:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-scheduler
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: user-scheduler
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: user-scheduler
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---

--- a/jupyterhub/templates/singleuser/image-credentials-secret.yaml
+++ b/jupyterhub/templates/singleuser/image-credentials-secret.yaml
@@ -3,6 +3,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: singleuser-image-credentials
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- $_ := merge (dict "componentSuffix" "-image-credentials") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
@@ -15,6 +16,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: hook-singleuser-image-credentials
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- $_ := merge (dict "componentPrefix" "hook-" "componentSuffix" "-image-credentials") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: singleuser
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
By explicitly setting the namespace on all resources, rendered templates can be applied by tools other than Tiller without also requiring special command line flags.