### PR TITLE
enable user scheduler by default

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -229,7 +229,7 @@ singleuser:
 scheduling:
   userScheduler:
     enabled: true
-    replicas: 1
+    replicas: 2
     logLevel: 4
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -228,7 +228,7 @@ singleuser:
 
 scheduling:
   userScheduler:
-    enabled: false
+    enabled: true
     replicas: 1
     logLevel: 4
     image:


### PR DESCRIPTION
I think we've learned through testing of 0.8 that the user scheduler is a success and we can turn it on by default for users with the next release