### PR TITLE
Allow adding additional ingress rules in network policy

### DIFF
--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -20,6 +20,10 @@ spec:
       ports:
         - protocol: TCP
           port: 8081
+    {{- /* Useful if you want to give hub access to pods from other namespaces */ }}
+    {{- if .Values.hub.networkPolicy.ingress.extraRules }}
+    {{- .Values.hub.networkPolicy.ingress.extraRules | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   egress:
     {{- /*
     The default is to allow all egress for hub If you want to restrict it the

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -20,9 +20,9 @@ spec:
       ports:
         - protocol: TCP
           port: 8081
-    {{- /* Useful if you want to give hub access to pods from other namespaces */ }}
-    {{- if .Values.hub.networkPolicy.ingress.extraRules }}
-    {{- .Values.hub.networkPolicy.ingress.extraRules | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- /* Useful if you want to give hub access to pods from other namespaces */}}
+    {{- if .Values.hub.networkPolicy.ingress}}
+    {{- .Values.hub.networkPolicy.ingress| toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
   egress:
     {{- /*

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -50,9 +50,9 @@ spec:
       ports:
         - protocol: TCP
           port: 8001
-    {{- /* Useful if you want to give proxy access to pods from other namespaces */ }}
-    {{- if .Values.proxy.networkPolicy.ingress.extraRules }}
-    {{- .Values.proxy.networkPolicy.ingress.extraRules | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- /* Useful if you want to give proxy access to pods from other namespaces */}}
+    {{- if .Values.proxy.networkPolicy.ingress}}
+    {{- .Values.proxy.networkPolicy.ingress | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
   egress:
     {{- /*

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -50,6 +50,10 @@ spec:
       ports:
         - protocol: TCP
           port: 8001
+    {{- /* Useful if you want to give proxy access to pods from other namespaces */ }}
+    {{- if .Values.proxy.networkPolicy.ingress.extraRules }}
+    {{- .Values.proxy.networkPolicy.ingress.extraRules | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   egress:
     {{- /*
     The default is to allow all egress for proxy If you want to restrict it the

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -21,6 +21,10 @@ spec:
       ports:
         - protocol: TCP
           port: 8888
+    {{- /* Useful if you want to give user server access to pods from other namespaces */ }}
+    {{- if .Values.singleuser.networkPolicy.ingress.extraRules }}
+    {{- .Values.singleuser.networkPolicy.ingress.extraRules | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   egress:
     - to:
         - podSelector:

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -21,9 +21,9 @@ spec:
       ports:
         - protocol: TCP
           port: 8888
-    {{- /* Useful if you want to give user server access to pods from other namespaces */ }}
-    {{- if .Values.singleuser.networkPolicy.ingress.extraRules }}
-    {{- .Values.singleuser.networkPolicy.ingress.extraRules | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- /* Useful if you want to give user server access to pods from other namespaces */}}
+    {{- if .Values.singleuser.networkPolicy.ingress }}
+    {{- .Values.singleuser.networkPolicy.ingress | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
   egress:
     - to:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -62,6 +62,7 @@ hub:
     minAvailable: 1
   networkPolicy:
     enabled: false
+    ingress: []
     egress:
       - to:
           - ipBlock:
@@ -124,6 +125,7 @@ proxy:
     hosts: []
   networkPolicy:
     enabled: false
+    ingress: []
     egress:
       - to:
           - ipBlock:
@@ -170,6 +172,7 @@ singleuser:
     ip: 169.254.169.254
   networkPolicy:
     enabled: false
+    ingress: []
     egress:
     # Required egress is handled by other rules so it's safe to modify this
       - to:


### PR DESCRIPTION
If you have a prometheus server in a different namespace,
explicit 'from' stanzas are needed to make sure it can
have access to your hub and user pods.

This change allows individual administrators to make
these changes.