### PR TITLE
use chartpress 0.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 # - builds images and can push them also (--push)
 # - updates image names and tags in values.yaml
 # - can publish the built Helm chart (--publish)
-chartpress==0.2.2
+chartpress==0.3.0
 
 # yamllint and pytest are important for local development, CI
 pytest>=3.7.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 # - builds images and can push them also (--push)
 # - updates image names and tags in values.yaml
 # - can publish the built Helm chart (--publish)
-chartpress==0.3.0
+chartpress==0.3.1
 
 # yamllint and pytest are important for local development, CI
 pytest>=3.7.1


### PR DESCRIPTION
will add chart version as prefix to image tags (0.8-abc123 instead of just abc123) making it easier to see which image builds go with which chart version