### PR TITLE
fix organisation whitelist config in documentation

### DIFF
--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -63,7 +63,7 @@ To do so, see the configuration below.
         type: github
         github:
           ...
-          org_whitelist:
+          orgWhitelist:
             - "SomeOrgName"
         scopes:
           - "read:user"


### PR DESCRIPTION
Documentation says to use `org_whitelist` key to use:

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/8c09a0c0907e4beebb3a4f79e75f730df395ad8b/doc/source/authentication.rst#L62-L67

but according to the config it is `orgWhitelist`:

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/8c09a0c0907e4beebb3a4f79e75f730df395ad8b/images/hub/jupyterhub_config.py#L264-L271