### PR TITLE
update jupyterhub version

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -9,7 +9,7 @@ charts:
       hub:
         valuesPath: hub.image
         buildArgs:
-          JUPYTERHUB_VERSION: git+https://github.com/jupyterhub/jupyterhub@89b0c42
+          JUPYTERHUB_VERSION: git+https://github.com/jupyterhub/jupyterhub@abb93ad
       network-tools:
         valuesPath: singleuser.networkTools.image
       image-awaiter:


### PR DESCRIPTION
I am not sure if it makes sense to update JupyterHub version now, since I know you are working on beta version already. I am just looking forward to use some new features without using custom a docker image in the chart :)