### PR TITLE
Tweaking readiness/liveness probe: faster startup

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -81,12 +81,12 @@ hub:
   templateVars: {}
   livenessProbe:
     enabled: false
-    initialDelaySeconds: 30
+    initialDelaySeconds: 60
     periodSeconds: 10
   readinessProbe:
     enabled: true
     initialDelaySeconds: 0
-    periodSeconds: 10
+    periodSeconds: 2
   # existingSecret: existing-secret
 
 rbac:
@@ -136,12 +136,12 @@ proxy:
       tag: 4.2.1
     livenessProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 60
       periodSeconds: 10
     readinessProbe:
       enabled: true
       initialDelaySeconds: 0
-      periodSeconds: 10
+      periodSeconds: 2
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
With a readinessProbe that polls every ten seconds, we potentially need
to wait ten seconds after the pod is actually ready. By reducing this
number significantly, we avoid eigght potential seconds of waiting for
nothing.

At the same time, this could clutter logs. But, the proxy will not log
these requests, and I made a PR to JupyterHub to only log requests to
the health endpoint on the debug level: https://github.com/jupyterhub/jupyterhub/pull/3047