### PR TITLE
k8s 1.16 compability - bump kube-scheduler, kubespawner, kubernetes python client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ env:
   ## ref: https://hub.docker.com/r/kindest/node/tags
   ## ref: https://github.com/kubernetes-sigs/kind/issues/197
   ##
-  - Z2JH_KUBE_VERSION=1.15.6
   - Z2JH_KUBE_VERSION=1.13.12
+  - Z2JH_KUBE_VERSION=1.15.6
   - Z2JH_KUBE_VERSION=1.16.3
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,20 +56,20 @@ env:
   ##
   - Z2JH_KUBE_VERSION=1.15.6
   - Z2JH_KUBE_VERSION=1.13.12
-  - &allow_failure Z2JH_KUBE_VERSION=1.16.3
+  - Z2JH_KUBE_VERSION=1.16.3
 
 jobs:
   ## allow experimental setups to fail
   ##
   ## ref: https://docs.travis-ci.com/user/customizing-the-build/#rows-that-are-allowed-to-fail
   ##
-  allow_failures:
-    - env: *allow_failure
+  # allow_failures:
+  #   - env: *allow_failure
   ## don't wait for the jobs that are allowed to fail to report success
   ##
   ## ref: https://docs.travis-ci.com/user/customizing-the-build/#fast-finishing
   ##
-  fast_finish: true
+  # fast_finish: true
 
   ## include additional individual jobs
   ##

--- a/dev
+++ b/dev
@@ -252,18 +252,56 @@ def upgrade(chart, version, values):
     _run(
         cmd=[
             "kubectl", "rollout", "status", "deployment/proxy",
-            "--timeout", "2m",
+            "--timeout", "3m",
             "--namespace", os.environ["Z2JH_KUBE_NAMESPACE"],
             "--context", os.environ["Z2JH_KUBE_CONTEXT"],
         ],
-        print_end=""
+        print_end="",
+        error_callback=_log_wait_hub_proxy_timeout,
     )
-    _run([
-        "kubectl", "rollout", "status", "deployment/hub",
-        "--timeout", "2m",
-        "--namespace", os.environ["Z2JH_KUBE_NAMESPACE"],
-        "--context", os.environ["Z2JH_KUBE_CONTEXT"],
-    ])
+    _run(
+        cmd=[
+            "kubectl", "rollout", "status", "deployment/hub",
+            "--timeout", "3m",
+            "--namespace", os.environ["Z2JH_KUBE_NAMESPACE"],
+            "--context", os.environ["Z2JH_KUBE_CONTEXT"],
+        ],
+        error_callback=_log_wait_hub_proxy_timeout,
+    )
+
+def _log_wait_hub_proxy_timeout():
+    print("Both Hub and Proxy never became ready")
+    _run(
+        cmd=[
+            "kubectl", "describe", "deploy/hub",
+            "--context", os.environ["Z2JH_KUBE_CONTEXT"],
+        ],
+        exit_on_error=False,
+        print_end="",
+    )
+    _run(
+        cmd=[
+            "kubectl", "logs", "deploy/hub",
+            "--context", os.environ["Z2JH_KUBE_CONTEXT"],
+        ],
+        exit_on_error=False,
+        print_end="",
+    )
+    _run(
+        cmd=[
+            "kubectl", "logs", "deploy/proxy",
+            "--context", os.environ["Z2JH_KUBE_CONTEXT"],
+        ],
+        exit_on_error=False,
+        print_end="",
+    )
+    _run(
+        cmd=[
+            "kubectl", "logs", "deploy/proxy",
+            "--context", os.environ["Z2JH_KUBE_CONTEXT"],
+        ],
+        exit_on_error=False,
+    )
 
 
 @depend_on(binaries=["kubectl"], envs=["KUBECONFIG", "Z2JH_KUBE_CONTEXT", "Z2JH_KUBE_NAMESPACE"])

--- a/dev
+++ b/dev
@@ -224,7 +224,15 @@ def upgrade(chart, version, values):
         _run(["chartpress"])
         # git --no-pager diff
 
-        if "kind-config-jh-dev" in os.environ["KUBECONFIG"]:
+        kubeconfig_path = _run(
+            cmd=[
+                "kind", "get", "kubeconfig-path",
+                "--name", "jh-dev",
+            ],
+            print_command=False,
+            capture_output=True,
+        )
+        if kubeconfig_path in os.environ["KUBECONFIG"]:
             print("Loading the locally built images into the kind cluster.")
             _run([
                 "python3", "ci/kind-load-docker-images.py",

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -4,17 +4,17 @@ jupyterhub-firstuseauthenticator==0.12
 jupyterhub-tmpauthenticator==0.6
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
-jupyterhub-kubespawner==0.11.*
-kubernetes==10.0.*
+jupyterhub-kubespawner==0.11.0
+kubernetes==10.0.1
 nullauthenticator==1.0
-oauthenticator==0.8.2
+oauthenticator==0.10.0
 pymysql==0.9.2
 psycopg2==2.7.5
 pycurl==7.43.0.*
 statsd==3.2.2
-mwoauth==0.3.2
+mwoauth==0.3.7
 globus_sdk[jwt]==1.5.0
-cryptography==2.3.*
+cryptography==2.8.*
 jupyterhub-hmacauthenticator
 # Very useful for profiling running hubs
 py-spy

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -4,8 +4,8 @@ jupyterhub-firstuseauthenticator==0.12
 jupyterhub-tmpauthenticator==0.6
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
--e git+https://github.com/consideRatio/kubespawner.git@k8s-1.16-fix#egg=kubespawner
-kubernetes==9.0.*
+jupyterhub-kubespawner==0.11.*
+kubernetes==10.0.*
 nullauthenticator==1.0
 oauthenticator==0.8.2
 pymysql==0.9.2

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -4,7 +4,7 @@ jupyterhub-firstuseauthenticator==0.12
 jupyterhub-tmpauthenticator==0.6
 jupyterhub-ltiauthenticator==0.3
 jupyterhub-ldapauthenticator==1.2.2
-jupyterhub-kubespawner==0.10.1
+-e git+https://github.com/consideRatio/kubespawner.git@k8s-1.16-fix#egg=kubespawner
 kubernetes==9.0.*
 nullauthenticator==1.0
 oauthenticator==0.8.2

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -302,7 +302,7 @@ scheduling:
     policy: {}
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
-      tag: v1.16.3
+      tag: v1.13.12
     nodeSelector: {}
     pdb:
       enabled: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -302,7 +302,7 @@ scheduling:
     policy: {}
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
-      tag: v1.11.2
+      tag: v1.16.3
     nodeSelector: {}
     pdb:
       enabled: true


### PR DESCRIPTION
1. **Make kubespawner function for k8s 1.16**
   - [x] https://github.com/jupyterhub/kubespawner/pull/362 makes it no longer crash, but z2jh run into user-scheduler issues now instead.
2. **Bump kube-scheduler**
    If I don't bump kube-scheduler, I note that the scheduler stop working in k8s 1.16. I'm not sure why. Anyhow, I bump various versions at the moment to see what works and doesn't work. We are bumping from kube-scheduler v1.11.2 in use by user-scheduler, which is just a configured kube-scheduler. [These are the available images](gcr.io/google_containers/kube-scheduler-amd64).
     - [x] Using 1.16.3 on k8s 1.13-1.15 failed with pending user pods never being scheduled and for k8s 1.16 It is untested yet.
     - [x] Using 1.13.12 on k8s 1.13-1.16 succeeded!
3. **Bump kubespawner**
   - [x] Tested against kubespawner PR
   - [x] Merged Kubespawner PR
   - [x] Made a kubespawner release
   - [x] Referenced the kubespawner release

Perhaps there are more things needed to be done, but I think all known issues are now addressed.

Closes #1444 entirely, see: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1444#issuecomment-554631155.