### PR TITLE
Fixing #1300 User-scheduler doesn't work with rancher/local-path-provisioner

### DIFF
--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -40,6 +40,10 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
+  # Workaround for missing permission with rancher local-path-provisioner
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["update"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Inspecting the user-schedule-xxxx pod log:

error binding volumes: persistentvolumeclaims "claim-test" is forbidden: User "system:serviceaccount:ns:user-scheduler" cannot update resource "persistentvolumeclaims" in API group "" in the namespace "ns"

I fix it by creating a new roleBinding to let user-scheduler update the volume claim: