### PR TITLE
Bump CHP image to 4.1.0 from 3.0.0

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -85,7 +85,7 @@ proxy:
   chp:
     image:
       name: jupyterhub/configurable-http-proxy
-      tag: 3.0.0
+      tag: 4.1.0
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
Could help us get #1004 merged. I created the PR to trigger our CI pipeline, but I'm not able to conclude if it is safe to merge.

DockerHub: https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags
Changelog: https://github.com/jupyterhub/configurable-http-proxy/blob/master/CHANGELOG.md