### PR TITLE
Dep: Bump deploy/autohttps's traefik to v2.2

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -149,7 +149,7 @@ proxy:
   traefik:
     image:
       name: traefik
-      tag: v2.1
+      tag: v2.2 # ref: https://hub.docker.com/_/traefik?tab=tags
     hsts:
       maxAge: 15724800 # About 6 months
       includeSubdomains: false


### PR DESCRIPTION
I was working a lot against treafik in a PR to come, and I bumped it to know that I was working against the latest version of documentation. It seems to work fine even though we can't test it in our CI setup - yet!