### PR TITLE
Docs update: Securing Helm

### DIFF
--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -9,6 +9,12 @@ Helm packages are called *charts*.
 We will be installing and managing JupyterHub on
 our Kubernetes cluster using a Helm chart.
 
+Charts are abstractions describing how to install packages onto a Kubernetes
+cluster. When a chart is deployed, it works as a templating engine to populate
+multiple `yaml` files for package dependencies with the required variables, and
+then runs `kubectl apply` to apply the configuration to the resource and install
+the package.
+
 Helm has two parts: a client (`helm`) and a server (`tiller`). Tiller runs
 inside of your Kubernetes cluster as a pod in the kube-system namespace. Tiller
 manages both, the *releases* (installations) and *revisions* (versions) of charts deployed
@@ -65,6 +71,8 @@ cluster:
    This command only needs to run once per Kubernetes cluster, it will create a
    `tiller` deployment in the kube-system namespace and setup your local `helm`
    client.
+   This is the step that configures `helm` commands executed in a local
+   terminal to be deployed within the remote cluster by `tiller`.
 
    .. note::
     
@@ -78,11 +86,18 @@ cluster:
 Secure Helm
 -----------
 
-Ensure that `tiller is secure <https://engineering.bitnami.com/articles/helm-security.html>`_ from access inside the cluster:
+Ensure that `tiller` is secure from access inside the cluster:
 
 .. code:: bash
 
    kubectl patch deployment tiller-deploy --namespace=kube-system --type=json --patch='[{"op": "add", "path": "/spec/template/spec/containers/0/command", "value": ["/tiller", "--listen=localhost:44134"]}]'
+
+`tiller` s port is exposed in the cluster without authentication and if you probe
+this port directly (i.e. by bypassing `helm`) then `tiller` s permissions can be
+exploited. This step forces `tiller` to listen to commands from localhost (i.e.
+`helm`) *only* so that e.g. other pods inside the cluster cannot ask `tiller` to
+install a new chart granting them arbitrary, elevated RBAC privileges and exploit
+them. `More details here. <https://engineering.bitnami.com/articles/helm-security.html>`_
 
 Verify
 ------

--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -71,10 +71,10 @@ cluster:
    This command only needs to run once per Kubernetes cluster, it will create a
    `tiller` deployment in the kube-system namespace and setup your local `helm`
    client.
-   This command installs and configures the ``tiller`` part of Helm (the whole
+   This command installs and configures the `tiller` part of Helm (the whole
    project, not the CLI) on the remote kubernetes cluster. Later when you want
-   to deploy changes with ``helm`` (the local CLI), it will talk to ``tiller``
-   and tell it what to do. ``tiller`` then executes these instructions from
+   to deploy changes with `helm` (the local CLI), it will talk to `tiller`
+   and tell it what to do. `tiller` then executes these instructions from
    within the cluster.
 
    .. note::

--- a/doc/source/setup-helm.rst
+++ b/doc/source/setup-helm.rst
@@ -71,8 +71,11 @@ cluster:
    This command only needs to run once per Kubernetes cluster, it will create a
    `tiller` deployment in the kube-system namespace and setup your local `helm`
    client.
-   This is the step that configures `helm` commands executed in a local
-   terminal to be deployed within the remote cluster by `tiller`.
+   This command installs and configures the ``tiller`` part of Helm (the whole
+   project, not the CLI) on the remote kubernetes cluster. Later when you want
+   to deploy changes with ``helm`` (the local CLI), it will talk to ``tiller``
+   and tell it what to do. ``tiller`` then executes these instructions from
+   within the cluster.
 
    .. note::
     


### PR DESCRIPTION
This PR proposes some changes to the documentation surrounding Helm. These are some things I've learned while deploying my own JupyterHub/BinderHub and I thought it would be cool to make these concepts more explicit in the documentation.

Additions are:
* A short description of what a Helm Chart is and does when it is applied
* Making explicit which step it is that allows `helm` commands executed locally to affect a remote cluster without an ssh
* Adding a short explanation as to why the security patch for `tiller` is required, still pointing to the awesome blog post

will fix #1179 