### PR TITLE
due to a kubernetes change in 1.14 the ssl service must come first

### DIFF
--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -42,18 +42,6 @@ spec:
     {{- end }}
     release: {{ .Release.Name }}
   ports:
-    - name: http
-      port: 80
-      protocol: TCP
-      {{- if $autoHTTPS }}
-      targetPort: 80
-      {{- else }}
-      targetPort: 8000
-      {{- end }}
-      # allow proxy.service.nodePort for http
-      {{- if .Values.proxy.service.nodePorts.http }}
-      nodePort: {{ .Values.proxy.service.nodePorts.http }}
-      {{- end }}
     {{- if $HTTPS }}
     - name: https
       port: 443
@@ -67,6 +55,18 @@ spec:
       {{- end }}
       {{- if .Values.proxy.service.nodePorts.https }}
       nodePort: {{ .Values.proxy.service.nodePorts.https }}
+      {{- end }}
+    - name: http
+      port: 80
+      protocol: TCP
+      {{- if $autoHTTPS }}
+      targetPort: 80
+      {{- else }}
+      targetPort: 8000
+      {{- end }}
+      # allow proxy.service.nodePort for http
+      {{- if .Values.proxy.service.nodePorts.http }}
+      nodePort: {{ .Values.proxy.service.nodePorts.http }}
       {{- end }}
     {{- end }}
   type: {{ .Values.proxy.service.type }}


### PR DESCRIPTION
In kubernetes 1.14 if the type is LoadBalancer and the backend has any SSL configuration it will configure an https health check, but it will use the first port which in this case is http and will fail.  Putting the possible https port first fixes this issue.

https://github.com/kubernetes/kubernetes/issues/83070