### PR TITLE
Use helm 2.15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ env:
   - Z2JH_KUBE_VERSION=1.15.3
   - Z2JH_KUBE_VERSION=1.14.6
   - Z2JH_KUBE_VERSION=1.13.10
-  - &allow_failure Z2JH_KUBE_VERSION=1.16.1 Z2JH_HELM_VERSION=2.15.0-rc.2
+  - &allow_failure Z2JH_KUBE_VERSION=1.16.1
 
 jobs:
   ## allow experimental setups to fail

--- a/ci/common
+++ b/ci/common
@@ -24,10 +24,7 @@ fi
 if [ -z ${Z2JH_HELM_VERSION:-} ]; then
     ## ref: https://github.com/helm/helm/releases
     ##
-    ## FIXME: Helm version 2.15.0-rc.1 errored with "Transport is closing",
-    ##        but Kubernetes 1.16 requires a fix for tiller that is using the
-    ##        apiVersion: extensions/v1beta1 still.
-    export Z2JH_HELM_VERSION=2.14.3
+    export Z2JH_HELM_VERSION=2.15.1
 fi
 if [ -z ${Z2JH_KUBEVAL_VERSION:-} ]; then
     ## ref: https://github.com/instrumenta/kubeval/releases


### PR DESCRIPTION
Helm 2.15.0 stopped using extensions/v1beta1 for tiller, which was
required for installation on k8s 1.16 as we have testing for. So now we
don't have to maintain a separate Helm version for k8s 1.16 tests.