### PR TITLE
Fix duplicate docs label

### DIFF
--- a/doc/source/microsoft/step-zero-azure-autoscale.rst
+++ b/doc/source/microsoft/step-zero-azure-autoscale.rst
@@ -1,4 +1,4 @@
-.. _microsoft-azure:
+.. _microsoft-azure-autoscale:
 
 Kubernetes on Microsoft Azure Kubernetes Service (AKS) with Autoscaling
 -----------------------------------------------------------------------


### PR DESCRIPTION
Should fix this warning in the CircleCI docs build:
`/home/circleci/project/doc/source/microsoft/step-zero-azure-autoscale.rst:4: WARNING: duplicate label microsoft-azure, other instance in /home/circleci/project/doc/source/microsoft/step-zero-azure.rst`