### PR TITLE
Added OAuth callback URL to keycloak OIDC example

### DIFF
--- a/doc/source/authentication.rst
+++ b/doc/source/authentication.rst
@@ -193,6 +193,7 @@ and obtain the confidential client credentials.
      extraEnv:
        OAUTH2_AUTHORIZE_URL: https://${host}/auth/realms/${realm}/protocol/openid-connect/auth
        OAUTH2_TOKEN_URL: https://${host}/auth/realms/${realm}/protocol/openid-connect/token
+       OAUTH_CALLBACK_URL: https://<your_jupyterhub_host>/hub/oauth_callback
    auth:
      type: custom
      custom:


### PR DESCRIPTION
Had to specify an https callback URL for a keycloak OIDC auth, but didn't find how to do so in the docs. Found it discussed in the issues section with two options:

- OAUTH_CALLBACK_URL environment variables.
- oauth_callback_url in auth.custom.config.