### PR TITLE
Make proxy redirect to 443 instead of 8443

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -59,11 +59,13 @@ spec:
             {{- if $manualHTTPS }}
             - --port=8443
             - --redirect-port=8000
+            - --redirect-to=443
             - --ssl-key=/etc/chp/tls/tls.key
             - --ssl-cert=/etc/chp/tls/tls.crt
             {{- else if $manualHTTPSwithsecret }}
             - --port=8443
             - --redirect-port=8000
+            - --redirect-to=443
             - --ssl-key=/etc/chp/tls/{{ .Values.proxy.https.secret.key }}
             - --ssl-cert=/etc/chp/tls/{{ .Values.proxy.https.secret.crt }}
             {{- else }}


### PR DESCRIPTION
configurable-http-proxy redirects to '--port' which in this case is 8443 and unresolvable outside of the cluster.

The master branch now uses version 4.1.0 of configurable-http-proxy which added '--redirect-to' to solve this problem.