### PR TITLE
tmpauthenticator 0.6 needed for jupyterhub 1.0

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -1,7 +1,7 @@
 # jupyterhub version is defined in chartpress.yaml
 jupyterhub-dummyauthenticator==0.3.1
 jupyterhub-firstuseauthenticator==0.12
-jupyterhub-tmpauthenticator==0.5
+jupyterhub-tmpauthenticator==0.6
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
 jupyterhub-kubespawner==0.10.1


### PR DESCRIPTION
tmpauthenticator is broken in the current devel `0.9-7aaa255`.
See https://github.com/jupyterhub/tmpauthenticator/pull/18