### PR TITLE
First-class azuread support

### DIFF
--- a/doc/source/administrator/authentication.rst
+++ b/doc/source/administrator/authentication.rst
@@ -172,6 +172,26 @@ tape archive, public cloud, or your own laptop. Start a Globus app
        callbackUrl: "https://<your_jupyterhub_host>/hub/oauth_callback"
        identityProvider: "youruniversity.edu"
 
+
+Azure Active Directory
+^^^^^^^^^^^^^^^^^^^^^^
+
+Azure Active Directory <https://docs.microsoft.com/en-us/azure/active-directory/>`_
+is an identity provider from Microsoft Azure.
+The main additional option to configure for Azure AD from any other
+oauth provider is the tenant id.
+
+.. code-block:: yaml
+
+   auth:
+     type: azuread
+     azuread:
+       clientId: "your-aad-client-id"
+       clientSecret: "your-aad-client-secret"
+       tenantId: "your-aad-tenant-id"
+       callbackUrl: "https://<your_jupyterhub_host>/hub/oauth_callback"
+
+
 OpenID Connect
 ^^^^^^^^^^^^^^
 

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -10,7 +10,7 @@ jupyterhub-hmacauthenticator==0.1.*
 mwoauth==0.3.7
 globus_sdk[jwt]==1.8.*
 nullauthenticator==1.0.*
-oauthenticator==0.10.*
+oauthenticator==0.11.*
 
 ## Spawners
 jupyterhub-kubespawner==0.11.*

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -293,6 +293,16 @@ elif auth_type == 'gitlab':
         if cfg_key is None:
             cfg_key = camelCaseify(trait)
         set_config_if_not_none(c.GitLabOAuthenticator, trait, 'auth.gitlab.' + cfg_key)
+elif auth_type == 'azuread':
+    c.JupyterHub.authenticator_class = 'azuread'
+    for trait, cfg_key in common_oauth_traits + (
+        ('tenant_id', None),
+        ('username_claim', None),
+    ):
+        if cfg_key is None:
+            cfg_key = camelCaseify(trait)
+
+        set_config_if_not_none(c.AzureAdOAuthenticator, trait, 'auth.azuread.' + cfg_key)
 elif auth_type == 'mediawiki':
     c.JupyterHub.authenticator_class = 'oauthenticator.mediawiki.MWOAuthenticator'
     for trait, cfg_key in common_oauth_traits + (


### PR DESCRIPTION
Adds aliases for `auth.type = azuread`, so

```yaml
auth:
  type: azuread
  azuread:
    clientId: ...
    clientSecret: ...
    tenantId: ...
    usernameClaim: ...
    callbackUrl: "https://<your_jupyterhub_host>/hub/oauth_callback"
```

should work now. OAuthenticator is updated to 0.11, which fixes some azuread issues, including the requirement to set tenant id via env, not just standard config.

/cc @cnf