### PR TITLE
Add missing auth options for gitlab

### DIFF
--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -277,7 +277,10 @@ elif auth_type == 'cilogon':
         set_config_if_not_none(c.CILogonOAuthenticator, trait, 'auth.cilogon.' + cfg_key)
 elif auth_type == 'gitlab':
     c.JupyterHub.authenticator_class = 'oauthenticator.gitlab.GitLabOAuthenticator'
-    for trait, cfg_key in common_oauth_traits:
+    for trait, cfg_key in common_oauth_traits + (
+        ('gitlab_group_whitelist', None),
+        ('gitlab_project_id_whitelist', None),
+    ):
         if cfg_key is None:
             cfg_key = camelCaseify(trait)
         set_config_if_not_none(c.GitLabOAuthenticator, trait, 'auth.gitlab.' + cfg_key)


### PR DESCRIPTION
This single commit PR adds the ability to configure new options introduced with `oauthenticator==0.8.1`, and the config example below is how I understand that a working config would look.

---

The following is now a valid configuration for oauthenticator 0.8.1 I
think:

```yaml
hub:
  extraEnv:
    GITLAB_URL: https://my-gitlab-instance.example.com

auth:
  type: gitlab
  gitlab:
    clientId: <client id>
    clientSecret: <client secret>
    callbackUrl: <callback url>
    gitlabGroupWhitelist:
      - "groupName1"
      - "groupName2"
    gitlabProjectIdWhitelist:
      - "projectId1"
      - "projectId2"
```