### PR TITLE
Complexity reduction - combine passthrough values.yaml data in hub-config (k8s configmap) to hub-secret (k8s secret)

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -62,6 +62,7 @@ for trait, cfg_key in (
     ('active_server_limit', None),
     # base url prefix
     ('base_url', None),
+    ('cookie_secret', None),
     ('allow_named_servers', None),
     ('named_server_limit_per_user', None),
     ('authenticate_prometheus', None),

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -2,6 +2,8 @@ import os
 import re
 import sys
 
+from binascii import a2b_hex
+
 from tornado.httpclient import AsyncHTTPClient
 from kubernetes import client
 from jupyterhub.utils import url_path_join
@@ -55,14 +57,12 @@ else:
     set_config_if_not_none(c.JupyterHub, "db_url", "hub.db.url")
 
 
+# c.JupyterHub configuration from Helm chart's configmap
 for trait, cfg_key in (
-    # Max number of servers that can be spawning at any one time
     ('concurrent_spawn_limit', None),
-    # Max number of servers to be running at one time
     ('active_server_limit', None),
-    # base url prefix
     ('base_url', None),
-    ('cookie_secret', None),
+    # ('cookie_secret', None),  # requires a Hex -> Byte transformation
     ('allow_named_servers', None),
     ('named_server_limit_per_user', None),
     ('authenticate_prometheus', None),
@@ -74,6 +74,12 @@ for trait, cfg_key in (
     if cfg_key is None:
         cfg_key = camelCaseify(trait)
     set_config_if_not_none(c.JupyterHub, trait, 'hub.' + cfg_key)
+
+# a required Hex -> Byte transformation
+cookie_secret_hex = get_config("hub.cookieSecret")
+if cookie_secret_hex:
+    c.JupyterHub.cookie_secret = a2b_hex(cookie_secret_hex)
+
 
 c.JupyterHub.ip = os.environ['PROXY_PUBLIC_SERVICE_HOST']
 c.JupyterHub.port = int(os.environ['PROXY_PUBLIC_SERVICE_PORT'])

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -5,34 +5,6 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 data:
-{{- $values := pick .Values "auth" "cull" "custom" "debug" "hub" "scheduling" "singleuser" }}
-{{- /* trim secret values. Update here if new secrets are added! */ -}}
-{{- /* make a copy of values.auth to avoid modifying the original */ -}}
-{{- $_ := set $values "auth" (merge dict .Values.auth) }}
-{{- $_ := set $values.auth "state" (omit $values.auth.state "cryptoKey") }}
-{{- range $key, $auth := .Values.auth }}
-  {{- if typeIs "map[string]interface {}" $auth }}
-    {{- if (or $auth.clientSecret $auth.password) }}
-      {{- $_ := set $values.auth $key (omit $auth "clientSecret" "password") }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-{{- $_ := set $values "hub" (omit $values.hub "cookieSecret" "extraEnv" "extraConfigMap") -}}
-{{- $_ := set $values.hub "services" dict }}
-{{- range $key, $service := .Values.hub.services }}
-  {{- $_ := set $values.hub.services $key (omit $service "apiToken") }}
-{{- end }}
-{{- /* copy values.singleuser */ -}}
-{{- $_ := set $values "singleuser" (omit .Values.singleuser "imagePullSecret") }}
-{{- $_ := set $values.singleuser "imagePullSecret" (omit .Values.singleuser.imagePullSecret "password") }}
-{{- /* preserve behavior of deprecated hub.extraConfigMap */ -}}
-{{- $_ := set $values "custom" (merge dict $values.custom .Values.hub.extraConfigMap) }}
-{{- /* passthrough subset of Chart / Release */ -}}
-{{- $_ := set $values "Chart" (dict "Name" .Chart.Name "Version" .Chart.Version) }}
-{{- $_ := set $values "Release" (pick .Release "Name" "Namespace" "Service") }}
-  values.yaml: |
-    {{- $values | toYaml | nindent 4 }}
-
   {{- /* Glob files to allow them to be mounted by the hub pod */ -}}
   {{- /* key=filename: value=content */ -}}
   {{- (.Files.Glob "files/hub/*").AsConfig | nindent 2 }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -147,17 +147,6 @@ spec:
               value: "1"
             - name: HELM_RELEASE_NAME
               value: {{ .Release.Name | quote }}
-            {{- if .Values.hub.cookieSecret }}
-            - name: JPY_COOKIE_SECRET
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.hub.existingSecret }}
-                  name: {{ .Values.hub.existingSecret }}
-                  {{- else }}
-                  name: hub-secret
-                  {{- end }}
-                  key: hub.cookie-secret
-            {{- end }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -7,36 +7,31 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 type: Opaque
 data:
-  proxy.token: {{ (required "Proxy token must be a 32 byte random string generated with `openssl rand -hex 32`!" .Values.proxy.secretToken) | b64enc | quote }}
-  {{- if .Values.hub.cookieSecret }}
-  hub.cookie-secret: {{ .Values.hub.cookieSecret | b64enc | quote }}
+  {{- $values := merge dict .Values }}
+  {{- /* preserve behavior of deprecated hub.extraConfigMap */}}
+  {{- $_ := set $values "custom" (merge dict $values.custom .Values.hub.extraConfigMap) }}
+  {{- /* passthrough subset of Chart / Release */}}
+  {{- $_ := set $values "Chart" (dict "Name" .Chart.Name "Version" .Chart.Version) }}
+  {{- $_ := set $values "Release" (pick .Release "Name" "Namespace" "Service") }}
+  values.yaml: {{ $values | toYaml | b64enc | quote }}
+
+  # Used to mount CONFIGPROXY_AUTH_TOKEN on hub/proxy pods for mutual trust
+  proxy.token: {{ .Values.proxy.secretToken | required "Proxy token must be a 32 byte random string generated with `openssl rand -hex 32`!" | b64enc | quote }}
+
+  {{- with .Values.hub.db.password }}
+  # Used to mount MYSQL_PWD or PGPASSWORD on hub pod
+  hub.db.password: {{ . | b64enc | quote }}
   {{- end }}
-  {{- if .Values.hub.db.password }}
-  hub.db.password: {{ .Values.hub.db.password | b64enc | quote }}
-  {{- end }}
+
   {{- range $key, $service := .Values.hub.services }}
   {{- if $service.apiToken }}
+  # Potentially used to mount on an external service in the k8s cluster
   services.token.{{$key}}: {{ $service.apiToken | b64enc | quote }}
   {{- end }}
   {{- end }}
+
   {{- if .Values.auth.state.enabled }}
-  auth.state.crypto-key: {{ (required "Encryption key is required for auth state to be persisted!" .Values.auth.state.cryptoKey) | b64enc | quote }}
+  # Used to mount JUPYTERHUB_CRYPT_KEY on hub pod, used by authenticators
+  auth.state.crypto-key: {{ .Values.auth.state.cryptoKey | required "Encryption key is required for auth state to be persisted!" | b64enc | quote }}
   {{- end }}
-  {{- $values := dict "hub" dict }}
-  {{- /* pluck only needed secret values, preserving values.yaml structure */ -}}
-  {{- $_ := set $values "auth" dict }}
-  {{- range $key, $auth := .Values.auth }}
-    {{- if typeIs "map[string]interface {}" $auth }}
-      {{- if (or $auth.clientSecret $auth.password) }}
-        {{- $_ := set $values.auth $key (pick $auth "clientSecret" "password") }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-  {{- $_ := set $values.hub "services" dict }}
-  {{- range $key, $service := .Values.hub.services }}
-    {{- if $service.apiToken }}
-      {{- $_ := set $values.hub.services $key (pick $service "apiToken") }}
-    {{- end }}
-  {{- end }}
-  values.yaml: {{ $values | toYaml | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
JupyterHub itself, authenticators, etc, all may want to use the values
we also use to render the Helm charts templates. So, we typically take
them av available in {{ .Values }}, split it apart, and render it to a
k8s configmap as well as a k8s secret.

This separation had little to no benefit and was hard to maintain. In
this commit I gather the {{ .Values }} into the hub-secret file. I also
configure c.JupyterHub.cookie_secret instead of passing that
information by mounting a k8s secrets key's value into a
JPY_COOKIE_SECRET environment variable on the hub pod.