### PR TITLE
Disable becoming root inside hub and proxy containers

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -55,8 +55,6 @@ spec:
       {{- end }}
       securityContext:
         fsGroup: {{ .Values.hub.fsGid }}
-        # Don't allow any process to execute as root inside the container
-        allowPrivilegeEscalation: false
       {{- if .Values.hub.imagePullSecret.enabled }}
       imagePullSecrets:
         - name: hub-image-credentials
@@ -116,6 +114,8 @@ spec:
           {{- end }}
           securityContext:
             runAsUser: {{ .Values.hub.uid }}
+            # Don't allow any process to execute as root inside the container
+            allowPrivilegeEscalation: false
           env:
             - name: PYTHONUNBUFFERED
               value: "1"

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -55,6 +55,8 @@ spec:
       {{- end }}
       securityContext:
         fsGroup: {{ .Values.hub.fsGid }}
+        # Don't allow any process to execute as root inside the container
+        allowPrivilegeEscalation: false
       {{- if .Values.hub.imagePullSecret.enabled }}
       imagePullSecrets:
         - name: hub-image-credentials

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -46,9 +46,6 @@ spec:
           secret:
             secretName: {{ .Values.proxy.https.secret.name }}
       {{- end }}
-      securityContext:
-        # Don't allow any process to execute as root inside the container
-        allowPrivilegeEscalation: false
       containers:
         - name: chp
           image: {{ .Values.proxy.chp.image.name }}:{{ .Values.proxy.chp.image.tag }}
@@ -83,6 +80,9 @@ spec:
           {{- end }}
           resources:
             {{- .Values.proxy.chp.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+          securityContext:
+            # Don't allow any process to execute as root inside the container
+            allowPrivilegeEscalation: false
           env:
             - name: CONFIGPROXY_AUTH_TOKEN
               valueFrom:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -46,6 +46,9 @@ spec:
           secret:
             secretName: {{ .Values.proxy.https.secret.name }}
       {{- end }}
+      securityContext:
+        # Don't allow any process to execute as root inside the container
+        allowPrivilegeEscalation: false
       containers:
         - name: chp
           image: {{ .Values.proxy.chp.image.name }}:{{ .Values.proxy.chp.image.tag }}


### PR DESCRIPTION
We never need anything to become the root user inside
the hub / proxy containers while they are running.
This removes the ability from them, making it harder
for any exploit in the hub / proxy to be used to gain
root on the underlying machine