### PR TITLE
Add py-spy to hub image

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -16,3 +16,5 @@ mwoauth==0.3.2
 globus_sdk[jwt]==1.5.0
 cryptography==2.3.*
 jupyterhub-hmacauthenticator
+# Very useful for profiling running hubs
+py-spy


### PR DESCRIPTION
https://github.com/benfred/py-spy is a sampling profiler for Python
that works really solidly with minimum fuss, and has been extremely
helpful in debugging issues. It's also very useful in doing performance
analysis. Having this be present in the hub image by default will
make it easier for everyone to create profiles of the hub process
at loads they are having trouble with, and share it with the community
to see what is up.