### PR TITLE
adding information about helm chart versions etc

### DIFF
--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -14,7 +14,7 @@ Prepare configuration file
 In this step we will prepare a `YAML <https://en.wikipedia.org/wiki/YAML>`_
 configuration file that we will refer to as `config.yaml`. It will contain the multiple
 :term:`Helm values` to be provided to a JupyterHub :term:`Helm chart` developed
-specifically together with this guide. 
+specifically together with this guide.
 
 Helm charts contains :term:`templates
 <helm template>` that with provided values will render to :term:`Kubernetes
@@ -33,30 +33,30 @@ config file will provide the values to be used by our Helm chart.
    <https://en.wikipedia.org/wiki/GNU_nano>`_, but any editor will do.
 
    .. code-block:: bash
-   
+
       nano config.yaml
-   
+
 3. Write the following into the ``config.yaml`` file but instead of writing
    ``<RANDOM-HEX>`` paste the generated hex string you copied in step 1.
-   
+
    .. code-block:: yaml
 
       proxy:
         secretToken: "<RANDOM_HEX>"
 
    .. note::
-   
+
       It is common practice for Helm and Kubernetes YAML files to indent using
       two spaces.
 
 4. Save the ``config.yaml`` file. In the nano editor this is done by pressing **CTRL+X** or
-   **CMD+X** followed by a confirmation to save the changes. 
+   **CMD+X** followed by a confirmation to save the changes.
 
 .. Don't put an example here! People will just copy paste that & that's a
    security issue.
 
 Install JupyterHub
------------------- 
+------------------
 
 1. Make Helm aware of the `JupyterHub Helm chart repository
    <https://jupyterhub.github.io/helm-chart/>`_ so you can install the
@@ -130,6 +130,8 @@ Install JupyterHub
         chart*, not the version of JupyterHub. Each version of the JupyterHub
         Helm chart is paired with a specific version of JupyterHub. E.g.,
         ``0.7.0`` of the Helm chart runs JupyterHub ``0.9.2``.
+        For a list of which JupyterHub version is installed in each version
+        of the Z2JH Helm Chart, see the `Helm Chart repository <https://github.com/jupyterhub/helm-chart#versions-coupled-to-each-chart-release>`_.
 
 3. While Step 2 is running, you can see the pods being created by entering in
    a different terminal:

--- a/doc/source/troubleshooting.rst
+++ b/doc/source/troubleshooting.rst
@@ -21,3 +21,10 @@ How does billing for this work?
 JupyterHub isn't handling any of the billing for your usage. That's done
 through whatever cloud service you're using. For considerations about
 managing cost with JupyterHub, see :ref:`cost`.
+
+What version of JupyterHub is installed in the Helm Chart?
+----------------------------------------------------------
+
+Each Helm Chart is packaged with a specific version of JupyterHub (and
+other software as well). See see the `Helm Chart repository <https://github.com/jupyterhub/helm-chart#versions-coupled-to-each-chart-release>`_
+for information about the versions of relevant software packages.

--- a/doc/source/upgrading.md
+++ b/doc/source/upgrading.md
@@ -135,6 +135,12 @@ you would use:
 RUN pip install --no-cache-dir jupyterhub==0.8.1
 ```
 
+## JupyterHub versions installed in each Helm Chart
+
+Each Helm Chart is packaged with a specific version of JupyterHub (and
+other software as well). See the [Helm Chart repository](https://github.com/jupyterhub/helm-chart#versions-coupled-to-each-chart-release>) for
+information about the versions of relevant software packages.
+
 ## Troubleshooting
 
 If the upgrade is failing on a test system or a system that does not serve users, you can try


### PR DESCRIPTION
Once https://github.com/jupyterhub/helm-chart/pull/94 lands there will be a nice little table with jupyterhub versions listed per helm chart...this adds in links to that table in a few places in Z2JH where we think people might be looking.