### PR TITLE
Bump kind to 0.7.0 and include k8s 1.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,9 @@ env:
   ## ref: https://github.com/kubernetes-sigs/kind/issues/197
   ##
   - Z2JH_KUBE_VERSION=1.13.12
-  - Z2JH_KUBE_VERSION=1.15.6
-  - Z2JH_KUBE_VERSION=1.16.3
+  - Z2JH_KUBE_VERSION=1.15.7
+  - Z2JH_KUBE_VERSION=1.16.4
+  - Z2JH_KUBE_VERSION=1.17.0
 
 jobs:
   ## allow experimental setups to fail

--- a/ci/common
+++ b/ci/common
@@ -14,12 +14,12 @@ if [ -z ${Z2JH_KUBE_VERSION:-} ]; then
     ## ref: https://hub.docker.com/r/kindest/node/tags
     ## ref: https://github.com/kubernetes/kubernetes/releases
     ##
-    export Z2JH_KUBE_VERSION=1.15.6
+    export Z2JH_KUBE_VERSION=1.15.7
 fi
 if [ -z ${Z2JH_KIND_VERSION:-} ]; then
     ## ref: https://github.com/kubernetes-sigs/kind/releases
     ##
-    export Z2JH_KIND_VERSION=0.6.0
+    export Z2JH_KIND_VERSION=0.7.0
 fi
 if [ -z ${Z2JH_HELM_VERSION:-} ]; then
     ## ref: https://github.com/helm/helm/releases

--- a/dev
+++ b/dev
@@ -96,19 +96,9 @@ def kind_create(recreate):
         "--image", f"kindest/node:v{os.environ['Z2JH_KUBE_VERSION']}",
         "--config", "ci/kind-config.yaml",
     ])
-    
-    kubeconfig_path = _run(
-        cmd=[
-            "kind", "get", "kubeconfig-path",
-            "--name", "jh-dev",
-        ],
-        print_command=False,
-        capture_output=True,
-    )
-    if os.environ.get("KUBECONFIG", None) != kubeconfig_path:
-        print(f'Updating your .env file\'s KUBECONFIG value to "{kubeconfig_path}"')
-        dotenv.set_key(".env", "KUBECONFIG", kubeconfig_path)
-        os.environ["KUBECONFIG"] = kubeconfig_path
+
+    if not os.environ.get("KUBECONFIG", None):
+        os.environ["KUBECONFIG"] = ""
 
     kube_context = _run(
         cmd=["kubectl", "config", "current-context"],
@@ -224,20 +214,11 @@ def upgrade(chart, version, values):
         _run(["chartpress"])
         # git --no-pager diff
 
-        kubeconfig_path = _run(
-            cmd=[
-                "kind", "get", "kubeconfig-path",
-                "--name", "jh-dev",
-            ],
-            print_command=False,
-            capture_output=True,
-        )
-        if kubeconfig_path in os.environ["KUBECONFIG"]:
-            print("Loading the locally built images into the kind cluster.")
-            _run([
-                "python3", "ci/kind-load-docker-images.py",
-                "--kind-cluster", "jh-dev",
-            ])
+        print("Loading the locally built images into the kind cluster.")
+        _run([
+            "python3", "ci/kind-load-docker-images.py",
+            "--kind-cluster", "jh-dev",
+        ])
     else:
         print("External chart specified, skipping use of chartpress.")
 
@@ -652,7 +633,7 @@ if __name__ == "__main__":
             #
             # The "./dev kind create" command will set this files KUBECONFIG
             # entry automatically on cluster creation.
-            KUBECONFIG=""
+            KUBECONFIG=".jh-dev-kubeconfig"
 
             # Z2JH_KUBE_CONTEXT and Z2JH_KUBE_NAMESPACE is used to ensure we
             # work with the right cluster, with the right credentials, and in

--- a/dev
+++ b/dev
@@ -664,7 +664,7 @@ if __name__ == "__main__":
             # versions that are found on kindest/node can be used.
             #
             # ref: https://hub.docker.com/r/kindest/node/tags
-            Z2JH_KUBE_VERSION="1.15.6"
+            Z2JH_KUBE_VERSION="1.15.7"
 
             # Z2JH_VALIDATE_KUBE_VERSIONS is influences "./dev check templates",
             # what Kubernetes versions do we validate against? Note that only


### PR DESCRIPTION
Note that `kind create cluster` no longer creates new kubeconfig and provides the `kubeconfig-path` subcommand. Instead a new context is created into the current kubeconfig.

This PR adds `.jh-dev-kubeconfig` as the default KUBECONFIG for CI. However since the code path is in `dev`, this might be an unexpected change. cc/@consideRatio 