### PR TITLE
Bump k8s/helm requirement to 1.11 / 2.11

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -6,5 +6,5 @@ home: https://z2jh.jupyter.org
 sources:
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
 icon: https://jupyter.org/assets/hublogo.svg
-kubeVersion: '>=1.8.0-0'
-tillerVersion: '>=2.9.1-0'
+kubeVersion: '>=1.11.0-0'
+tillerVersion: '>=2.11.0-0'


### PR DESCRIPTION
The policy of helms chart repository is to support two versions of k8s
backwards. Since this chart relies on 1.11 for various optional features
for this release, that are still quite essential for the release, I
think we should declare this version require k8s 1.11 now that k8s 1.13
is out. Regarding the Helm version, 2.11 is the first version supporting
k8s 1.11.