### PR TITLE
Bump configurable-http-proxy image

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -133,7 +133,7 @@ proxy:
   chp:
     image:
       name: jupyterhub/configurable-http-proxy
-      tag: 4.2.0
+      tag: 4.2.1
     livenessProbe:
       enabled: true
       initialDelaySeconds: 30


### PR DESCRIPTION
A security fix in the configurable-http-proxy image caused by having npm
installed.

ref: https://github.com/jupyterhub/configurable-http-proxy/pull/226