### PR TITLE
Updated notes, pod status to Running

### DIFF
--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -6,7 +6,7 @@ You can find if the hub and proxy is ready by doing:
 
  kubectl --namespace={{ .Release.Namespace }} get pod
 
-and watching for both those pods to be in status 'Ready'.
+and watching for both those pods to be in status 'Running'.
 
 You can find the public IP of the JupyterHub by doing:
 


### PR DESCRIPTION
Ready is a PodCondition type, but status returned from kubectl get pods is the phase, which should be Running.