### PR TITLE
hub deployment: tcp readiness/liveness probes

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -224,17 +224,15 @@ spec:
           # database upgrades midway or ending up in an infinite restart
           # loop.
           livenessProbe:
+            tcpSocket:
+              port: http
             initialDelaySeconds: {{ .Values.hub.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.hub.livenessProbe.periodSeconds }}
-            httpGet:
-              path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
-              port: http
           {{- end }}
           {{- if .Values.hub.readinessProbe.enabled }}
           readinessProbe:
+            tcpSocket:
+              port: http
             initialDelaySeconds: {{ .Values.hub.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.hub.readinessProbe.periodSeconds }}
-            httpGet:
-              path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
-              port: http
           {{- end }}


### PR DESCRIPTION
The http probes clogged the jupyterhub log, which wasn't helpful. Using TCP probes that checks if is possible to establish a TCP connection wouldn't do that.

But, at the same time, https://github.com/jupyterhub/jupyterhub/pull/3047 also resolves the same thing to some degree by hiding logs about /health endpoint requests unless a loglevel is set to debug. This isn't yet available though.

I'm not sure, http vs TCP probes, pro's / con's. I assume tcpSocket may be more lightweight, I'm not sure.

Merge or close? It felt a bit simpler with TCP socket readiness/liveness probes as that didn't require us to choose a path etc as well.