### PR TITLE
Clean up a line in the CI logs

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -95,7 +95,7 @@ proxy:
       name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
       tag: 0.15.0
     proxyBodySize: 64m
-    hstsIncludeSubdomains: "false"
+    hstsIncludeSubdomains: 'false'
     resources: {}
   lego:
     image:


### PR DESCRIPTION
This value was previously quoted with ", but when `chartpress` parses this
YAML and writes it back in our CI steps, the following change arise and is
written to the logs which distracted me.

```diff
-    hstsIncludeSubdomains: "false"
+    hstsIncludeSubdomains: 'false'
```

So, by either making this value a boolean or a string with single quote
we get rid of this log entry coming from a `git diff`. I went with
single quotes for a minimalistic change.