### PR TITLE
Fixed typo in user-environment.rst

### DIFF
--- a/doc/source/user-environment.rst
+++ b/doc/source/user-environment.rst
@@ -314,7 +314,7 @@ configuration options passed to the `profileList` configuration will
 overwrite the defaults in Kubespawner (or any configuration you've
 added elsewhere in your helm chart).
 
-Profiles are stored under ``singluser.profileList``, and are defined as
+Profiles are stored under ``singleuser.profileList``, and are defined as
 a list of profiles with specific configuration options each. Here's an example:
 
 .. code-block:: yaml


### PR DESCRIPTION
Fixes a small typo on the User Environment page