### PR TITLE
Remove unneeded directive in traefik config

### DIFF
--- a/jupyterhub/templates/proxy/autohttps/configmap.yaml
+++ b/jupyterhub/templates/proxy/autohttps/configmap.yaml
@@ -88,7 +88,6 @@ data:
 
       # Used to set appropriate headers in requests sent to CHP
       [http.middlewares.https.headers]
-        sslProxyHeaders = true
         [http.middlewares.https.headers.customRequestHeaders]
           # Tornado needs this for referrer checks
           # You run into stuff like https://github.com/jupyterhub/jupyterhub/issues/2284 otherwise


### PR DESCRIPTION
Based on
https://github.com/yuvipanda/zero-to-jupyterhub-k8s/commit/d5892ab50c2bfce1138771bf6b2eca6fef60556c,
this directive is only useful when traefik is *behind* a TLS
termination proxy.