### PR TITLE
Default HTTPS on proxy does not function

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -165,7 +165,7 @@ proxy:
     enabled: true
     minAvailable: 1
   https:
-    enabled: true
+    enabled: false
     type: letsencrypt
     #type: letsencrypt, manual, offload, secret
     letsencrypt:


### PR DESCRIPTION
By default the proxy has HTTPS enabled, but no certificates exist.  The user must either setup letsencrypt or supply their own certificates.  We should disable this by default as to not expose something that does not work.  

This resolves - https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1637