### PR TITLE
Recreate as CHP proxy pod's deployment strategy

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}
+  strategy:
+    {{- .Values.proxy.deploymentStrategy | toYaml | trimSuffix "\n" | nindent 4 }}
   template:
     metadata:
       labels:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -18,10 +18,13 @@ hub:
   consecutiveFailureLimit: 5
   activeServerLimit:
   deploymentStrategy:
-    # sqlite-pvc backed hub requires Recreate strategy to work
+    ## type: Recreate
+    ## - sqlite-pvc backed hubs require the Recreate deployment strategy as a
+    ##   typical PVC storage can only be bound to one pod at the time.
+    ## - JupyterHub isn't designed to support being run in parallell. More work
+    ##   needs to be done in JupyterHub itself for a fully highly available (HA)
+    ##   deployment of JupyterHub on k8s is to be possible.
     type: Recreate
-    # This is required for upgrading to work
-    rollingUpdate:
   db:
     type: sqlite-pvc
     upgrade:
@@ -82,6 +85,21 @@ rbac:
 
 proxy:
   secretToken: ''
+  deploymentStrategy:
+    ## type: Recreate
+    ## - JupyterHub's interaction with the CHP proxy becomes a lot more robust
+    ##   with this configuration. To understand this, consider that JupyterHub
+    ##   during startup will interact a lot with the k8s service to reach a
+    ##   ready proxy pod. If the hub pod during a helm upgrade is restarting
+    ##   directly while the proxy pod is making a rolling upgrade, the hub pod
+    ##   could end up running a sequence of interactions with the old proxy pod
+    ##   and finishing up the sequence of interactions with the new proxy pod.
+    ##   As CHP proxy pods carry individual state this is very error prone. One
+    ##   outcome when not using Recreate as a strategy has been that user pods
+    ##   have been deleted by the hub pod because it considered them unreachable
+    ##   as it only configured the old proxy pod but not the new before trying
+    ##   to reach them.
+    type: Recreate
   service:
     type: LoadBalancer
     labels: {}


### PR DESCRIPTION
Using a rolling update by default on the proxy pod is a mistake by us,
because of the JupyterHub / CHP proxy interaction. JupyterHub assumes in
check_routes / add_route etc to be speaking to one specific CHP proxy
server, but there can be different ones responding if we make an upgrade
and the proxy pod is making a rolling upgrade.

For example, consider a hub pod making a recreate upgrade, and a proxy
pod makinga rolling upgrade. The new hub pod could for example get ready
before the proxy pod and start speaking with the old proxy pod and later
at a crucial point start speaking with the new pod. If you switch to
speaking with the new pod at the wrong time, you may end up with failure
to get responses from user pods that are verified to be around, and then
they are deleted.

So, this commit hope to fix a sneaky bug where user pods are deleted
during upgrades where the proxy pod is also updated!

---

Note that with the traefik proxy that would store state in a key value store, this may not be a problem, but we don't yet use traefik proxy.