### PR TITLE
Remove --yes option in pip install

### DIFF
--- a/doc/source/user-environment.rst
+++ b/doc/source/user-environment.rst
@@ -138,7 +138,7 @@ by the Helm chart.
    # https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook/Dockerfile
 
    # install additional package...
-   RUN pip install --yes astropy
+   RUN pip install --no-cache-dir astropy
 
 .. note:
 


### PR DESCRIPTION
The --yes install doesn't seem to exist : https://pip.pypa.io/en/stable/reference/pip_install/