### PR TITLE
Do not hardcode IPv4 localhost address for IPv6 compatibility

### DIFF
--- a/jupyterhub/files/hub/cull_idle_servers.py
+++ b/jupyterhub/files/hub/cull_idle_servers.py
@@ -24,7 +24,7 @@ You can run this as a service managed by JupyterHub with this in your config::
 Or run it manually by generating an API token and storing it in `JUPYTERHUB_API_TOKEN`:
 
     export JUPYTERHUB_API_TOKEN=`jupyterhub token`
-    python cull_idle_servers.py [--timeout=900] [--url=http://127.0.0.1:8081/hub/api]
+    python cull_idle_servers.py [--timeout=900] [--url=http://localhost:8081/hub/api]
 """
 
 from datetime import datetime, timezone

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -379,7 +379,7 @@ if get_config('cull.enabled', False):
     ]
     base_url = c.JupyterHub.get('base_url', '/')
     cull_cmd.append(
-        '--url=http://127.0.0.1:8081' + url_path_join(base_url, 'hub/api')
+        '--url=http://localhost:8081' + url_path_join(base_url, 'hub/api')
     )
 
     cull_timeout = get_config('cull.timeout')


### PR DESCRIPTION
I am currently deploying Z2JH on an IPv6-only Kubernetes cluster.

There are a bunch of changes lined up for being upstreamed.
This is the first an easiest one.