### PR TITLE
Bump CHP to 4.2.0 - we get quicker chart upgrades now

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -124,7 +124,7 @@ proxy:
   chp:
     image:
       name: jupyterhub/configurable-http-proxy
-      tag: 4.1.0
+      tag: 4.2.0
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
This will make the proxy pod quickly terminate instead of taking full 30
seconds to terminate, and that in turn allows for the hub pod to not
crash so much on upgrades as it requires the proxy pod to upgrade first
by shutting down and starting up.

Changelog: https://github.com/jupyterhub/configurable-http-proxy/blob/master/CHANGELOG.md#42---2019-11-14

---

Solves the part regarding the proxy pod for #1476.