### PR TITLE
Fix bug affecting config of authenticators

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -272,22 +272,30 @@ elif auth_type == 'github':
 elif auth_type == 'cilogon':
     c.JupyterHub.authenticator_class = 'oauthenticator.CILogonOAuthenticator'
     for trait, cfg_key in common_oauth_traits:
+        if cfg_key is None:
+            cfg_key = camelCaseify(trait)
         set_config_if_not_none(c.CILogonOAuthenticator, trait, 'auth.cilogon.' + cfg_key)
 elif auth_type == 'gitlab':
     c.JupyterHub.authenticator_class = 'oauthenticator.gitlab.GitLabOAuthenticator'
     for trait, cfg_key in common_oauth_traits:
+        if cfg_key is None:
+            cfg_key = camelCaseify(trait)
         set_config_if_not_none(c.GitLabOAuthenticator, trait, 'auth.gitlab.' + cfg_key)
 elif auth_type == 'mediawiki':
     c.JupyterHub.authenticator_class = 'oauthenticator.mediawiki.MWOAuthenticator'
     for trait, cfg_key in common_oauth_traits + (
         ('index_url', None),
     ):
+        if cfg_key is None:
+            cfg_key = camelCaseify(trait)
         set_config_if_not_none(c.MWOAuthenticator, trait, 'auth.mediawiki.' + cfg_key)
 elif auth_type == 'globus':
     c.JupyterHub.authenticator_class = 'oauthenticator.globus.GlobusOAuthenticator'
     for trait, cfg_key in common_oauth_traits + (
         ('identity_provider', None),
     ):
+        if cfg_key is None:
+            cfg_key = camelCaseify(trait)
         set_config_if_not_none(c.GlobusOAuthenticator, trait, 'auth.globus.' + cfg_key)
 elif auth_type == 'hmac':
     c.JupyterHub.authenticator_class = 'hmacauthenticator.HMACAuthenticator'


### PR DESCRIPTION
The bugfix relates to using config like:

```yaml
auth:
  type: X # where X is cilogin, gitlab, mediawiki or globus
  X:
    clientId: something... # not utilized pre-fix
    clientSecret: something... # not utilized pre-fix
```

---

Closes one bug described in #1167 