### PR TITLE
jupyterhub-ldapauthenticator==1.3

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -5,7 +5,7 @@ jupyterhub-dummyauthenticator==0.3.*
 jupyterhub-firstuseauthenticator==0.12.*
 jupyterhub-tmpauthenticator==0.6.*
 jupyterhub-ltiauthenticator==0.4.*
-jupyterhub-ldapauthenticator==1.2.*
+jupyterhub-ldapauthenticator==1.3.*
 jupyterhub-hmacauthenticator==0.1.*
 mwoauth==0.3.7
 globus_sdk[jwt]==1.8.*


### PR DESCRIPTION
Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1561

Significant changes (taken from https://github.com/jupyterhub/ldapauthenticator/blob/1.3.0/CHANGELOG.md):

-    Avoid binding the connection twice
-    Gracefully handle username lookups with list return values
-    Empty DN templates are now ignored, search_filter and allowed_groups are no longer mutually exclusive*.
-    Allow authentication with empty bind_dn_template when using lookup_dn
-    Ignore username returned by resolve_username - use_lookup_dn_username configuration option added
-    Lookup additional LDAP user info - user_info_attributes is now saved in auth_state for a valid user.
