### PR TITLE
[1464] Move z2jh.py to python and distribution agnostic path

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -6,6 +6,10 @@ from tornado.httpclient import AsyncHTTPClient
 from kubernetes import client
 from jupyterhub.utils import url_path_join
 
+# Make sure that modules placed in the same directory as the jupyterhub config are added to the pythonpath
+configuration_directory = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, configuration_directory)
+
 from z2jh import get_config, set_config_if_not_none
 
 # Configure JupyterHub to use the curl backend for making HTTP requests,

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -106,7 +106,7 @@ spec:
             - mountPath: /etc/jupyterhub/jupyterhub_config.py
               subPath: jupyterhub_config.py
               name: config
-            - mountPath: /usr/local/lib/python3.6/dist-packages/z2jh.py
+            - mountPath: /etc/jupyterhub/z2jh.py
               subPath: z2jh.py
               name: config
             - mountPath: /etc/jupyterhub/cull_idle_servers.py


### PR DESCRIPTION
Path `/usr/local/lib/python3.6/dist-packages` binds chart to Ubuntu-like distribution and Python 3.6 docker images.

Currently, configuration script is placed in `/etc/jupyterhub/jupyterhub_config.py` and JupyterHub execs it.

```
jupyterhub
--config /etc/jupyterhub/jupyterhub_config.py
...
```

Thus, it is not enough that `z2jh.py` is in `/etc/jupyterhub/` as it is not from where the python config is executed. Thus, the optimal solution could be to add the script to `PYTHONPATH` to container spec.

Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1464
@consideRatio @mkjpryor-stfc