### PR TITLE
CI: fix sphinx warnings turned into errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Build docs to store
           command: |
             cd doc
-            make html SPHINXOPTS='-W --keep-going'
+            make html
 
       - store_artifacts:
           path: doc/build/html/

--- a/doc/source/customizing/user-environment.rst
+++ b/doc/source/customizing/user-environment.rst
@@ -125,7 +125,7 @@ we recommend that you build a new image on top of an existing Docker image from
 jupyter/docker-stacks.
 
 Below is an example :term:`Dockerfile` building on top of the *minimal-notebook*
-image. This file can be built to a :term:`docker image`, and pushed to a
+image. This file can be built to a :term:`Docker image`, and pushed to a
 :term:`image registry`, and finally configured in :term:`config.yaml` to be used
 by the Helm chart.
 

--- a/doc/source/reference/glossary.rst
+++ b/doc/source/reference/glossary.rst
@@ -22,7 +22,7 @@ details.
       Dummy (anyone can log in), etc.
    
    `config.yaml`
-      The :term:`Helm charts <helm chart>` templates are rendered with these
+      The :term:`Helm charts <Helm chart>` templates are rendered with these
       :term:`Helm values` as input. The file is written in the `YAML
       <https://en.wikipedia.org/wiki/YAML>`_ format. The YAML format is essential
       to grasp if working with Kubernetes and Helm.
@@ -57,7 +57,7 @@ details.
    `Helm chart <https://docs.helm.sh/developing_charts/#charts>`_
       A Helm chart is a group of :term:`Helm templates <Helm template>` that
       can, given its default values and overrides in provided ``yaml`` files,
-      render to a set of :term:`Kubernetes resources <kubernetes resource>` that
+      render to a set of :term:`Kubernetes resources <Kubernetes resource>` that
       can be easily installed to your Kubernetes cluster. In other words a Helm
       chart is like a configurable installation of software and infrastructure
       to exist on a cloud.
@@ -67,10 +67,10 @@ details.
       :term:`Kubernetes resource`.
 
    `Helm values <https://docs.helm.sh/chart_template_guide/#values-files>`_
-      :term:`Helm charts <helm chart>` has a set of predefined values
+      :term:`Helm charts <Helm chart>` has a set of predefined values
       (`values.yaml`) typically overridden by other values in `config.yaml`. The
-      final values are used to generate :term:`Kubernetes resources <kubernetes
-      resource>` from :term:`Helm templates <helm template>` within a
+      final values are used to generate :term:`Kubernetes resources <Kubernetes
+      resource>` from :term:`Helm templates <Helm template>` within a
       :term:`Helm chart`.
 
    Kubernetes

--- a/doc/source/setup-jupyterhub/setup-jupyterhub.rst
+++ b/doc/source/setup-jupyterhub/setup-jupyterhub.rst
@@ -5,7 +5,7 @@ Setting up JupyterHub
 
 Now that we have a :doc:`Kubernetes cluster </create-k8s-cluster>` and :doc:`Helm
 <setup-helm>` setup, we can proceed by using Helm to install JupyterHub
-and related :term:`Kubernetes resources <kubernetes resource>` using a
+and related :term:`Kubernetes resources <Kubernetes resource>` using a
 :term:`Helm chart`.
 
 Prepare configuration file
@@ -17,8 +17,8 @@ configuration file that we will refer to as `config.yaml`. It will contain the m
 specifically together with this guide.
 
 Helm charts contains :term:`templates
-<helm template>` that with provided values will render to :term:`Kubernetes
-resources <kubernetes resource>` to be installed in a Kubernetes cluster. This
+<Helm template>` that with provided values will render to :term:`Kubernetes
+resources <Kubernetes resource>` to be installed in a Kubernetes cluster. This
 config file will provide the values to be used by our Helm chart.
 
 1. Generate a random hex string representing 32 bytes to use as a security


### PR DESCRIPTION
We make warnings into errors on circle-ci's test of the docs, and when sphinx was bumped a new kind of warning about case mismatched referenced arrived.

I fixed the case mismatches, and made CircleCI less harsh, because we are already checking for errors properly in TravisCI and CircleCI's purpose as I understand it in this repo is to provide us with previews of built documentation.