### PR TITLE
Revert "Configure liveness/readinessProbe"

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -179,11 +179,3 @@ spec:
           ports:
             - containerPort: 8081
               name: hub
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: hub
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: hub

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -101,11 +101,3 @@ spec:
               name: proxy-public
             - containerPort: 8001
               name: api
-          livenessProbe:
-            httpGet:
-              path: /_chp_healthz
-              port: proxy-public
-          readinessProbe:
-            httpGet:
-              path: /health  # Wait until hub is ready (this is proxied to hub)
-              port: proxy-public


### PR DESCRIPTION
Reverts jupyterhub/zero-to-jupyterhub-k8s#1004

My hub and proxy pod wasn't entering a Ready state after this PR was merged by me. So I'll investigate things further but for now I figure I'll revert the PR so it does not cause disruptions for others like me.

```
Events:
  Type     Reason     Age                From                                         Message
  ----     ------     ----               ----                                         -------
  Normal   Scheduled  78s                default-scheduler                            Successfully assigned jupyterhub/proxy-7d4dcc5c64-pqv9w to gke-ds-platform-core-4d566784-54l4
  Normal   Pulled     76s                kubelet, gke-ds-platform-core-4d566784-54l4  Container image "jupyterhub/configurable-http-proxy:4.1.0" already present on machine
  Normal   Created    76s                kubelet, gke-ds-platform-core-4d566784-54l4  Created container
  Normal   Started    76s                kubelet, gke-ds-platform-core-4d566784-54l4  Started container
  Warning  Unhealthy  10s (x7 over 70s)  kubelet, gke-ds-platform-core-4d566784-54l4  Readiness probe failed: Get http://10.72.0.84:8000/health: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

```
Events:
  Type     Reason     Age               From                                         Message
  ----     ------     ----              ----                                         -------
  Normal   Scheduled  31s               default-scheduler                            Successfully assigned jupyterhub/hub-b9dccf7f7-htrxq to gke-ds-platform-core-4d566784-lspf
  Normal   Pulled     29s               kubelet, gke-ds-platform-core-4d566784-lspf  Container image "jupyterhub/k8s-hub:0.9-dcde99a" already present on machine
  Normal   Created    29s               kubelet, gke-ds-platform-core-4d566784-lspf  Created container
  Normal   Started    29s               kubelet, gke-ds-platform-core-4d566784-lspf  Started container
  Warning  Unhealthy  6s (x3 over 26s)  kubelet, gke-ds-platform-core-4d566784-lspf  Liveness probe failed: Get http://10.72.2.185:8081/health: dial tcp 10.72.2.185:8081: connect: connection refused
  Warning  Unhealthy  1s (x3 over 21s)  kubelet, gke-ds-platform-core-4d566784-lspf  Readiness probe failed: Get http://10.72.2.185:8081/health: dial tcp 10.72.2.185:8081: connect: connection refused
```
