### PR TITLE
Reference static ip docs

### DIFF
--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -50,6 +50,23 @@ changes to your `config.yaml` file:
 2. Apply the config changes by running `helm upgrade ...`
 3. Wait for about a minute, now your hub should be HTTPS enabled!
 
+***
+**NOTE:**
+
+If the proxy service is of type `LoadBalancer`, then a specific static IP address can be requested (if available) instead of a dynamically acquired one.  
+Although not essential for HTTPS, using a static IP address is a recommended practice for domain names referencing fixed IPs.
+This ensures the same IP address for multiple deployments.
+The IP can be provided like:
+
+```yaml
+  proxy:
+    service:
+      loadBalancerIP: xxx.xxx.xxx.xxx
+```
+
+More info about this can be found on the [Configuration Reference](https://zero-to-jupyterhub.readthedocs.io/en/latest/reference/reference.html) page.
+***
+
 ### Set up manual HTTPS
 
 If you have your own HTTPS certificates & want to use those instead of the automatically provisioned Let's Encrypt ones, that's also possible. Note that this is considered an advanced option, so we recommend not doing it unless you have good reasons.

--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -53,7 +53,7 @@ changes to your `config.yaml` file:
 ***
 **NOTE:**
 
-If the proxy service is of type `LoadBalancer`, then a specific static IP address can be requested (if available) instead of a dynamically acquired one.  
+If the proxy service is of type `LoadBalancer`, which it is by default, then a specific static IP address can be requested (if available) instead of a dynamically acquired one.  
 Although not essential for HTTPS, using a static IP address is a recommended practice for domain names referencing fixed IPs.
 This ensures the same IP address for multiple deployments.
 The IP can be provided like:

--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -64,7 +64,7 @@ The IP can be provided like:
       loadBalancerIP: xxx.xxx.xxx.xxx
 ```
 
-More info about this can be found on the [Configuration Reference](https://zero-to-jupyterhub.readthedocs.io/en/latest/reference/reference.html) page.
+More info about this can be found on the [Configuration Reference](helm-chart-configuration-reference) page.
 ***
 
 ### Set up manual HTTPS

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -395,28 +395,6 @@ properties:
               The default type is `ClusterIP`.
               See the [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
               to learn more about service types.
-          loadBalancerIP:
-            type: string
-            description: |
-              The public IP address the hub service should be exposed on.
-
-              This sets the IP address that should be used by the LoadBalancer for exposing the hub service.
-              Set this if you want the hub service to be provided with a fixed external IP address instead of a dynamically acquired one.
-              Useful to ensure a stable IP to access to the hub with, for example if you have reserved an IP address in your network to communicate with the JupyterHub.
-
-              To be provided like:
-              ```
-              hub:
-                service:
-                  loadBalancerIP: xxx.xxx.xxx.xxx
-              ```
-          loadBalancerSourceRanges:
-            type: list
-            description: |
-              A list of IP CIDR ranges that are allowed to access the load balancer service.
-              Defaults to allowing everyone to access it.
-
-              For more information please check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service).
           ports:
             type: object
             description: |
@@ -533,7 +511,25 @@ properties:
           loadBalancerIP:
             type: string
             description: |
-              See `hub.service.loadBalancerIP`
+              The public IP address the hub service should be exposed on.
+
+              This sets the IP address that should be used by the LoadBalancer for exposing the hub service.
+              Set this if you want the hub service to be provided with a fixed external IP address instead of a dynamically acquired one.
+              Useful to ensure a stable IP to access to the hub with, for example if you have reserved an IP address in your network to communicate with the JupyterHub.
+
+              To be provided like:
+              ```
+              hub:
+                service:
+                  loadBalancerIP: xxx.xxx.xxx.xxx
+              ```
+          loadBalancerSourceRanges:
+            type: list
+            description: |
+              A list of IP CIDR ranges that are allowed to access the load balancer service.
+              Defaults to allowing everyone to access it.
+
+              For more information please check the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service).
       https:
         type: object
         description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -511,18 +511,15 @@ properties:
           loadBalancerIP:
             type: string
             description: |
-              The public IP address the hub service should be exposed on.
-
-              This sets the IP address that should be used by the LoadBalancer for exposing the hub service.
-              Set this if you want the hub service to be provided with a fixed external IP address instead of a dynamically acquired one.
-              Useful to ensure a stable IP to access to the hub with, for example if you have reserved an IP address in your network to communicate with the JupyterHub.
-
-              To be provided like:
-              ```
-              hub:
-                service:
-                  loadBalancerIP: xxx.xxx.xxx.xxx
-              ```
+              The public IP address the proxy-public Kubernetes service should
+              be exposed on. This entry will end up at the configurable proxy
+              server that JupyterHub manages, which will direct traffic to user
+              pods at the `/user` path and the hub pod at the `/hub` path.
+              
+              Set this if you want to use a fixed external IP address instead of
+              a dynamically acquired one. This is relevant if you have a domain
+              name that you want to point to a specific IP and want to ensure it
+              doesn't change.
           loadBalancerSourceRanges:
             type: list
             description: |


### PR DESCRIPTION
This references the documentation about setting up static IPs in the configuration reference section from the automatic https section.

Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1599

P.S.  After reading a bit through comments and other issues related to this, it seems that the `loadBalancerIP` should be set on the proxy service and not on the hub (or is it both?).
If it's just the proxy, we should probably remove the hub part from the docs.