### PR TITLE
[resource prefixing] Service name with fullname function

### DIFF
--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -82,11 +82,20 @@
     function properly. It is a way to override the default app label's value.
 */}}
 
+{{/*
+Create a fully qualified name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+
+{{- define "jhub.fullName" -}}
+{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end }}
 
 {{- /*
   jupyterhub.appLabel:
     Used by "jupyterhub.labels".
 */}}
+
 {{- define "jupyterhub.appLabel" -}}
 {{ .Values.nameOverride | default .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: hub
+  name: {{ include "jhub.fullName" . }}-hub
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   annotations:

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: proxy-api
+  name: {{- include "jhub.fullName" . }}-proxy-api
   labels:
     {{- $_ := merge (dict "componentSuffix" "-api") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
@@ -21,7 +21,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: proxy-public
+  name: {{- include "jhub.fullName" . }}-proxy-public
   labels:
     {{- $_ := merge (dict "componentSuffix" "-public") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{- include "jhub.fullName" . }}-proxy-api
+  name: {{ include "jhub.fullName" . }}-proxy-api
   labels:
     {{- $_ := merge (dict "componentSuffix" "-api") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
@@ -21,7 +21,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{- include "jhub.fullName" . }}-proxy-public
+  name: {{ include "jhub.fullName" . }}-proxy-public
   labels:
     {{- $_ := merge (dict "componentSuffix" "-public") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}


### PR DESCRIPTION
First commit of the feature to have the service name with the fullname

Related with the Issue #1208

Signed-off-by: Jdavid <jose.david@harbur.io>