### PR TITLE
Refactor: reference ports by name instead of repeating the number

### DIFF
--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -281,10 +281,8 @@ singleuser:
             protocol: UDP
       - ports:
           - port: 80
-            protocol: TCP
       - ports:
           - port: 443
-            protocol: TCP
 ```
 
 See the [Kubernetes

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -216,8 +216,8 @@ spec:
             {{- end }}
             {{- end }}
           ports:
-            - containerPort: 8081
-              name: hub
+            - name: http
+              containerPort: 8081
           {{- if .Values.hub.livenessProbe.enabled }}
           # livenessProbe notes:
           # We don't know how long hub database upgrades could take
@@ -231,7 +231,7 @@ spec:
             periodSeconds: {{ .Values.hub.livenessProbe.periodSeconds }}
             httpGet:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
-              port: hub
+              port: http
           {{- end }}
           {{- if .Values.hub.readinessProbe.enabled }}
           readinessProbe:
@@ -239,5 +239,5 @@ spec:
             periodSeconds: {{ .Values.hub.readinessProbe.periodSeconds }}
             httpGet:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
-              port: hub
+              port: http
           {{- end }}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -18,8 +18,7 @@ spec:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
       ports:
-        - protocol: TCP
-          port: 8081
+        - port: 8081
     {{- /* Useful if you want to give hub access to pods from other namespaces */}}
     {{- if .Values.hub.networkPolicy.ingress}}
     {{- .Values.hub.networkPolicy.ingress| toYaml | trimSuffix "\n" | nindent 4 }}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -18,7 +18,7 @@ spec:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
       ports:
-        - port: 8081
+        - port: http
     {{- /* Useful if you want to give hub access to pods from other namespaces */}}
     {{- if .Values.hub.networkPolicy.ingress}}
     {{- .Values.hub.networkPolicy.ingress| toYaml | trimSuffix "\n" | nindent 4 }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -23,7 +23,7 @@ spec:
     {{- include "jupyterhub.matchLabels" . | nindent 4 }}
   ports:
     - port: 8081
-      targetPort: 8081
+      targetPort: http
       {{- if .Values.hub.service.ports.nodePort }}
       nodePort: {{ .Values.hub.service.ports.nodePort }}
       {{- end }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -22,8 +22,7 @@ spec:
   selector:
     {{- include "jupyterhub.matchLabels" . | nindent 4 }}
   ports:
-    - protocol: TCP
-      port: 8081
+    - port: 8081
       targetPort: 8081
       {{- if .Values.hub.service.ports.nodePort }}
       nodePort: {{ .Values.hub.service.ports.nodePort }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -64,10 +64,8 @@ spec:
           ports:
             - name: http
               containerPort: 80
-              protocol: TCP
             - name: https
               containerPort: 443
-              protocol: TCP
           volumeMounts:
             - name: traefik-config
               mountPath: /etc/traefik

--- a/jupyterhub/templates/proxy/autohttps/service.yaml
+++ b/jupyterhub/templates/proxy/autohttps/service.yaml
@@ -18,5 +18,5 @@ spec:
     {{- include "jupyterhub.matchLabels" $_ | nindent 4 }}
   ports:
     - port: 8000
-      targetPort: 8000
+      targetPort: http
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/service.yaml
+++ b/jupyterhub/templates/proxy/autohttps/service.yaml
@@ -17,7 +17,6 @@ spec:
     {{- $_ := merge (dict "componentLabel" "proxy") . }}
     {{- include "jupyterhub.matchLabels" $_ | nindent 4 }}
   ports:
-    - protocol: TCP
-      port: 8000
+    - port: 8000
       targetPort: 8000
 {{- end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -102,13 +102,13 @@ spec:
           {{- end }}
           ports:
             {{- if or $manualHTTPS $manualHTTPSwithsecret }}
-            - containerPort: 8443
-              name: proxy-https
+            - name: https
+              containerPort: 8443
             {{- end }}
-            - containerPort: 8000
-              name: proxy-public
-            - containerPort: 8001
-              name: api
+            - name: http
+              containerPort: 8000
+            - name: api
+              containerPort: 8001
           {{- if .Values.proxy.chp.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.proxy.chp.livenessProbe.initialDelaySeconds }}
@@ -116,10 +116,10 @@ spec:
             httpGet:
               path: /_chp_healthz
               {{- if or $manualHTTPS $manualHTTPSwithsecret }}
-              port: proxy-https
+              port: https
               scheme: HTTPS
               {{- else }}
-              port: proxy-public
+              port: http
               scheme: HTTP
               {{- end }}
           {{- end }}
@@ -130,10 +130,10 @@ spec:
             httpGet:
               path: /_chp_healthz
               {{- if or $manualHTTPS $manualHTTPSwithsecret }}
-              port: proxy-https
+              port: https
               scheme: HTTPS
               {{- else }}
-              port: proxy-public
+              port: http
               scheme: HTTP
               {{- end }}
           {{- end }}

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -18,30 +18,22 @@ spec:
     - Egress
   ingress:
     - ports:
-      - port: 80
-      - port: 443
-      {{- if not $autoHTTPS }}
-      - port: 8000
-      {{- end }}
+      - port: http
       {{- if or $manualHTTPS $manualHTTPSwithsecret}}
-      - port: 8443
+      - port: https
       {{- end }}
-      # kube-lego /healthz
-      - port: 8080
-      # nginx /healthz
-      - port: 10254
     - from:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
       ports:
-        - port: 8000
+        - port: http
     - from:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
       ports:
-        - port: 8001
+        - port: api
     {{- /* Useful if you want to give proxy access to pods from other namespaces */}}
     {{- if .Values.proxy.networkPolicy.ingress}}
     {{- .Values.proxy.networkPolicy.ingress | toYaml | trimSuffix "\n" | nindent 4 }}

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -18,38 +18,30 @@ spec:
     - Egress
   ingress:
     - ports:
-      - protocol: TCP
-        port: 80
-      - protocol: TCP
-        port: 443
+      - port: 80
+      - port: 443
       {{- if not $autoHTTPS }}
-      - protocol: TCP
-        port: 8000
+      - port: 8000
       {{- end }}
       {{- if or $manualHTTPS $manualHTTPSwithsecret}}
-      - protocol: TCP
-        port: 8443
+      - port: 8443
       {{- end }}
       # kube-lego /healthz
-      - protocol: TCP
-        port: 8080
+      - port: 8080
       # nginx /healthz
-      - protocol: TCP
-        port: 10254
+      - port: 10254
     - from:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
       ports:
-        - protocol: TCP
-          port: 8000
+        - port: 8000
     - from:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
       ports:
-        - protocol: TCP
-          port: 8001
+        - port: 8001
     {{- /* Useful if you want to give proxy access to pods from other namespaces */}}
     {{- if .Values.proxy.networkPolicy.ingress}}
     {{- .Values.proxy.networkPolicy.ingress | toYaml | trimSuffix "\n" | nindent 4 }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -14,8 +14,7 @@ spec:
   selector:
     {{- include "jupyterhub.matchLabels" . | nindent 4 }}
   ports:
-    - protocol: TCP
-      port: 8001
+    - port: 8001
       targetPort: 8001
 ---
 apiVersion: v1
@@ -44,7 +43,6 @@ spec:
     {{- if $HTTPS }}
     - name: https
       port: 443
-      protocol: TCP
       {{- if or $manualHTTPS $manualHTTPSwithsecret }}
       targetPort: 8443
       {{- else if $offloadHTTPS }}
@@ -58,7 +56,6 @@ spec:
     {{- end }}
     - name: http
       port: 80
-      protocol: TCP
       {{- if $autoHTTPS }}
       targetPort: 80
       {{- else }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -15,7 +15,7 @@ spec:
     {{- include "jupyterhub.matchLabels" . | nindent 4 }}
   ports:
     - port: 8001
-      targetPort: 8001
+      targetPort: api
 ---
 apiVersion: v1
 kind: Service
@@ -43,12 +43,10 @@ spec:
     {{- if $HTTPS }}
     - name: https
       port: 443
-      {{- if or $manualHTTPS $manualHTTPSwithsecret }}
-      targetPort: 8443
-      {{- else if $offloadHTTPS }}
-      targetPort: 8000
+      {{- if $offloadHTTPS }}
+      targetPort: http
       {{- else }}
-      targetPort: 443
+      targetPort: https
       {{- end }}
       {{- with .Values.proxy.service.nodePorts.https }}
       nodePort: {{ . }}
@@ -56,11 +54,7 @@ spec:
     {{- end }}
     - name: http
       port: 80
-      {{- if $autoHTTPS }}
-      targetPort: 80
-      {{- else }}
-      targetPort: 8000
-      {{- end }}
+      targetPort: http
       {{- with .Values.proxy.service.nodePorts.http }}
       nodePort: {{ . }}
       {{- end }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -19,8 +19,7 @@ spec:
             matchLabels:
               hub.jupyter.org/network-access-singleuser: "true"
       ports:
-        - protocol: TCP
-          port: 8888
+        - port: 8888
     {{- /* Useful if you want to give user server access to pods from other namespaces */}}
     {{- if .Values.singleuser.networkPolicy.ingress }}
     {{- .Values.singleuser.networkPolicy.ingress | toYaml | trimSuffix "\n" | nindent 4 }}
@@ -36,8 +35,7 @@ spec:
               {{- $_ := merge (dict "componentLabel" "hub") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
       ports:
-        - protocol: TCP
-          port: 8081
+        - port: 8081
     {{- if .Values.singleuser.networkPolicy.egress }}
     {{- .Values.singleuser.networkPolicy.egress | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
- Port definitions `protocol: TCP` is no longer explicitly set
- Ports are now referenced by name from services and network policy ingress
- The deploy/hub and deploy/proxy pods got some ports renamed:
  - hub -> http
  - proxy-public -> http
  - proxy-https -> https
- I removed legacy ports allowed by the deploy/proxy pod's network policy for kube-lego and nginx /health. They could not be accessed anyhow as they were not exposed by the pod.

This should not influence anything.