### PR TITLE
Update setup-jupyterhub.rst

### DIFF
--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -181,7 +181,7 @@ Install JupyterHub
 
       .. code-block:: bash
 
-         kubectl describe service proxy-public --output=wide --namespace jhub
+         kubectl describe service proxy-public --namespace jhub
 
 
 7. To use JupyterHub, enter the external IP for the `proxy-public` service in


### PR DESCRIPTION
`describe` or `--output=wide`, not both.

The command as-presented doesn't work. It sounds like the author wanted the output of `describe`, so removed `--output=wide`.