### PR TITLE
Suggest Discourse in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,16 +3,16 @@ Welcome to Zero to JupyterHub!
 
 Before filing an issue, please search through the issues and
 [Discourse forum](https://discourse.jupyter.org/) to see
-if your question has been discussed before. If you
-need more information after searching, feel
-free to message us on the gitter channel. Many
-JupyterHub community members watch the gitter channel
+if your question has been discussed before.
+
+If you have a general question about using this repository, or are
+looking for advice on using and configuring JupyterHub,
+please use the [Discourse forum](https://discourse.jupyter.org/).
+Many JupyterHub community members are members of the forum
 so you will have the benefit of other users' experience
 as well as the JupyterHub team.
 
-If you have a general question about using this repository
-please use the [Discourse forum](https://discourse.jupyter.org/),
-and submit as much detail about your issue as possible.
+Please submit as much detail about your issue as possible.
 If you think it would be helpful, include a
 scrubbed version of your `config.yaml` file.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,8 @@
 <!--
 Welcome to Zero to JupyterHub!
 
-Before filing an issue, please search through the issues to see
+Before filing an issue, please search through the issues and
+[Discourse forum](https://discourse.jupyter.org/) to see
 if your question has been discussed before. If you
 need more information after searching, feel
 free to message us on the gitter channel. Many
@@ -9,11 +10,11 @@ JupyterHub community members watch the gitter channel
 so you will have the benefit of other users' experience
 as well as the JupyterHub team.
 
-If you still wish to file an issue, please submit
-as much detail about your issue as possible. If
-you think it would be helpful, include a
-scrubbed version of your `config.yaml` file. We've put
-a place below where you can paste this in.
+If you have a general question about using this repository
+please use the [Discourse forum](https://discourse.jupyter.org/),
+and submit as much detail about your issue as possible.
+If you think it would be helpful, include a
+scrubbed version of your `config.yaml` file.
 
 *** WARNING ***
 Make sure you remove all sensitive information that's
@@ -27,10 +28,7 @@ Please remove at *least* the following fields:
 
 If you post any sensitive information we reserve the
 right to edit your comment in order to remove it.
--->
 
-## Contents of `config.yaml`
-```
-CONTENTS HERE.
-DON'T FORGET TO REMOVE SENSITIVE INFO!
-```
+If you have a bug report or a technical suggestion directly relevant
+to this repostiory please open an issue.
+-->


### PR DESCRIPTION
See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1230#issuecomment-482305040
> Can move this discussion to http://discourse.jupyter.org/ (where most of the people who hang out here also hang out, as well as more people). We are trying to streamline the different discussion places and want to use the issues on GitHub repos for technical discussions on how to change the contents of the repo. More general discussions should go to discourse so that they are easier to find, better indexed by google and generally more accessible than being hidden in the bowls of a GitHub repository ;)

I thought it'd be useful to mention Discourse in the issue template.