### PR TITLE
Fix single-user storage section

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -240,8 +240,8 @@ singleuser:
     homeMountPath: /home/jovyan
     dynamic:
       storageClass:
-      pvcNameTemplate: claim-{username}{servername}
-      volumeNameTemplate: volume-{username}{servername}
+      pvcNameTemplate: 'claim-{username}{servername}'
+      volumeNameTemplate: 'volume-{username}{servername}'
       storageAccessModes: [ReadWriteOnce]
   image:
     name: jupyterhub/k8s-singleuser-sample


### PR DESCRIPTION
pvcNameTemplate and volumeNameTemplate under the singleuser.storage section we're missing quotation marks around the values, causing Helm to ignore the entire section.