### PR TITLE
DOC:fixing authentication link in user customization guide

### DIFF
--- a/doc/source/customizing/user-management.md
+++ b/doc/source/customizing/user-management.md
@@ -80,4 +80,4 @@ auth:
 ## Authenticating Users
 
 For information on authenticating users in JupyterHub, see
-[the Authentication guide](/administrator/authentication).
+[the Authentication guide](../../administrator/authentication).

--- a/doc/source/customizing/user-management.md
+++ b/doc/source/customizing/user-management.md
@@ -80,4 +80,4 @@ auth:
 ## Authenticating Users
 
 For information on authenticating users in JupyterHub, see
-[the Authentication guide](./authentication).
+[the Authentication guide](https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html).

--- a/doc/source/customizing/user-management.md
+++ b/doc/source/customizing/user-management.md
@@ -80,4 +80,4 @@ auth:
 ## Authenticating Users
 
 For information on authenticating users in JupyterHub, see
-[the Authentication guide](https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html).
+[the Authentication guide](/administrator/authentication).


### PR DESCRIPTION
The current link directs to the resource which doesn't exist. So changed it to point to the correct link (https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/authentication.html)

Link to issue #1511