### PR TITLE
Hub Prometheus annotations needs to include baseUrl

### DIFF
--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.hub.service.annotatePrometheus }}
+    prometheus.io/scrape: "true"
+    prometheus.io/path: {{ .Values.hub.baseUrl }}hub/metrics
+    {{- end }}
     {{- if .Values.hub.service.annotations }}
     {{- .Values.hub.service.annotations | toYaml | nindent 4 }}
     {{- end }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -5,8 +5,10 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.hub.service.annotatePrometheus }}
+    {{- if not (index .Values.hub.service.annotations "prometheus.io/scrape") }}
     prometheus.io/scrape: "true"
+    {{- end }}
+    {{- if not (index .Values.hub.service.annotations "prometheus.io/path") }}
     prometheus.io/path: {{ .Values.hub.baseUrl }}hub/metrics
     {{- end }}
     {{- if .Values.hub.service.annotations }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -4,7 +4,6 @@ hub:
   service:
     type: ClusterIP
     annotations: {}
-    annotatePrometheus: true
     ports:
       nodePort:
     loadBalancerIP:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -3,9 +3,8 @@ custom: {}
 hub:
   service:
     type: ClusterIP
-    annotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: /hub/metrics
+    annotations: {}
+    annotatePrometheus: true
     ports:
       nodePort:
     loadBalancerIP:


### PR DESCRIPTION
If jupyterhub is run under a prefix e.g. `hub.baseUrl: /jupyter` this prefix must be included in the Prometheus scrape path. Since Values can't be interpolated I've added a new value `hub.service.annotatePrometheus`. An alternative would be to not add a new value and to unconditionally include the prometheus annotations.