### PR TITLE
Feat: autohttps readinessProbe for quicker shutdowns

### DIFF
--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -68,6 +68,12 @@ spec:
               mountPath: /etc/traefik
             - name: certificates
               mountPath: /etc/acme
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 1
+            failureThreshold: 3
         - name: secret-sync
           image: "{{ .Values.proxy.secretSync.image.name }}:{{ .Values.proxy.secretSync.image.tag }}"
           {{- with .Values.proxy.secretSync.image.pullPolicy }}


### PR DESCRIPTION
When the autohttps deployment is updating, it keeps existing connections 
open for a while before it shuts down, but it closes itself for new 
connections.

After it has closed itself for new connections, it is still considered 
ready by the service that delegates traffic, so that makes the pod 
continue to receive traffic that will crash.

With this change, it will stop receiving traffic, which is preferred as 
it isn't actually doing its job to receive it as it should any more at 
this stage.