### PR TITLE
Fix broken links in the Reference documentation

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1172,14 +1172,18 @@ properties:
     properties:
       hook:
         description: |
-          See the [*optimization section*](optimization.html#pulling-images-before-users-arrive) for more details.
+          See the [*optimization
+          section*](https://zero-to-jupyterhub.readthedocs.io/en/stable/administrator/optimization.html#pulling-images-before-users-arrive)
+          for more details.
         type: object
         properties:
           enabled:
             type: bool
       continuous:
         description: |
-          See the [*optimization section*](optimization.html#pulling-images-before-users-arrive) for more details.
+          See the [*optimization
+          section*](https://zero-to-jupyterhub.readthedocs.io/en/stable/administrator/optimization.html#pulling-images-before-users-arrive)
+          for more details.
 
           **NOTE**: If used with a Cluster Autoscaler (an autoscaling node
           pool), also add user-placeholders and enable pod priority.
@@ -1190,7 +1194,9 @@ properties:
       extraImages:
         type: object
         description: |
-          See the [*optimization section*](optimization.html#the-images-that-will-be-pulled) for more details.
+          See the [*optimization
+          section*](https://zero-to-jupyterhub.readthedocs.io/en/stable/administrator/optimization.html#the-images-that-will-be-pulled)
+          for more details.
 
           ```yaml
           prePuller:


### PR DESCRIPTION
The Reference documentation page is generated from the JupyterHub
schema. Fix the broken links[1] there and enjoy the propagation to
the documentation.

[1]: Turn relative links into absolute links to the stable
  documentation page on ReadTheDocs. This mimicks how the other
  links are set in the schema.