### PR TITLE
Fix regarding image-puller & profileList - #1097

### DIFF
--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -61,6 +61,7 @@ spec:
             - -c
             - echo "Pulling complete"
         {{- range $k, $container := .Values.singleuser.profileList }}
+        {{- if $container.kubespawner_override }}
         {{- if $container.kubespawner_override.image }}
         - name: image-pull-singleuser-profilelist-{{ $k }}
           image: {{ $container.kubespawner_override.image }}
@@ -69,6 +70,7 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if not .Values.singleuser.cloudMetadata.enabled }}


### PR DESCRIPTION
We forgot to check if the parent value was defined at one point. The go
templating that Helm relies on does not allow for a nice way to do this
with `and` functions as I understand it, see:
https://github.com/helm/helm/issues/3708

So, I opted for this functional solution even though it isnt very
elegant.

Closes #1097