### PR TITLE
Relax HSTS requirement on subdomains

### DIFF
--- a/jupyterhub/templates/proxy/autohttps/configmap-nginx.yaml
+++ b/jupyterhub/templates/proxy/autohttps/configmap-nginx.yaml
@@ -9,4 +9,5 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 data:
   proxy-body-size: "{{ .Values.proxy.nginx.proxyBodySize }}"
+  hsts-include-subdomains: "{{ .Values.proxy.nginx.hstsIncludeSubdomains }}"
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -95,6 +95,7 @@ proxy:
       name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
       tag: 0.15.0
     proxyBodySize: 64m
+    hstsIncludeSubdomains: "false"
     resources: {}
   lego:
     image:


### PR DESCRIPTION
Currently, if you have a JupyterHub at datahub.berkeley.edu with
HTTPS, you can *not* have a grafana.datahub.berkeley.edu without
HTTPS. This is because the default HSTS is set to 'includeSubdomains',
which means any subdomain must also enforce HTTPS.

This is a bit of an overreach, since the hub doesn't control any
other subdomain. This sets the default to be a bit more relaxed,
and allows people to turn it on if needed.