### PR TITLE
Ignore venv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+lib64
+pip-selfcheck.json
+pyvenv.cfg
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
These files where generated when installing the venv and should probably be ignored by git.