### PR TITLE
add livenessProbe and readinessProbe to proxy

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -96,3 +96,11 @@ spec:
               name: proxy-public
             - containerPort: 8001
               name: api
+          livenessProbe:
+            httpGet:
+              path: /hub/login
+              port: proxy-public
+          readinessProbe:
+            httpGet:
+              path: /hub/login
+              port: proxy-public


### PR DESCRIPTION
This is necessary for GCE ingress to work, because it pickups healthchecks from readinessProbe. If there is none, then it takes `/`, which in case of proxy-public returns `302` (which is not sufficient). `/hub/login` always returns 200, so this works.