### PR TITLE
Include jupyter-firstuseauthenticator.

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -1,5 +1,6 @@
 # jupyterhub version is defined in chartpress.yaml
 jupyterhub-dummyauthenticator==0.3.1
+jupyterhub-firstuseauthenticator==0.12
 jupyterhub-tmpauthenticator==0.5
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2


### PR DESCRIPTION
It would be convenient to have this authenticator, which is nice model for
JupyterHubs used at workshops, available in the hub image by default.

If this change is acceptable, I would be happy to add mention of this option to
the documentation in this PR.