### PR TITLE
Added existing pull secrets changes from PR #1426 to schema

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -152,6 +152,18 @@ properties:
               v1.11.1
               zhy270a
               ```
+          pullSecrets:
+            type: list
+            description: |
+              Use an existing kubernetes secret to pull the custom image.
+              
+              ```yaml
+              # example existing pull secret.
+              singleuser:
+                image:
+                  pullSecrets:
+                    - gcr-pull
+              ```
       db:
         type: object
         properties:
@@ -786,6 +798,18 @@ properties:
 
               See the [Kubernetes docs](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
               for more info.
+          pullSecrets:
+            type: list
+            description: |
+              Use an existing kubernetes secret to pull the custom image.
+              
+              ```yaml
+              # example existing pull secret
+              singleuser:
+                image:
+                  pullSecrets:
+                    - gcr-pull
+              ```
       profileList:
         type: list
         description: |


### PR DESCRIPTION
A recent PR (#1426) allowed for existing kubernetes secrets to be used for image pull of the `hub` and `singleuser` images. This PR adds the changes to the schema so they can also carry over into the documentation. 