### PR TITLE
Supply runAsUser at the container level

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -54,7 +54,6 @@ spec:
       serviceAccountName: hub
       {{- end }}
       securityContext:
-        runAsUser: {{ .Values.hub.uid }}
         fsGroup: {{ .Values.hub.fsGid }}
       {{- if .Values.hub.imagePullSecret.enabled }}
       imagePullSecrets:
@@ -113,6 +112,8 @@ spec:
           {{- with .Values.hub.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
+          securityContext:
+            runAsUser: {{ .Values.hub.uid }}
           env:
             - name: PYTHONUNBUFFERED
               value: "1"


### PR DESCRIPTION
Without this the istio-init initContainer fails.

This is a similar issue as existed in this chart: https://github.com/helm/charts/commit/4daf2d02ed2532572872e8cf6eb4915e5a8af53a