### PR TITLE
Fix the default value of lifecycleHooks

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -180,7 +180,7 @@ singleuser:
   extraLabels:
     hub.jupyter.org/network-access-hub: 'true'
   extraEnv: {}
-  lifecycleHooks:
+  lifecycleHooks: {}
   initContainers: []
   extraContainers: []
   uid: 1000

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -215,7 +215,7 @@ singleuser:
   events: true
   extraLabels: {}
   extraEnv: {}
-  lifecycleHooks:
+  lifecycleHooks: {}
   initContainers:
     - name: mock-init-container-name
       image: mock-init-container-image


### PR DESCRIPTION
If we used the blank value as we had before, Helm would fail to override
it with an object and say:

```
2019/04/03 21:38:31 Warning: Merging destination map for chart 'jupyterhub'. The destination item 'lifecycleHooks' is a table and ignoring the source 'lifecycleHooks' as it has a non-table value of: <nil>
```