### PR TITLE
[MRG] Add option to remove named server when culling

### DIFF
--- a/jupyterhub/files/hub/cull_idle_servers.py
+++ b/jupyterhub/files/hub/cull_idle_servers.py
@@ -322,7 +322,7 @@ if __name__ == '__main__':
            )
     define('remove_named_servers', default=False,
            help="""Remove named servers in addition to stopping them.
-                This is for use in temporary-user cases such as Binderhub.""",
+                This is useful for a BinderHub that uses authentication and named servers.""",
            )
     define('concurrency', default=10,
            help="""Limit the number of concurrent requests made to the Hub.

--- a/jupyterhub/files/hub/cull_idle_servers.py
+++ b/jupyterhub/files/hub/cull_idle_servers.py
@@ -179,6 +179,10 @@ def cull_idle(
         body = None
         if server_name:
             # culling a named server
+            # A named server can be stopped and kept available to the user
+            # for starting again or stopped and removed. To remove the named
+            # server we have to pass an additional option in the body of our
+            # DELETE request.
             delete_url = url + "/users/%s/servers/%s" % (
                 quote(user['name']),
                 quote(server['name']),

--- a/jupyterhub/files/hub/cull_idle_servers.py
+++ b/jupyterhub/files/hub/cull_idle_servers.py
@@ -80,7 +80,15 @@ def format_td(td):
 
 
 @coroutine
-def cull_idle(url, api_token, inactive_limit, cull_users=False, max_age=0, concurrency=10):
+def cull_idle(
+    url,
+    api_token,
+    inactive_limit,
+    cull_users=False,
+    remove_named_servers=False,
+    max_age=0,
+    concurrency=10,
+):
     """Shutdown idle single-user servers
 
     If cull_users, inactive *users* will be deleted as well.
@@ -168,16 +176,24 @@ def cull_idle(url, api_token, inactive_limit, cull_users=False, max_age=0, concu
                 log_name, format_td(age), format_td(inactive))
             return False
 
+        body = None
         if server_name:
             # culling a named server
-            delete_url = url + "/users/%s/servers/%s"%(
-                quote(user['name']), quote(server['name'])
+            delete_url = url + "/users/%s/servers/%s" % (
+                quote(user['name']),
+                quote(server['name']),
             )
+            if remove_named_servers:
+                body = json.dumps({"remove": True})
         else:
             delete_url = url + '/users/%s/server' % quote(user['name'])
 
         req = HTTPRequest(
-            url=delete_url, method='DELETE', headers=auth_header,
+            url=delete_url,
+            method='DELETE',
+            headers=auth_header,
+            body=body,
+            allow_nonstandard_methods=True,
         )
         resp = yield fetch(req)
         if resp.code == 202:
@@ -302,7 +318,11 @@ if __name__ == '__main__':
            help="The maximum age (in seconds) of servers that should be culled even if they are active")
     define('cull_users', default=False,
            help="""Cull users in addition to servers.
-                This is for use in temporary-user cases such as tmpnb.""",
+                This is for use in temporary-user cases such as BinderHub.""",
+           )
+    define('remove_named_servers', default=False,
+           help="""Remove named servers in addition to stopping them.
+                This is for use in temporary-user cases such as Binderhub.""",
            )
     define('concurrency', default=10,
            help="""Limit the number of concurrent requests made to the Hub.
@@ -332,6 +352,7 @@ if __name__ == '__main__':
         api_token=api_token,
         inactive_limit=options.timeout,
         cull_users=options.cull_users,
+        remove_named_servers=options.remove_named_servers,
         max_age=options.max_age,
         concurrency=options.concurrency,
     )

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -386,6 +386,9 @@ if get_config('cull.enabled', False):
     if get_config('cull.users'):
         cull_cmd.append('--cull-users')
 
+    if get_config('cull.namedServers'):
+        cull_cmd.append('--remove-named-servers')
+
     cull_max_age = get_config('cull.maxAge')
     if cull_max_age:
         cull_cmd.append('--max-age=%s' % cull_max_age)

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -357,7 +357,7 @@ ingress:
 cull:
   enabled: true
   users: false
-  namedServers: false
+  removeNamedServers: false
   timeout: 3600
   every: 600
   concurrency: 10

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -357,6 +357,7 @@ ingress:
 cull:
   enabled: true
   users: false
+  namedServers: false
   timeout: 3600
   every: 600
   concurrency: 10


### PR DESCRIPTION
In a setup like a BinderHub with auth I enable the named server option to allow users to launch the same repository multiple times in an attempt to keep the experience as much like mybinder.org as possible. The reason the bhub has auth is because it has access to private repositories.

This PR adds a flag to the culler to allow it to remove a named server when it culls the server. With the old culler you have to enable culling of users and wait roughly two culling periods before a user who has maxed out their number of allowed named servers can start a new server again. (Or you have to teach users about the control panel and deleting servers there manually.)

I don't really want to cull users as that means you have to click the login button again.

What do people think? What is missing from this PR in terms of helm chart'ing? (it has been a while since I've made my last contribution this deep inside this project).