### PR TITLE
Update Dockerfile to JH 1.0

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ARG JUPYTERHUB_VERSION=0.9.*
+ARG JUPYTERHUB_VERSION=1.0.*
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Took me awhile to debug this one. Dockerfile doesn't actually point to JH 1.0 in #1263 @minrk

Perhaps it'd be better to remove the arg from the ci system and rely on the dockerfile to keep this from happening again?