### PR TITLE
Added documentation of secret https mode

### DIFF
--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -54,6 +54,10 @@ changes to your `config.yaml` file:
 
 If you have your own HTTPS certificates & want to use those instead of the automatically provisioned Let's Encrypt ones, that's also possible. Note that this is considered an advanced option, so we recommend not doing it unless you have good reasons.
 
+There are 2 ways to specify your manual certificate, directly in the config.yaml or by creating a `secret`.
+
+#### Specify certificate in config.yaml
+
 1.  Add your domain name & HTTPS certificate info to your `config.yaml`
 
     ```yaml
@@ -73,8 +77,26 @@ If you have your own HTTPS certificates & want to use those instead of the autom
             -----END CERTIFICATE-----
     ```
 
-2.  Apply the config changes by running helm upgrade ....
-3.  Wait for about a minute, now your hub should be HTTPS enabled!
+2. Apply the config changes by running helm upgrade ....
+3. Wait for about a minute, now your hub should be HTTPS enabled!
+
+
+#### Specify certificate through Secret resource
+
+1. Create a `secret` resource with type `kubernetes.io/tls` containing your certificate. Add your domain and the name of your `secret` to your config.yaml.
+
+    ```yaml
+    proxy:
+      https:
+        hosts:
+          - <your-domain-name>
+        type: secret
+          secret:
+            name: <your-secret-name>
+    ```
+
+2. Apply the config changes by running helm upgrade ....
+3. Wait for about a minute, now your hub should be HTTPS enabled!
 
 ### Off-loading SSL to a Load Balancer
 

--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -83,7 +83,11 @@ There are two ways to specify your manual certificate, directly in the config.ya
 
 #### Specify certificate through Secret resource
 
-1. Create a `secret` resource with type `kubernetes.io/tls` containing your certificate. Add your domain and the name of your `secret` to your config.yaml.
+1. Create a `secret` resource with type `kubernetes.io/tls` containing your certificate.
+
+   `kubectl create secret tls example-tls --key="tls.key" --cert="tls.crt"`
+
+2. Add your domain and the name of your `secret` to your config.yaml.
 
     ```yaml
     proxy:
@@ -92,11 +96,11 @@ There are two ways to specify your manual certificate, directly in the config.ya
           - <your-domain-name>
         type: secret
           secret:
-            name: <your-secret-name>
+            name: example-tls
     ```
 
-2. Apply the config changes by running helm upgrade ....
-3. Wait for about a minute, now your hub should be HTTPS enabled!
+3. Apply the config changes by running helm upgrade ....
+4. Wait for about a minute, now your hub should be HTTPS enabled!
 
 ### Off-loading SSL to a Load Balancer
 

--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -54,7 +54,7 @@ changes to your `config.yaml` file:
 
 If you have your own HTTPS certificates & want to use those instead of the automatically provisioned Let's Encrypt ones, that's also possible. Note that this is considered an advanced option, so we recommend not doing it unless you have good reasons.
 
-There are 2 ways to specify your manual certificate, directly in the config.yaml or by creating a `secret`.
+There are two ways to specify your manual certificate, directly in the config.yaml or by creating a [Kubernetes `secret`](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 #### Specify certificate in config.yaml
 


### PR DESCRIPTION
I added documentation explaining how to configure https using a secret resource.

Storing private keys in a secret resource is better practice than stroing secret information like that in a plain text file.