### PR TITLE
Minor fix in docs

### DIFF
--- a/doc/source/security.md
+++ b/doc/source/security.md
@@ -112,7 +112,7 @@ There are many ways to confirm that a domain is running trusted HTTPS
 certificates. One options is to use the [Qualys SSL Labs](https://ssllabs.com)
 security report generator. Use the following URL structure to test your domain:
 
-```yaml
+```
 http://ssllabs.com/ssltest/analyze.html?d=<YOUR-DOMAIN>
 ```
 


### PR DESCRIPTION
Currently, the code snippet displayed under the subsection https://zero-to-jupyterhub.readthedocs.io/en/stable/security.html#confirm-that-your-domain-is-running-https, shows some quotation marks which shouldn't be there. This minor PR fixes that and improves other minor aspects in the style of that doc.


![screen shot 2019-01-04 at 17 13 46](https://user-images.githubusercontent.com/2938045/50698305-d0e50000-1044-11e9-9fd1-6224ba0d7661.png)

Thanks for this project. I would love to try to contribute more shortly.