### PR TITLE
autohttps: instant secret-sync shutdown

### DIFF
--- a/images/secret-sync/Dockerfile
+++ b/images/secret-sync/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.7-alpine
 
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static /tini
+RUN chmod +x /tini
+
 RUN pip install --no-cache kubernetes
 
 COPY secret-sync.py /usr/local/bin/secret-sync.py
+
+ENTRYPOINT [ "/tini", "--", "/usr/local/bin/secret-sync.py" ]

--- a/images/secret-sync/secret-sync.py
+++ b/images/secret-sync/secret-sync.py
@@ -29,15 +29,16 @@ and update the secret object as needed. However, for now we
 just operate in a 30s loop. This is good enough, since
 traefik can always re-generate certs if needed.
 """
-import sys
+import argparse
+import base64
+import io
+import logging
 import os
 import subprocess
-import argparse
-import time
+import sys
 import tarfile
-import io
-import base64
-import logging
+import time
+
 from kubernetes import client, config
 
 def update_secret(namespace, secret_name, labels, key, value):

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -45,7 +45,11 @@ spec:
         {{- with .Values.proxy.secretSync.image.pullPolicy }}
         imagePullPolicy: {{ . }}
         {{- end }}
-        command: ["/usr/local/bin/secret-sync.py", "load", "proxy-public-tls-acme", "acme.json", "/etc/acme/acme.json"]
+        args:
+          - load
+          - proxy-public-tls-acme
+          - acme.json
+          - /etc/acme/acme.json
         env:
         # We need this to get logs immediately
         - name: PYTHONUNBUFFERED
@@ -82,8 +86,7 @@ spec:
           {{- with .Values.proxy.secretSync.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
-          command:
-            - /usr/local/bin/secret-sync.py
+          args:
             - watch-save
             - --label=app={{ include "jupyterhub.appLabel" . }}
             - --label=release={{ .Release.Name }}


### PR DESCRIPTION
During an upgrade, the autohttps pod can restart in a rolling update fashion, which makes us have two autothttps pods, and two secret-sync pods. The new pod may be getting certificates for a new hostname, but suddenly the old pods secret-sync container may override the content. It may not be a big deal, but it will at least slowdown the shutdown of the autohttps pod that the secret-sync container is slow to shutdown and require the full 30 seconds of grace period for no reason.

This fixes that issue by listening to the SIGTERM signal that comes before the SIGKILL as part of kubectl delete or docker stop.