### PR TITLE
Bump proxy's nginx-ingress-controller image

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -132,7 +132,7 @@ proxy:
   nginx:
     image:
       name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-      tag: 0.15.0
+      tag: 0.26.1
     proxyBodySize: 64m
     hstsIncludeSubdomains: 'false'
     resources: {}


### PR DESCRIPTION
I think it can make sense to update this for security reasons, but I'd need help reviewing the breaking changes and if they affect us.

This bumps 0.15.0 to 0.26.1: https://github.com/kubernetes/ingress-nginx/releases