### PR TITLE
This PR allows to use template call in singleuser values.yaml

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -33,4 +33,4 @@ data:
 {{- $_ := set $values "Chart" (dict "Name" .Chart.Name "Version" .Chart.Version) }}
 {{- $_ := set $values "Release" (pick .Release "Name" "Namespace" "Service") }}
   values.yaml: |
-    {{- $values | toYaml | nindent 4 }}
+    {{- tpl ($values | toYaml | nindent 4) . }}


### PR DESCRIPTION
 This PR allows to use template call in singleuser values.yaml, enabling for example to mount volumes whose name depends on  .Release.Name