### PR TITLE
Proxy deployment: Change probes to https port

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -106,8 +106,8 @@ spec:
           livenessProbe:
             httpGet:
               path: /_chp_healthz
-              port: proxy-public
+              port: proxy-https
           readinessProbe:
             httpGet:
               path: /_chp_healthz
-              port: proxy-public
+              port: proxy-https

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -106,8 +106,16 @@ spec:
           livenessProbe:
             httpGet:
               path: /_chp_healthz
+              {{- if or $manualHTTPS $manualHTTPSwithsecret }}
               port: proxy-https
+              {{- else }}
+              port: proxy-public
+              {{- end }}
           readinessProbe:
             httpGet:
               path: /_chp_healthz
+              {{- if or $manualHTTPS $manualHTTPSwithsecret }}
               port: proxy-https
+              {{- else }}
+              port: proxy-public
+              {{- end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -108,14 +108,18 @@ spec:
               path: /_chp_healthz
               {{- if or $manualHTTPS $manualHTTPSwithsecret }}
               port: proxy-https
+              scheme: HTTPS
               {{- else }}
               port: proxy-public
+              scheme: HTTP
               {{- end }}
           readinessProbe:
             httpGet:
               path: /_chp_healthz
               {{- if or $manualHTTPS $manualHTTPSwithsecret }}
               port: proxy-https
+              scheme: HTTPS
               {{- else }}
               port: proxy-public
+              scheme: HTTP
               {{- end }}


### PR DESCRIPTION
When left on http and http to https redirection is configured the probes may be redirected to the wrong port.