### PR TITLE
Support CD with git tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,6 @@ git:
   depth: false
 services:
   - docker
-## This if conditions gives us control to run the stages and jobs. Not running
-## on pushed tags make us enforce that our tags reside on the master branch,
-## that chartpress' logic require for proper versioning.
-##
-## ref: https://docs.travis-ci.com/user/conditions-v1
-##
-if: tag IS blank
 ## stages declares and orders stages
 ##
 ## ref: https://docs.travis-ci.com/user/build-stages/#build-stages-and-deployments

--- a/ci/publish
+++ b/ci/publish
@@ -17,8 +17,12 @@ set -x
 export GIT_SSH_COMMAND="ssh -i ${PWD}/ci/id_rsa"
 
 if [ "${TRAVIS_TAG:-}" == "" ]; then
-    chartpress --push --publish-chart
+    # Using --long, we are ensured to get a build suffix, which ensures we don't
+    # build the same tag twice.
+    chartpress --push --publish-chart --long
 else
+    # Setting a tag explicitly enforces a rebuild if this tag had already been
+    # built and we wanted to override it.
     chartpress --push --publish-chart --tag "${TRAVIS_TAG}"
 fi
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@
 ##
 ## ref: https://github.com/jupyterhub/chartpress
 ##
-chartpress>=0.4.1
+chartpress>=0.4.2
 
 ## pytest run tests that require requests, pytest is run from test
 ## script


### PR DESCRIPTION
TravisCI would make two builds if a commit and a tag referencing this
commit was pushed. This could lead to duplication of chart build and
publishing jobs. So, I disabled the tag triggered builds before to avoid
this, in case we ended up with duplicated entries or failure due to
existing entries etc.

In this PR, with chartpress 0.4.2 and the --long flag, we can let both
bulds finish. There are some key benefits.

1. We can now push a tag retrospectively now to trigger a build.
2. We avoid a failure to build a tag because it was pushed not as the
HEAD commit but some steps down the history.
3. We can still build on all pushed commits to master for dev releases.