### PR TITLE
fix link to Helm chart best practices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,4 +352,4 @@ differently.
 We strive to follow the guidelines provided by
 [kubernetes/charts](https://github.com/kubernetes/charts/blob/master/REVIEW_GUIDELINES.md)
 and the [Helm chart best practices
-guide](https://github.com/kubernetes/helm/tree/master/docs/chart_best_practices).
+guide](https://helm.sh/docs/topics/chart_best_practices/).


### PR DESCRIPTION
Looks like the Helm docs have been consolidated on [new website](https://helm.sh)