### PR TITLE
DX: more recognizable port numbers

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -3,7 +3,8 @@ proxy:
   service:
     type: NodePort
     nodePorts:
-      http: 31212
+      http: 30080
+      https: 30443
   chp:
     resources:
       requests:


### PR DESCRIPTION
Whenever it works to use a port number that indicates what it is, I appreciate it. This does that for the dev-config, not relevant for production use.