### PR TITLE
GCE ingress improvements and documentation extension on github and profile

### DIFF
--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -76,8 +76,8 @@ GitHub organisations and users.
 For example, omitting the scope means members of an organisation must `set
 their membership to Public
 <https://help.github.com/articles/publicizing-or-hiding-organization-membership/>`_
-to login, whereas setting it to ``read:org`` may require approval of the
-application by a GitHub organisation admin.
+to login, whereas setting it to ``read:org`` (which is needed to let non-admin organization members
+sign in) may require approval of the application by a GitHub organisation admin. 
 Please see `this issue
 <https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/687>`_ for further
 information.

--- a/doc/source/user-environment.rst
+++ b/doc/source/user-environment.rst
@@ -313,7 +313,9 @@ Each configuration is a set of options for `Kubespawner <https://github.com/jupy
 which defines how Kubernetes should launch a new user server pod. Any
 configuration options passed to the `profileList` configuration will
 overwrite the defaults in Kubespawner (or any configuration you've
-added elsewhere in your helm chart).
+added elsewhere in your helm chart). All `kubespawner` options can be found in the source
+code of `kubespawner <https://github.com/jupyterhub/kubespawner/blob/master/kubespawner/spawner.py#L79>`_
+class. 
 
 Profiles are stored under ``singluser.profileList``, and are defined as
 a list of profiles with specific configuration options each. Here's an example:
@@ -333,8 +335,9 @@ a list of profiles with specific configuration options each. Here's an example:
 The above configuration will show a screen with information about this profile
 displayed when users start a new server.
 
-Here's an example with two profiles that lets users select the environment they
-wish to use.
+Here's an example with three profiles that lets users select the environment they
+wish to use, where environment can range from different image to spawning 
+on a different node with different requirements or limits.
 
 .. code-block:: yaml
 
@@ -355,6 +358,17 @@ wish to use.
          description: "The Jupyter Stacks spark image!"
          kubespawner_override:
            image: jupyter/all-spark-notebook:2343e33dec46
+       - display_name: "Spark environment on High Mem Node with taints"
+         description: "The Jupyter Stacks spark image on high mem node!"
+         kubespawner_override:
+           image: jupyter/all-spark-notebook:2343e33dec46
+           node_selector:
+             your_label: my_high_mem_node_specifier
+           tolerations:
+             - key: "resilent"
+               operator: "Equal"
+               value: "true"
+               effect: "NoSchedule"
 
 This allows users to select from three profiles, each with their own
 environment (defined by each Docker image in the configuration above).

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  backend:
+    serviceName: proxy-public
+    servicePort: 80
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host | quote }}


### PR DESCRIPTION
# Attempt to summarize by @consideRatio

### About using the GCE Ingress Controller

This PR adds documentation (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1136/commits/331f1cbf3045b837481fe50ccd588e4e919c3e74) and two lines of code (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1136/commits/87380cc99b1fee75e3f67eb94ef78aa35ba1f147) to use the GCE Ingress Controller to manage the optional ingress k8s resources that the z2jh helm chart can provide.

### Additional parts (LGTM)

This PR also clarifies setup of GitHub authentication (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1136/commits/60268f5581b4f25a7587fc5e65357502be7c15e3) and adds an example to use the kubespawner's profile list feature (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1136/commits/63fd107faffa30584a9fe0fb762121495585beba).

---

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1125