### PR TITLE
Remove out-of-order adjective.

### DIFF
--- a/doc/source/optimization.md
+++ b/doc/source/optimization.md
@@ -332,5 +332,5 @@ scheduling:
 ```
 
 **NOTE**: For the user scheduler to work well, you need old user pods to shut
-down at some point. Make sure to configure the
-[*culler*](user-management.html#culling-user-pods) suitable properly.
+down at some point. Make sure to properly configure the
+[*culler*](user-management.html#culling-user-pods).


### PR DESCRIPTION
Alternatively, rather than remove "suitable", replace it with "service" ?

Or remove the last sentence altogether and link "user pods to shut down" to the culler.