### PR TITLE
init helm and tiller with history-max settings

### DIFF
--- a/doc/source/setup-jupyterhub/setup-helm.rst
+++ b/doc/source/setup-jupyterhub/setup-helm.rst
@@ -73,7 +73,7 @@ cluster:
 
    .. code-block:: bash
 
-      helm init --service-account tiller --wait
+      helm init --service-account tiller --history-max 100 --wait
 
    This command only needs to run once per Kubernetes cluster, it will create a
    `tiller` deployment in the kube-system namespace and setup your local `helm`

--- a/doc/source/setup-jupyterhub/setup-helm.rst
+++ b/doc/source/setup-jupyterhub/setup-helm.rst
@@ -83,6 +83,8 @@ cluster:
    to deploy changes with `helm` (the local CLI), it will talk to `tiller`
    and tell it what to do. `tiller` then executes these instructions from
    within the cluster.
+   We limit the history to 100 previous installs as very long histories slow 
+   down helm commands a lot.
 
    .. note::
 


### PR DESCRIPTION
Hi, I have just seen that mybinder also had problem with helm history and remembered the issue related to that I opened. So I just want to make the first step and add the  `--history-max 100` setting in the documentation of helm setup. Please feel free to add more, I am not comfortable with my wording and it usually takes more time for me than other people :)

closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1339