### PR TITLE
[do not merge] Verifying build of rebased #1004

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -179,3 +179,11 @@ spec:
           ports:
             - containerPort: 8081
               name: hub
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: hub
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: hub

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -107,5 +107,5 @@ spec:
               port: proxy-public
           readinessProbe:
             httpGet:
-              path: /health # Wait until hub is ready (this is proxied to hub)
+              path: /health  # Wait until hub is ready (this is proxied to hub)
               port: proxy-public

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -101,3 +101,11 @@ spec:
               name: proxy-public
             - containerPort: 8001
               name: api
+          livenessProbe:
+            httpGet:
+              path: /_chp_healthz
+              port: proxy-public
+          readinessProbe:
+            httpGet:
+              path: /health # Wait until hub is ready (this is proxied to hub)
+              port: proxy-public


### PR DESCRIPTION
I wanted to ensure build of #1004 with new CI pipeline works as it should after a rebase.

Oh, it turns out this was not needed to verify the test in #1004, i could just restart it and it would try the merged version as compared to the specific commit.