### PR TITLE
Fix broken link in architecture.rst

### DIFF
--- a/doc/source/administrator/architecture.rst
+++ b/doc/source/administrator/architecture.rst
@@ -9,5 +9,5 @@ pods in which users will work, and connecting users with those pods.
 The following diagram gives a high-level overview of the many pieces of
 JupyterHub, and how they fit together in this process:
 
-.. image:: _static/images/architecture.png
+.. image:: ../_static/images/architecture.png
    :align: center


### PR DESCRIPTION
Relative path was wrong, one more level needed. This should fix the page https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/architecture.html and show the image correctly.