### PR TITLE
proxy.service.type: Default is different from hub.service.type

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -497,7 +497,7 @@ properties:
               - LoadBalancer
               - ExternalName
             description: |
-              See `hub.service.type`.
+              Default `LoadBalancer`. See `hub.service.type` for supported values.
           labels:
             type: object
             description: |


### PR DESCRIPTION
https://zero-to-jupyterhub.readthedocs.io/en/latest/reference/reference.html#proxy-service-type just says `See hub.service.type.`
![image](https://user-images.githubusercontent.com/1644105/80317332-21184080-87fb-11ea-9aab-5783cf2c8f0a.png)

It's not identical though since the default is different.