### PR TITLE
Bump chartpress for Helm 3 compatible dev releases

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@
 ##
 ## ref: https://github.com/jupyterhub/chartpress
 ##
-chartpress==0.5.*
+chartpress==0.6.*
 
 ## pytest run tests that require requests, pytest is run from test
 ## script


### PR DESCRIPTION
Ping @scottyhq @betatim, this is relevant for Pangeo and BinderHub. When we make releases with chartpress 0.4.*-0.5.* we create dev releases of charts with an invalid semver version. This is resolved in 0.6.0, and that is important to have Helm 3 compatibility.

Here is [the chartpress chagelog](https://github.com/jupyterhub/chartpress/blob/master/CHANGELOG.md#060---2020-01-12).