### PR TITLE
Cull user exclusion

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -9,7 +9,7 @@ charts:
       hub:
         valuesPath: hub.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.9.5
+          JUPYTERHUB_VERSION: 0.9.6
       network-tools:
         valuesPath: singleuser.networkTools.image
       image-awaiter:
@@ -17,4 +17,4 @@ charts:
       singleuser-sample:
         valuesPath: singleuser.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.9.5
+          JUPYTERHUB_VERSION: 0.9.6

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -9,7 +9,7 @@ charts:
       hub:
         valuesPath: hub.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.9.4
+          JUPYTERHUB_VERSION: 0.9.5
       network-tools:
         valuesPath: singleuser.networkTools.image
       image-awaiter:
@@ -17,4 +17,4 @@ charts:
       singleuser-sample:
         valuesPath: singleuser.image
         buildArgs:
-          JUPYTERHUB_VERSION: 0.9.4
+          JUPYTERHUB_VERSION: 0.9.5

--- a/doc/source/extending-jupyterhub.rst
+++ b/doc/source/extending-jupyterhub.rst
@@ -23,7 +23,7 @@ The general method to modify your Kubernetes deployment is to:
       RELEASE=jhub
 
       helm upgrade $RELEASE jupyterhub/jupyterhub \
-        --version=0.8.1 \
+        --version=0.8.2 \
         --values config.yaml
 
    Note that ``helm list`` should display ``<YOUR_RELEASE_NAME>`` if you forgot it.

--- a/doc/source/extending-jupyterhub.rst
+++ b/doc/source/extending-jupyterhub.rst
@@ -23,7 +23,7 @@ The general method to modify your Kubernetes deployment is to:
       RELEASE=jhub
 
       helm upgrade $RELEASE jupyterhub/jupyterhub \
-        --version=0.8.0 \
+        --version=0.8.1 \
         --values config.yaml
 
    Note that ``helm list`` should display ``<YOUR_RELEASE_NAME>`` if you forgot it.

--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -89,7 +89,7 @@ Install JupyterHub
 
       helm upgrade --install $RELEASE jupyterhub/jupyterhub \
         --namespace $NAMESPACE  \
-        --version=0.8.0 \
+        --version=0.8.1 \
         --values config.yaml
 
    where:

--- a/doc/source/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub.rst
@@ -89,7 +89,7 @@ Install JupyterHub
 
       helm upgrade --install $RELEASE jupyterhub/jupyterhub \
         --namespace $NAMESPACE  \
-        --version=0.8.1 \
+        --version=0.8.2 \
         --values config.yaml
 
    where:

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,6 +1,6 @@
 name: jupyterhub
-version: 0.8.0
-appVersion: 0.9.4
+version: 0.8.1
+appVersion: 0.9.5
 description: Multi-user Jupyter installation
 home: https://z2jh.jupyter.org
 sources:

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,6 +1,6 @@
 name: jupyterhub
-version: 0.8.1
-appVersion: 0.9.5
+version: 0.8.2
+appVersion: 0.9.6
 description: Multi-user Jupyter installation
 home: https://z2jh.jupyter.org
 sources:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -44,7 +44,7 @@ hub:
   extraVolumeMounts: []
   image:
     name: jupyterhub/k8s-hub
-    tag: '0.8.1'
+    tag: '0.8.2'
   resources:
     requests:
       cpu: 200m
@@ -166,7 +166,7 @@ singleuser:
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools
-      tag: '0.8.1'
+      tag: '0.8.2'
   cloudMetadata:
     enabled: false
     ip: 169.254.169.254
@@ -207,7 +207,7 @@ singleuser:
       storageAccessModes: [ReadWriteOnce]
   image:
     name: jupyterhub/k8s-singleuser-sample
-    tag: '0.8.1'
+    tag: '0.8.2'
     pullPolicy: IfNotPresent
   imagePullSecret:
     enabled: false
@@ -266,7 +266,7 @@ prePuller:
     enabled: true
     image:
       name: jupyterhub/k8s-image-awaiter
-      tag: '0.8.1'
+      tag: '0.8.2'
   continuous:
     enabled: false
   extraImages: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -44,7 +44,7 @@ hub:
   extraVolumeMounts: []
   image:
     name: jupyterhub/k8s-hub
-    tag: '0.8.0'
+    tag: '0.8.1'
   resources:
     requests:
       cpu: 200m
@@ -166,7 +166,7 @@ singleuser:
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools
-      tag: '0.8.0'
+      tag: '0.8.1'
   cloudMetadata:
     enabled: false
     ip: 169.254.169.254
@@ -207,7 +207,7 @@ singleuser:
       storageAccessModes: [ReadWriteOnce]
   image:
     name: jupyterhub/k8s-singleuser-sample
-    tag: '0.8.0'
+    tag: '0.8.1'
     pullPolicy: IfNotPresent
   imagePullSecret:
     enabled: false
@@ -266,7 +266,7 @@ prePuller:
     enabled: true
     image:
       name: jupyterhub/k8s-image-awaiter
-      tag: '0.8.0'
+      tag: '0.8.1'
   continuous:
     enabled: false
   extraImages: {}


### PR DESCRIPTION
For internal use, this adds `--exclude_users_from_culling` to `cull_idle_servers.py` against the latest stable tag, `0.8.2` (per [JupyterHub Helm chart reference](https://github.com/jupyterhub/helm-chart#the-jupyterhub-helm-chart)).

This PR should also produce a different tag, for internal usage, of the `jupyterhub/k8s-hub` image containing this updated `cull_idle_servers.py`, so that I can select that image in our z2jh Helm yaml.