### PR TITLE
Correct outdated warning about AKS

### DIFF
--- a/doc/source/security.md
+++ b/doc/source/security.md
@@ -177,10 +177,8 @@ rbac:
 ```
 
 We strongly **discourage disabling** the RBAC rules and remind you that this
-action will open up security vulnerabilities. However, some cloud providers
-(particularly Azure AKS)
-[do not support RBAC](https://github.com/Azure/AKS/issues/67) right now,
-and you might have to disable RBAC with this config to run on Azure.
+action will open up security vulnerabilities. However, some cloud providers may
+not support RBAC in which case you can disable it with this config.
 
 ## Kubernetes API Access
 


### PR DESCRIPTION
It seem that AKS does support RBAC now.

https://docs.microsoft.com/en-us/azure/aks/faq#does-aks-support-kubernetes-role-based-access-control-rbac
