### PR TITLE
Allow configuration of Kuberspawner's pod_name_template

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -100,8 +100,6 @@ if release:
 
 c.KubeSpawner.namespace = os.environ.get('POD_NAMESPACE', 'default')
 
-c.KubeSpawner.pod_name_template = get_config('singleuser.podNameTemplate')
-
 # Max number of consecutive failures before the Hub restarts itself
 # requires jupyterhub 0.9.2
 set_config_if_not_none(
@@ -111,6 +109,7 @@ set_config_if_not_none(
 )
 
 for trait, cfg_key in (
+    ('pod_name_template', None),
     ('start_timeout', None),
     ('image_pull_policy', 'image.pullPolicy'),
     ('image_pull_secrets', 'image.pullSecrets'),

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -100,6 +100,8 @@ if release:
 
 c.KubeSpawner.namespace = os.environ.get('POD_NAMESPACE', 'default')
 
+c.KubeSpawner.pod_name_template = get_config('singleuser.podNameTemplate')
+
 # Max number of consecutive failures before the Hub restarts itself
 # requires jupyterhub 0.9.2
 set_config_if_not_none(

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -770,6 +770,10 @@ properties:
     description: |
       Options for customizing the environment that is provided to the users after they log in.
     properties:
+      podNameTemplate:
+        type: string
+        description: |
+          Template for the pod name of each user, such as `jupyter-{username}{servername}`.
       cpu:
         type: object
         description: |

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -231,7 +231,7 @@ auth:
 
 
 singleuser:
-  podNameTemplate: jupyter-{username}{servername}
+  podNameTemplate:
   extraTolerations: []
   nodeSelector: {}
   extraNodeAffinity:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -231,6 +231,7 @@ auth:
 
 
 singleuser:
+  podNameTemplate: jupyter-{username}{servername}
   extraTolerations: []
   nodeSelector: {}
   extraNodeAffinity:


### PR DESCRIPTION
Kubespawner allows us to configure user's pod name, but it's not exposed in this z2j chart.
I made it configurable in values.yaml.

ref: https://github.com/jupyterhub/kubespawner/blob/7e515c50bc3aeed75539df321ee63b4d070168d1/kubespawner/spawner.py#L262-L274