### PR TITLE
[MRG] Sphinx: warnings are errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Build docs to store
           command: |
             cd doc
-            make html
+            make html SPHINXOPTS='-W'
 
       - store_artifacts:
           path: doc/build/html/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Build docs to store
           command: |
             cd doc
-            make html SPHINXOPTS='-W'
+            make html SPHINXOPTS='-W --keep-going'
 
       - store_artifacts:
           path: doc/build/html/

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=1.7
+sphinx>=1.8
 recommonmark
 pyyaml
 sphinx-copybutton

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 - python=3.5
-- sphinx>=1.7
+- sphinx>=1.8
 - pip:
     - recommonmark==0.4.0
     - pyyaml

--- a/doc/source/administrator/optimization.md
+++ b/doc/source/administrator/optimization.md
@@ -325,7 +325,7 @@ for the first time, it is showing the amount of user pods active on five
 different nodes. When the user scheduler was enabled, two nodes were in time
 freed up from user pods and scaled down.
 
-[![](../_static/images/user_scheduler.png)](../_static/images/user_scheduler.png)
+![User scheduler node activity](../_static/images/user_scheduler.png)
 
 To enable the user scheduler:
 

--- a/doc/source/amazon/efs_storage.rst
+++ b/doc/source/amazon/efs_storage.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _amazon-efs:
 
 Setting up EFS storage on AWS

--- a/doc/source/repo2docker.rst
+++ b/doc/source/repo2docker.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. This is a backup of the repo2docker instructions from user-environment.rst
 
 .. _r2d-custom-image:

--- a/doc/source/setup-jupyterhub/setup-helm.rst
+++ b/doc/source/setup-jupyterhub/setup-helm.rst
@@ -25,8 +25,8 @@ instructions to `tiller` in the cluster that in turn make the requested changes.
 
    These instructions are for Helm 2.
    Helm 3 includes several major breaking changes and is not yet officially
-   supported, but `preliminary instructions are available for testing
-   <setup-helm3>`_.
+   supported, but :doc:`preliminary instructions are available for testing
+   <setup-helm3>`.
 
 Installation
 ------------

--- a/doc/source/setup-jupyterhub/setup-helm3.rst
+++ b/doc/source/setup-jupyterhub/setup-helm3.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _setup-helm3:
 
 Setting up Helm 3 (Preview)

--- a/doc/source/setup-jupyterhub/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub/setup-jupyterhub.rst
@@ -3,8 +3,8 @@
 Setting up JupyterHub
 =====================
 
-Now that we have a `Kubernetes cluster <create-k8s-cluster>`_ and `Helm
-<setup-helm>`_ setup, we can proceed by using Helm to install JupyterHub
+Now that we have a :doc:`Kubernetes cluster </create-k8s-cluster>` and :doc:`Helm
+<setup-helm>` setup, we can proceed by using Helm to install JupyterHub
 and related :term:`Kubernetes resources <kubernetes resource>` using a
 :term:`Helm chart`.
 


### PR DESCRIPTION
As suggested in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1601#issuecomment-602637363 changes Sphinx warnings to errors
1. First commit adds `-W` to convert warnings to errors, circle-ci fails.
2. Second commit fixes the errors detected in (1), circle-ci passes. Note the broken cross references from https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1601 **were not detected**
3. Third commit fixes the broken internal links

Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1601

Updated:
- Bump sphinx so `--keep-going` flag can be used to show all doc errors