### PR TITLE
Ensure a default value for hub.existingSecret

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -87,7 +87,7 @@ hub:
     enabled: true
     initialDelaySeconds: 0
     periodSeconds: 10
-  # existingSecret: existing-secret
+  existingSecret: false
 
 rbac:
   enabled: true


### PR DESCRIPTION
Installing the chart without providing hub.existingSecret results in an error. Provide `false` by default. 

Helm 2:
`Error: render error in "jupyterhub/templates/proxy/deployment.yaml": template: jupyterhub/templates/proxy/deployment.yaml:28:32: executing "jupyterhub/templates/proxy/deployment.yaml" at <include (print $.Tem...>: error calling include: template: jupyterhub/templates/hub/secret.yaml:1:18: executing "jupyterhub/templates/hub/secret.yaml" at <.Values.hub.existing...>: can't evaluate field existingSecret in type interface {}`

Helm 3:
`Error: template: jupyterhub/templates/proxy/deployment.yaml:28:32: executing "jupyterhub/templates/proxy/deployment.yaml" at <include (print $.Template.BasePath "/hub/secret.yaml") .>: error calling include: template: jupyterhub/templates/hub/secret.yaml:1:18: executing "jupyterhub/templates/hub/secret.yaml" at <.Values.hub.existingSecret>: nil pointer evaluating interface {}.existingSecret`