### PR TITLE
Added the ability to use an existing/shared imge pull secret

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -55,10 +55,16 @@ spec:
       {{- end }}
       securityContext:
         fsGroup: {{ .Values.hub.fsGid }}
-      {{- if .Values.hub.imagePullSecret.enabled }}
+      {{- if or .Values.hub.imagePullSecret.enabled .Values.hub.image.pullSecrets }}
       imagePullSecrets:
+        {{- if .Values.hub.imagePullSecret.enabled }}
         - name: hub-image-credentials
-      {{- end }}  
+        {{ else }}
+        {{- range .Values.hub.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.hub.initContainers }}
       initContainers:
         {{- .Values.hub.initContainers | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -48,9 +48,15 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
-      {{- if .Values.singleuser.imagePullSecret.enabled }}
+      {{- if or .Values.singleuser.imagePullSecret.enabled .Values.singleuser.image.pullSecrets }}
       imagePullSecrets:
+        {{- if .Values.singleuser.imagePullSecret.enabled }}
         - name: {{ if .hook -}} hook- {{- end -}} singleuser-image-credentials
+        {{ else }}
+        {{- range .Values.singleuser.image.pullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+        {{ end }}
       {{- end }}
       initContainers:
         - name: image-pull-singleuser

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -49,6 +49,8 @@ hub:
   image:
     name: jupyterhub/k8s-hub
     tag: generated-by-chartpress
+    # pullSecrets:
+    #   - secretName
   resources:
     requests:
       cpu: 200m
@@ -245,6 +247,8 @@ singleuser:
     name: jupyterhub/k8s-singleuser-sample
     tag: generated-by-chartpress
     pullPolicy: IfNotPresent
+    # pullSecrets:
+    #   - secretName
   imagePullSecret:
     enabled: false
     registry:


### PR DESCRIPTION
This enables using pull secrets in a way that is more consistent with other helm charts.