### PR TITLE
Force sphinx>=2,<3 for myst_parser

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,6 +1,5 @@
 pydata_sphinx_theme
 pyyaml
-myst_parser
+myst_parser[sphinx]
 sphinx-autobuild
 sphinx-copybutton
-sphinx<3


### PR DESCRIPTION
I ran into [this build error](https://readthedocs.org/projects/zero-to-jupyterhub/builds/11003549/) after merging #1628.

I created an issue in myst_parser related to this: https://github.com/executablebooks/MyST-Parser/issues/139