### PR TITLE
Use 443 as https port or redirection. FIX #806

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -59,11 +59,13 @@ spec:
             {{- if $manualHTTPS }}
             - --port=8443
             - --redirect-port=8000
+            - --redirect-to=443
             - --ssl-key=/etc/chp/tls/tls.key
             - --ssl-cert=/etc/chp/tls/tls.crt
             {{- else if $manualHTTPSwithsecret }}
             - --port=8443
             - --redirect-port=8000
+            - --redirect-to=443
             - --ssl-key=/etc/chp/tls/{{ .Values.proxy.https.secret.key }}
             - --ssl-cert=/etc/chp/tls/{{ .Values.proxy.https.secret.crt }}
             {{- else }}


### PR DESCRIPTION
Using jupyterhub/configurable-http-proxy#187 `--redirect-to` to correctly redirect http to https with manual certificates.