### PR TITLE
unpin some dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,6 @@
 chartpress==0.2.2
 
 # yamllint and pytest are important for local development, CI
-pytest==3.7.1
-requests==2.19.1
+pytest>=3.7.1
+requests
 yamllint>=1.1.1


### PR DESCRIPTION
no need to pin some super-stable packages down. Resolves security alert on the repo for out-of-date requests.