### PR TITLE
WIP: Allow manual definition of service accounts

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -43,10 +43,10 @@ properties:
         description: |
           Creates an image pull secret for you and makes the hub pod utilize
           it, allowing it to pull images from private image registries.
-          
+
           Using this configuration option automates the following steps that
           normally is required to pull from private image registries.
-          
+
           ```sh
           # you won't need to run this manually...
           kubectl create secret docker-registry hub-image-credentials \
@@ -108,7 +108,7 @@ properties:
 
               For gcr.io registries the password will be a big JSON blob for a
               Google cloud service account, it should look something like below.
-                            
+
               ```yaml
               password: |-
                 {
@@ -144,7 +144,7 @@ properties:
             type: string
             description: |
               The tag of the image to pull.
-              
+
               This is the value after the `:` in your full image name.
 
               ```
@@ -280,7 +280,7 @@ properties:
         type: list
         description: |
           list of initContainers to be run with hub pod. See [Kubernetes Docs](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
-          
+
           ```yaml
           hub:
             initContainers:
@@ -451,7 +451,7 @@ properties:
         description: |
           Object to configure the service the JupyterHub's proxy will be exposed on by the Kubernetes server.
         properties:
-          type: 
+          type:
             type: string
             enum:
               - ClusterIP
@@ -567,12 +567,12 @@ properties:
               key:
                 type: string
                 description: |
-                  Path to the private key to be used for HTTPS. 
+                  Path to the private key to be used for HTTPS.
                   Example: `'tls.key'`
               crt:
                 type: string
                 description: |
-                  Path to the certificate to be used for HTTPS. 
+                  Path to the certificate to be used for HTTPS.
                   Example: `'tls.crt'`
           hosts:
             type: list
@@ -583,7 +583,7 @@ properties:
               ```
               hosts:
                 - <your-domain-name>
-              ```   
+              ```
       pdb:
         type: object
         description: |
@@ -655,7 +655,7 @@ properties:
         type: object
         description: |
           Set Memory limits & guarantees that are enforced for each user.
-          
+
           See the [Kubernetes docs](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container)
           for more info.
         properties:
@@ -674,10 +674,10 @@ properties:
         description: |
           Creates an image pull secret for you and makes the user pods utilize
           it, allowing them to pull images from private image registries.
-          
+
           Using this configuration option automates the following steps that
           normally is required to pull from private image registries.
-          
+
           ```sh
           # you won't need to run this manually...
           kubectl create secret docker-registry singleuser-image-credentials \
@@ -741,7 +741,7 @@ properties:
 
               For gcr.io registries the password will be a big JSON blob for a
               Google cloud service account, it should look something like below.
-                            
+
               ```yaml
               password: |-
                 {
@@ -840,7 +840,7 @@ properties:
           certain label (node affinity). They may also require to be scheduled
           in proximity or with a lack of proximity to another pod (pod affinity
           and anti pod affinity).
-          
+
           See the [Kubernetes
           docs](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
           for more info.
@@ -1166,3 +1166,56 @@ properties:
           myConfig.py: |
             c.MyAuthenticator.host = get_config("custom.myHost")
       ```
+
+
+  rbac:
+    type: object
+    properties:
+      create:
+        type: boolean
+        description: |
+            Create RBAC roles for a Kubenertes Cluster when RBAC is enabled.
+            Users who wish to manage RBAC access controls themselves can set this value to false and
+            would adapt the `serviceAccount` part of their configuration.
+
+
+  serviceAccounts:
+    type: object
+    description: |
+      Allow to create or set the service account to use for the puller, culler and https proxy.
+      Please note it does not impact the singleuser pod (see `singleuser.serviceAccountName`).
+    properties:
+      hub:
+        type: object
+        properties:
+          create:
+            type: bool
+          name:
+            type: string
+      imagePuller:
+        type: object
+        properties:
+          create:
+            type: bool
+          name:
+            type: string
+      autohttps:
+        type: object
+        properties:
+          create:
+            type: bool
+          name:
+            type: string
+      scheduling:
+        type: object
+        properties:
+          userScheduler:
+            type: object
+            properties:
+              create:
+                type: bool
+              name:
+                type: string
+          customServiceAccount:
+            type: string
+            description: |

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -11,8 +11,8 @@
   single a single punctuation (.).
 
   When you ask a helper to render its content, one often forward the current
-  scope to the helper in order to allow it to access .Release.Name,
-  .Values.rbac.enabled and similar values.
+  scope to the helper in order to allow it to access .Release.Name and similar
+  values.
 
   #### Example - Passing the current scope
   {{ include "jupyterhub.commonLabels" . }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -50,15 +50,13 @@ spec:
           persistentVolumeClaim:
             claimName: hub-db-dir
         {{- end }}
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: hub
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccounts.hub.name }}
       securityContext:
         fsGroup: {{ .Values.hub.fsGid }}
       {{- if .Values.hub.imagePullSecret.enabled }}
       imagePullSecrets:
         - name: hub-image-credentials
-      {{- end }}  
+      {{- end }}
       {{- if .Values.hub.initContainers }}
       initContainers:
         {{- .Values.hub.initContainers | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,15 +1,15 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.serviceAccounts.hub.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hub
+  name: {{ .Values.serviceAccounts.hub.name }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hub
+  name: {{ .Values.serviceAccounts.hub.name -}}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 rules:
@@ -23,8 +23,8 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hub
-  labels:
+  name: {{ .Values.serviceAccounts.hub.name -}}
+  labels: {{ .Values.serviceAccounts.hub.name -}}
     {{- include "jupyterhub.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
@@ -32,6 +32,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: hub
+  name: {{ .Values.serviceAccounts.hub.name -}}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -25,9 +25,7 @@ spec:
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: hook-image-awaiter
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccounts.imagePuller.name }}
       containers:
         - image: {{ .Values.prePuller.hook.image.name }}:{{ .Values.prePuller.hook.image.tag }}
           name: hook-image-awaiter

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -1,15 +1,15 @@
 {{- /*
-Permissions to be used by the hook-image-awaiter job
+Permissions to be used by the {{ .Values.serviceAccounts.imagePuller.name }} job
 */}}
 {{- if .Values.prePuller.hook.enabled }}
-{{- if .Values.rbac.enabled }}
+{{- if .Values.serviceAccounts.imagePuller.create }}
 {{- /*
 This service account...
 */ -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hook-image-awaiter
+  name: {{ .Values.serviceAccounts.imagePuller.name }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -24,7 +24,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hook-image-awaiter
+  name: {{ .Values.serviceAccounts.imagePuller.name }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -43,7 +43,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: hook-image-awaiter
+  name: {{ .Values.serviceAccounts.imagePuller.name }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -53,11 +53,11 @@ metadata:
     "helm.sh/hook-weight": "0"
 subjects:
   - kind: ServiceAccount
-    name: hook-image-awaiter
+    name: {{ .Values.serviceAccounts.imagePuller.name }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: hook-image-awaiter
+  name: {{ .Values.serviceAccounts.imagePuller.name }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -32,9 +32,7 @@ spec:
         {{- include "jupyterhub.matchLabels" $_ | nindent 8 }}
         hub.jupyter.org/network-access-proxy-http: "true"
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: autohttps
-      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccounts.scheduling.userScheduler.name }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ .Release.Name }}-default-priority
       {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -1,13 +1,13 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
-{{- if (and $autoHTTPS .Values.rbac.enabled) -}}
+{{- if (and $autoHTTPS .Values.serviceAccounts.proxy.autohttps.create) -}}
 # This is way too many permissions, but apparently the nginx-controller
 # is written to sortof assume it is clusterwide ingress provider.
 # So we keep this as is, for now.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: autohttps
+  name: {{ .Values.serviceAccounts.proxy.autohttps.name }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---
@@ -86,7 +86,7 @@ roleRef:
   name: nginx-{{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    name: autohttps
+    name: {{ .Values.serviceAccounts.proxy.autohttps.name }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -178,7 +178,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: autohttps
+    name: {{ .Values.serviceAccounts.proxy.autohttps.name }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -193,6 +193,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: autohttps
+    name: {{ .Values.serviceAccounts.proxy.autohttps.name }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -19,9 +19,7 @@ spec:
         # This lets us autorestart when the configmap changes!
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: user-scheduler
-      {{- end }}
+      serviceAccountName:  {{ .Values.serviceAccounts.scheduling.userScheduler.name }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ .Release.Name }}-default-priority
       {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,22 +1,22 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
-{{- if .Values.rbac.enabled }}
+{{- if .Values.serviceAccounts.scheduling.userScheduler.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: user-scheduler
+  name: {{ .Values.serviceAccounts.scheduling.userScheduler.name }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-user-scheduler-base
+  name: {{ .Release.Name }}-{{ .Values.serviceAccounts.scheduling.userScheduler.name }}-base
   labels:
     {{- $_ := merge (dict "componentSuffix" "-base") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: user-scheduler
+    name: {{ .Values.serviceAccounts.scheduling.userScheduler.name }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -26,14 +26,14 @@ roleRef:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-user-scheduler-complementary
+  name: {{ .Release.Name }}-{{ .Values.serviceAccounts.scheduling.userScheduler.name }}-complementary
   labels:
     {{- $_ := merge (dict "componentSuffix" "-complementary") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
 rules:
   # Support leader elections
   - apiGroups: [""]
-    resourceNames: ["user-scheduler"]
+    resourceNames: ["{{ .Values.serviceAccounts.scheduling.userScheduler.name }}"]
     resources: ["configmaps"]
     verbs: ["get", "update"]
   # Workaround for missing permission in system:kube-scheduler as of k8s 1.10.4
@@ -44,17 +44,17 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}-user-scheduler-complementary
+  name: {{ .Release.Name }}-{{ .Values.serviceAccounts.scheduling.userScheduler.name }}-complementary
   labels:
     {{- $_ := merge (dict "componentSuffix" "-complementary") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: user-scheduler
+    name: {{ .Values.serviceAccounts.scheduling.userScheduler.name }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Release.Name }}-user-scheduler-complementary
+  name: {{ .Release.Name }}-{{ .Values.serviceAccounts.scheduling.userScheduler.name }}-complementary
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -73,6 +73,23 @@ rbac:
   enabled: true
 
 
+serviceAccounts:
+  hub:
+    create: false
+    name: "hub"
+  imagePuller:
+    create: false
+    name: 'hook-image-awaiter'
+  proxy:
+    autohttps:
+      create: false
+      name: 'autohttps'
+  scheduling:
+    userScheduler:
+      create: false
+      name: 'user-scheduler'
+
+
 proxy:
   secretToken: ''
   service:


### PR DESCRIPTION
We are not allowed to create any service accounts in our cluster, so I need to be able to change the name of the SA used for hub/proxy/...

It tries to fix #921, but there may be additional work to do onit

TODO:
- [ ] Document the breaking change `rbac.enabled` to `rbac.create`
- [ ] Service accounts name does not depends on the the fullname as described in [Helm Best Practices](https://helm.sh/docs/chart_best_practices/#using-rbac-resources). That would also be a breaking change (the `hub` service account would be set to `myjhubreleasename-hub`). I think this is ok, that would ultimately result in being able to deploy several independent jupyterhub in the same namespace
- [ ] there is no `jupyterhub.fullname` template defined :(
- [ ] use default account if `serviceAccounts.*.create` is `false` and the name is not specified
