### PR TITLE
Bind proxy on IPv4 and IPv6 for dual stack support

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -53,8 +53,8 @@ spec:
           image: {{ .Values.proxy.chp.image.name }}:{{ .Values.proxy.chp.image.tag }}
           command:
             - configurable-http-proxy
-            - --ip=0.0.0.0
-            - --api-ip=0.0.0.0
+            - '--ip=::'
+            - '--api-ip=::'
             - --api-port=8001
             - --default-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
             - --error-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)/hub/error


### PR DESCRIPTION
The `configurable-http-proxy` relies on the `http` module which in turn relies on the `server` module:

https://nodejs.org/api/net.html#net_server_listen

We dont make use of the `ipv6Only` option. Therefore we can safely listen on `::` for dual stack support.