### PR TITLE
move endif to only bracket https options

### DIFF
--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -56,6 +56,7 @@ spec:
       {{- if .Values.proxy.service.nodePorts.https }}
       nodePort: {{ .Values.proxy.service.nodePorts.https }}
       {{- end }}
+    {{- end }}
     - name: http
       port: 80
       protocol: TCP
@@ -68,7 +69,6 @@ spec:
       {{- if .Values.proxy.service.nodePorts.http }}
       nodePort: {{ .Values.proxy.service.nodePorts.http }}
       {{- end }}
-    {{- end }}
   type: {{ .Values.proxy.service.type }}
   {{- if .Values.proxy.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.proxy.service.loadBalancerIP }}


### PR DESCRIPTION
The specification for proxy-public disables both HTTPS and HTTP ports if HTTPS is disabled, making it impossible to use an unsecured proxy (e.g. if you're moving to cert-manager)