### PR TITLE
Update hub image dependencies and RELEASE.md regarding dependencies

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,48 @@ This issue will be used to coordinate the next release of the Helm chart
 according to the instructions in [RELEASE.md](RELEASE.md). Below is the
 checklist for this release.
 
+## Look through dependencies
+
+The JupyterHub Helm chart relies on many dependent projects, and when we make a
+release it is good to be updated about their status and what version we decide
+to couple the Helm chart release with. Below are the more important depdencies.
+Put a check on those that reach a state good enough for a z2jh release to be
+cut.
+
+### Depdendent Python packages
+A more complete list is available in the
+[images/hub/requirements.txt](images/hub/requirements.txt), but here are some of
+the big ones.
+
+- [ ] [jupyterhub](https://github.com/jupyterhub/jupyterhub)
+- [ ] [kubespawner](https://github.com/jupyterhub/kubespawner)
+  - [ ] [kubernetes-client/python](https://github.com/kubernetes-client/python)
+- [ ] [oauthenticator](https://github.com/jupyterhub/oauthenticator)
+
+### Depdendent docker images
+These images version/tags are set in [values.yaml](jupyterhub/values.yaml).
+
+- [ ] [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
+  - [Available image tags](https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags)
+  - values.yaml entry: proxy.chp.image
+- [ ] [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
+  - [Available image tags](https://quay.io/repository/kubernetes-ingress-controller/nginx-ingress-controller?tab=tags)
+  - values.yaml entry: proxy.nginx.image
+- [ ] [kube-scheduler](https://github.com/kubernetes/kube-scheduler)
+  - [Available image tags](https://gcr.io/google_containers/kube-scheduler-amd64)
+  - values.yaml entry: scheduling.userScheduler.image
+- [ ] [kubernetes/pause](https://github.com/kubernetes/kubernetes/tree/master/build/pause)
+  - [Available image tags](https://gcr.io/google_containers/pause)
+
+We may may also be impacted by the `FROM` image we build our own images from.
+Give these a quick glance as well.
+
+- [ ] [hub](images/hub/Dockerfile)
+- [ ] [image-awaiter](images/image-awaiter/Dockerfile)
+- [ ] [network-tools](images/network-tools/Dockerfile)
+- [ ] [singleuser-sample](images/singleuser-sample/Dockerfile)
+
+
 ## Pre-release iteration 1
 
 - Update [CHANGELOG.md](CHANGELOG.md) and make a commit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@ to couple the Helm chart release with. Below are the more important depdencies.
 Put a check on those that reach a state good enough for a z2jh release to be
 cut.
 
-### Depdendent Python packages
+### Dependent Python packages
 A more complete list is available in the
 [images/hub/requirements.txt](images/hub/requirements.txt), but here are some of
 the big ones.
@@ -28,18 +28,18 @@ the big ones.
   - [ ] [kubernetes-client/python](https://github.com/kubernetes-client/python)
 - [ ] [oauthenticator](https://github.com/jupyterhub/oauthenticator)
 
-### Depdendent docker images
+### Dependent docker images
 These images version/tags are set in [values.yaml](jupyterhub/values.yaml).
 
 - [ ] [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
   - [Available image tags](https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags)
-  - values.yaml entry: proxy.chp.image
+  - values.yaml entry: `proxy.chp.image`
 - [ ] [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
   - [Available image tags](https://quay.io/repository/kubernetes-ingress-controller/nginx-ingress-controller?tab=tags)
-  - values.yaml entry: proxy.nginx.image
+  - values.yaml entry: `proxy.nginx.image`
 - [ ] [kube-scheduler](https://github.com/kubernetes/kube-scheduler)
   - [Available image tags](https://gcr.io/google_containers/kube-scheduler-amd64)
-  - values.yaml entry: scheduling.userScheduler.image
+  - values.yaml entry: `scheduling.userScheduler.image`
 - [ ] [kubernetes/pause](https://github.com/kubernetes/kubernetes/tree/master/build/pause)
   - [Available image tags](https://gcr.io/google_containers/pause)
 

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -64,7 +64,7 @@ pymysql==0.9
 
 # https://github.com/psycopg/psycopg2
 # https://pypi.org/search/?q=psycopg2
-psycopg2==2.8
+psycopg2-binary==2.8
 
 # https://pypi.org/project/pycurl/
 pycurl==7.43.0.*

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -5,7 +5,7 @@
 
 # https://github.com/jupyterhub/dummyauthenticator
 # https://pypi.org/project/jupyterhub-dummyauthenticator
-jupyterhub-dummyauthenticator==0.3.1
+jupyterhub-dummyauthenticator==0.3
 
 # https://github.com/jupyterhub/firstuseauthenticator
 # https://pypi.org/project/jupyterhub-firstuseauthenticator
@@ -34,7 +34,7 @@ mwoauth==0.3.7
 
 # https://github.com/globus/globus-sdk-python
 # https://pypi.org/project/globus_sdk
-globus_sdk[jwt]==1.5
+globus_sdk[jwt]==1.8
 
 # https://github.com/jupyterhub/nullauthenticator
 # https://pypi.org/project/nullauthenticator
@@ -42,27 +42,39 @@ nullauthenticator==1.0
 
 # https://github.com/jupyterhub/oauthenticator
 # https://pypi.org/project/oauthenticator
-oauthenticator==0.10.0
+oauthenticator==0.10
 
 ## Spawners
 # ---------------------------------------------------------
 
 # https://github.com/jupyterhub/kubespawner
 # https://pypi.org/project/jupyterhub-kubespawner
-jupyterhub-kubespawner==0.11.1
+jupyterhub-kubespawner==0.11
 
 # https://github.com/kubernetes-client/python
 # https://pypi.org/project/kubernetes
-kubernetes==10.0.1
+kubernetes==10.0
 
 ## Other dependencies
 # ---------------------------------------------------------
 
-pymysql==0.9.2
-psycopg2==2.7.5
+# https://github.com/PyMySQL/PyMySQL
+# https://pypi.org/project/PyMySQL/
+pymysql==0.9
+
+# https://github.com/psycopg/psycopg2
+# https://pypi.org/search/?q=psycopg2
+psycopg2==2.8
+
+# https://pypi.org/project/pycurl/
 pycurl==7.43.0.*
-statsd==3.2.2
-cryptography==2.8.*
+
+# https://github.com/jsocol/pystatsd
+# https://pypi.org/project/statsd/
+statsd==3.3
+
+# https://pypi.org/project/cryptography/
+cryptography==2.8
 
 ## Useful tools
 # ---------------------------------------------------------

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -1,20 +1,71 @@
-# jupyterhub version is defined in chartpress.yaml
+# JupyterHub's version is defined in chartpress.yaml
+
+## Authenticators
+# ---------------------------------------------------------
+
+# https://github.com/jupyterhub/dummyauthenticator
+# https://pypi.org/project/jupyterhub-dummyauthenticator
 jupyterhub-dummyauthenticator==0.3.1
+
+# https://github.com/jupyterhub/firstuseauthenticator
+# https://pypi.org/project/jupyterhub-firstuseauthenticator
 jupyterhub-firstuseauthenticator==0.12
+
+# https://github.com/jupyterhub/tmpauthenticator
+# https://pypi.org/project/jupyterhub-tmpauthenticator
 jupyterhub-tmpauthenticator==0.6
+
+# https://github.com/jupyterhub/ltiauthenticator
+# https://pypi.org/project/jupyterhub-ltiauthenticator
 jupyterhub-ltiauthenticator==0.3
-jupyterhub-ldapauthenticator==1.2.2
-jupyterhub-kubespawner==0.11.1
-kubernetes==10.0.1
+
+# https://github.com/jupyterhub/ldapauthenticator
+# https://pypi.org/project/jupyterhub-ldapauthenticator
+# NEEDS NEW RELEASE
+jupyterhub-ldapauthenticator==1.2
+
+# https://github.com/jupyterhub/hmacauthenticator
+# https://pypi.org/project/jupyterhub-hmacauthenticator
+jupyterhub-hmacauthenticator==0.1
+
+# https://github.com/mediawiki-utilities/python-mwoauth
+# https://pypi.org/project/mwoauth
+mwoauth==0.3.7
+
+# https://github.com/globus/globus-sdk-python
+# https://pypi.org/project/globus_sdk
+globus_sdk[jwt]==1.5
+
+# https://github.com/jupyterhub/nullauthenticator
+# https://pypi.org/project/nullauthenticator
 nullauthenticator==1.0
+
+# https://github.com/jupyterhub/oauthenticator
+# https://pypi.org/project/oauthenticator
 oauthenticator==0.10.0
+
+## Spawners
+# ---------------------------------------------------------
+
+# https://github.com/jupyterhub/kubespawner
+# https://pypi.org/project/jupyterhub-kubespawner
+jupyterhub-kubespawner==0.11.1
+
+# https://github.com/kubernetes-client/python
+# https://pypi.org/project/kubernetes
+kubernetes==10.0.1
+
+## Other dependencies
+# ---------------------------------------------------------
+
 pymysql==0.9.2
 psycopg2==2.7.5
 pycurl==7.43.0.*
 statsd==3.2.2
-mwoauth==0.3.7
-globus_sdk[jwt]==1.5.0
 cryptography==2.8.*
-jupyterhub-hmacauthenticator
-# Very useful for profiling running hubs
+
+## Useful tools
+# ---------------------------------------------------------
+
+# py-spy is useful for profiling running hubs
 py-spy

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -340,7 +340,7 @@ prePuller:
   pause:
     image:
       name: gcr.io/google_containers/pause
-      tag: '3.0'
+      tag: '3.1'
 
 
 ingress:


### PR DESCRIPTION
Making a z2jh release is sometimes motivated by bumping dependencies etc. In this PR I add an overview about the relevant dependencies within RELEASE.md and provide lots of relevant links from the hub image's requirements.txt file to facilitate version bumping.