### PR TITLE
[MRG] Update step zero for Azure docs with commands to setup an VNet and network policy

### DIFF
--- a/doc/source/microsoft/step-zero-azure-autoscale.rst
+++ b/doc/source/microsoft/step-zero-azure-autoscale.rst
@@ -250,8 +250,8 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
    where:
 
    * ``--name`` is the name you want to use to refer to your cluster
-   * ``--resource-group`` is the ResourceGroup you created in step 4
-   * ``--ssh-key-value`` is the ssh public key created in step 6
+   * ``--resource-group`` is the ResourceGroup you created
+   * ``--ssh-key-value`` is the ssh public key created
    * ``--node-count`` is the number of nodes you want in your Kubernetes cluster
    * ``--node-vm-size`` is the size of the nodes you want to use, which varies based on
      what you are using your cluster for and how much RAM/CPU each of your users need.
@@ -295,8 +295,8 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
 
    where:
 
-   * ``--name`` is the name you gave your cluster in step 5
-   * ``--resource-group`` is the ResourceGroup you created in step 4
+   * ``--name`` is the name you gave your cluster
+   * ``--resource-group`` is the ResourceGroup you created
 
    This automatically updates your Kubernetes client configuration file.
 
@@ -360,7 +360,7 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
 
    .. note::
 
-     This form can also be used to change ``--node-count``/``--min-count``/``--max-count`` that was set in step 7 by using the "Instance limits" section of the scale condition ("Default", "Minimum" and "Maximum" respectively).
+     This form can also be used to change ``--node-count``/``--min-count``/``--max-count`` that was set previously by using the "Instance limits" section of the scale condition ("Default", "Minimum" and "Maximum" respectively).
 
      If you prefer to use the command line, you can run the following:
 

--- a/doc/source/microsoft/step-zero-azure-autoscale.rst
+++ b/doc/source/microsoft/step-zero-azure-autoscale.rst
@@ -5,7 +5,7 @@ Kubernetes on Microsoft Azure Kubernetes Service (AKS) with Autoscaling
 
 .. warning::
 
-  These instructions involve parts of the Azure command line that are in preview, hence the following documentation to subject to change.
+  These instructions involve parts of the Azure command line that are in preview, hence the following documentation is subject to change.
 
 You can create a Kubernetes cluster `either through the Azure portal website, or using the Azure command line tools <https://docs.microsoft.com/en-us/azure/aks/>`_.
 

--- a/doc/source/microsoft/step-zero-azure-autoscale.rst
+++ b/doc/source/microsoft/step-zero-azure-autoscale.rst
@@ -208,7 +208,7 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
       SP_PASSWD=$(az ad create-for-rbac \
           --name <SERVICE-PRINCIPAL-NAME> \
           --role Contributor \
-          --scopes $VNET_ID \
+          --scope $VNET_ID \
           --query password \
           --output tsv)
       SP_ID=$(az ad sp show \

--- a/doc/source/microsoft/step-zero-azure.rst
+++ b/doc/source/microsoft/step-zero-azure.rst
@@ -142,7 +142,7 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
    where:
 
    * ``--resource-group`` is the ResourceGroup you created
-   * ``-name`` is the name you want to assign to your virtual network, for example, ``hub-vnet``
+   * ``--name`` is the name you want to assign to your virtual network, for example, ``hub-vnet``
    * ``--address-prefixes`` are the IP address prefixes for your virtual network
    * ``--subnet-name`` is your desired name for your subnet, for example, ``hub-subnet``
    * ``--subnet-prefixes`` are the IP address prefixes in `CIDR format <https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing>`_ for the subnet

--- a/doc/source/microsoft/step-zero-azure.rst
+++ b/doc/source/microsoft/step-zero-azure.rst
@@ -151,16 +151,16 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
 
    .. code-block:: bash
 
-      VNET_ID=$(az network vnet show
-          --resource-group <RESOURCE-GROUP-NAME>
-          --name <VNET-NAME>
-          --query id
+      VNET_ID=$(az network vnet show \
+          --resource-group <RESOURCE-GROUP-NAME> \
+          --name <VNET-NAME> \
+          --query id \
           --output tsv)
-      SUBNET_ID=$(az network vnet subnet show
-          --resource-group <RESOURCE-GROUP-NAME>
-          --vnet-name <VNET-NAME>
-          --name <SUBNET-NAME>
-          --query id
+      SUBNET_ID=$(az network vnet subnet show \
+          --resource-group <RESOURCE-GROUP-NAME> \
+          --vnet-name <VNET-NAME> \
+          --name <SUBNET-NAME> \
+          --query id \
           --output tsv)
 
    We will create an Azure Active Directory (Azure AD) `service principal <https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals>`_ for use with the cluster, and assign the `Contributor role <https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor>`_ for use with the VNet.
@@ -168,15 +168,15 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
 
    .. code-block:: bash
 
-      SP_PASSWD=$(az ad create-for-rbac
-          --name <SERVICE-PRINCIPAL-NAME>
-          --role Contributor
-          --scopes $VNET_ID
-          --query password
+      SP_PASSWD=$(az ad create-for-rbac \
+          --name <SERVICE-PRINCIPAL-NAME> \
+          --role Contributor \
+          --scopes $VNET_ID \
+          --query password \
           --output tsv)
-      SP_ID=$(az ad sp show
-          --id http://<SERVICE-PRINCIPAL-NAME>
-          --query appId
+      SP_ID=$(az ad sp show \
+          --id http://<SERVICE-PRINCIPAL-NAME> \
+          --query appId \
           --output tsv)
 
    .. warning::

--- a/doc/source/microsoft/step-zero-azure.rst
+++ b/doc/source/microsoft/step-zero-azure.rst
@@ -57,7 +57,7 @@ If you prefer to use the Azure portal see the `Azure Kubernetes Service quicksta
 
    .. code-block:: bash
 
-      az account set -s <YOUR-CHOSEN-SUBSCRIPTION-NAME>
+      az account set --subscription <YOUR-CHOSEN-SUBSCRIPTION-NAME>
 
 
 #. Create a resource group. Azure uses the concept of


### PR DESCRIPTION
This PR updates the Step Zero docs for Azure k8s to create a virtual network into which the cluster is deployed. This is because k8s does not come with a network controller by default and so the `networkpolicy` resources installed by a helm chart will not be obeyed.

fixes #1526 