### PR TITLE
hub: Add useful debugging tools to hub image

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && \
       libcurl4-openssl-dev \
       build-essential \
       sqlite3 \
+      curl \
+      dnsutils \
       $(bash -c 'if [[ $JUPYTERHUB_VERSION == "git"* ]]; then \
         echo npm; \
       fi') \


### PR DESCRIPTION
When debugging hub network issues, it is handy to have
the following tools:

1. curl - Validate HTTP / HTTPS endpoints
2. dig - Validate DNS

They don't increase the image size too much. This commit
adds them both