### PR TITLE
Fix typo in home page of docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -140,7 +140,7 @@ up, managing, and maintaining JupyterHub.
    experiences.
 
 .. note::
-   **Contibuting to Z2JH**. If you would like to help improve the Zero to
+   **Contributing to Z2JH**. If you would like to help improve the Zero to
    JupyterHub guide, please see the `issues page`_ as well as the `contributor guide
    <https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/CONTRIBUTING.md>`_.
 


### PR DESCRIPTION
Just caught a really small typo in the docs.