### PR TITLE
Changing Azure Container Service to Azure Kubernetes Service

### DIFF
--- a/doc/source/microsoft/step-zero-azure-autoscale.rst
+++ b/doc/source/microsoft/step-zero-azure-autoscale.rst
@@ -1,6 +1,6 @@
 .. _microsoft-azure:
 
-Step Zero: Kubernetes on Microsoft Azure Container Service (AKS) with Autoscaling
+Step Zero: Kubernetes on Microsoft Azure Kubernetes Service (AKS) with Autoscaling
 ---------------------------------------------------------------------------------
 
 .. warning::

--- a/doc/source/microsoft/step-zero-azure.rst
+++ b/doc/source/microsoft/step-zero-azure.rst
@@ -1,6 +1,6 @@
 .. _microsoft-azure:
 
-Step Zero: Kubernetes on Microsoft Azure Container Service (AKS)
+Step Zero: Kubernetes on Microsoft Azure Kubernetes Service (AKS)
 ----------------------------------------------------------------
 
 You can create a Kubernetes cluster `either through the Azure portal website, or using the Azure command line tools <https://docs.microsoft.com/en-us/azure/aks/>`_.


### PR DESCRIPTION
This PR updates the Azure setup article to use the current full name of AKS, Azure Kubernetes Service.