### PR TITLE
[MRG] sphinx: linkcheck in travis (allowed to fail)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,13 +68,13 @@ jobs:
   ##
   ## ref: https://docs.travis-ci.com/user/customizing-the-build/#rows-that-are-allowed-to-fail
   ##
-  # allow_failures:
-  #   - env: *allow_failure
+  allow_failures:
+    - name: check docs
   ## don't wait for the jobs that are allowed to fail to report success
   ##
   ## ref: https://docs.travis-ci.com/user/customizing-the-build/#fast-finishing
   ##
-  # fast_finish: true
+  fast_finish: true
 
   ## include additional individual jobs
   ##
@@ -87,6 +87,13 @@ jobs:
       env:
         ## inclusions of more than three versions cause rate limiting failures
         - Z2JH_VALIDATE_KUBE_VERSIONS=1.11.0,1.14.0,1.16.0
+    - stage: lint and validate
+      name: check docs
+      script:
+        - pip install -r doc/doc-requirements.txt
+        - cd doc
+        - make html SPHINXOPTS='-W --keep-going'
+        - make linkcheck
     - stage: publish
       script:
         - setup_git_crypt


### PR DESCRIPTION
Related to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/724

Runs the Sphinx linkcheck in Travis, currently allowed to fail.

Although this means the docs are built twice (in Circle CI and Travis) I think it's clearer to have all the build statuses in one place, and the overhead of building the docs is small compared to that of running the deployment tests.