### PR TITLE
Bump python-kubernetes to 9.0.*

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -5,7 +5,7 @@ jupyterhub-tmpauthenticator==0.6
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
 jupyterhub-kubespawner==0.10.1
-kubernetes==8.0.*
+kubernetes==9.0.*
 nullauthenticator==1.0
 oauthenticator==0.8.2
 pymysql==0.9.2


### PR DESCRIPTION
It seems the V1PodSpec in 8.0 does not support enableServiceLinks in case we want to disable it.