### PR TITLE
Fix wrong dev version in README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/jupyterhub/zero-to-jupyterhub-k8s.svg?branch=master)](https://travis-ci.org/jupyterhub/zero-to-jupyterhub-k8s)
 [![Documentation Status](https://readthedocs.org/projects/zero-to-jupyterhub/badge/?version=latest)](https://zero-to-jupyterhub.readthedocs.io/en/latest/?badge=latest)
-[![Latest stable release](https://img.shields.io/badge/dynamic/json.svg?label=stable&url=https://api.github.com/repos/jupyterhub/zero-to-jupyterhub-k8s/releases&query=$..[0].tag_name&colorB=orange)](https://jupyterhub.github.io/helm-chart/)
-[![Latest development release](https://img.shields.io/badge/dynamic/yaml.svg?label=dev&url=https%3A%2F%2Fjupyterhub.github.io%2Fhelm-chart%2Findex.yaml&query=%24.entries..jupyterhub[0].version&colorB=orange)](https://jupyterhub.github.io/helm-chart/)
+[![Latest stable release](https://img.shields.io/badge/dynamic/json.svg?label=dev&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.stable&colorB=orange)](https://jupyterhub.github.io/helm-chart/)
+[![Latest development release](https://img.shields.io/badge/dynamic/json.svg?label=dev&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.latest&colorB=orange)](https://jupyterhub.github.io/helm-chart/)
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue.svg)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues)
 [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue.svg)](https://discourse.jupyter.org/c/jupyterhub/z2jh-k8s)
 [![Gitter](https://img.shields.io/badge/social_chat-gitter-blue.svg)](https://gitter.im/jupyterhub/jupyterhub)


### PR DESCRIPTION
The information about the latest version dev version from the chart repo
was not easily accessible without some additional sorting. Therefore I
made a commit to helm-chart's gh-pages to add a info.json file that
contained exactly the information we require for these badges.

```sh
curl https://jupyterhub.github.io/helm-chart/info.json
```

```json
{
    "jupyterhub": {
        "latest": "0.8-580f46e",
        "stable": "0.7.0"
    },
    "binderhub": {
        "latest": "0.2.0-276d090",
        "stable": ""
    }
}
```