### PR TITLE
fix: Bump to base-notebook with JH 1.1.0 etc

### DIFF
--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -6,6 +6,10 @@ FROM jupyter/base-notebook:a07573d685a4
 # The jupyter/docker-stacks images contains jupyterhub, jupyterlab and the
 # jupyterlab-hub extension already.
 
+## NOTE: This is a default and be overridden by chartpress using the
+##       chartpress.yaml configuration
+ARG JUPYTERHUB_VERSION=1.1.*
+
 # Example install of git and nbgitpuller.
 # NOTE: git is already available in the jupyter/minimal-notebook image.
 USER root
@@ -14,7 +18,12 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 USER $NB_USER
 
-RUN pip install nbgitpuller && \
+RUN python -m pip install nbgitpuller \
+    $(bash -c 'if [[ $JUPYTERHUB_VERSION == "git"* ]]; then \
+       echo ${JUPYTERHUB_VERSION}; \
+     else \
+       echo jupyterhub==${JUPYTERHUB_VERSION}; \
+     fi') && \
     jupyter serverextension enable --py nbgitpuller --sys-prefix
 
 # Uncomment the line below to make nbgitpuller default to start up in JupyterLab

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:d4e60350af15
+FROM jupyter/base-notebook:a07573d685a4
 # Built from... https://hub.docker.com/r/jupyter/base-notebook/
 #               https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile
 # Built from... Ubuntu 18.04
@@ -14,8 +14,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 USER $NB_USER
 
-RUN pip install --upgrade jupyterhub && \
-    pip install nbgitpuller && \
+RUN pip install nbgitpuller && \
     jupyter serverextension enable --py nbgitpuller --sys-prefix
 
 # Uncomment the line below to make nbgitpuller default to start up in JupyterLab


### PR DESCRIPTION
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1549 bumps jupyter/base-notebook:d4e60350af15 which has jhub 1.0.0 installed (https://hub.docker.com/r/jupyter/base-notebook/tags/?page=2), but because in Dockerfile `pip install --upgrade jupyterhub` is executed, at the end image has jhub 1.1.0.

Since https://github.com/jupyter/docker-stacks/issues/992 is fixed, we can use the latest jupyter/base-notebook and dont have to manually upgrade jhub anymore.