### PR TITLE
Use --num-nodes instead of --size to resize gcloud cluster

### DIFF
--- a/doc/source/customizing/user-resources.rst
+++ b/doc/source/customizing/user-resources.rst
@@ -166,13 +166,13 @@ Google Cloud Platform
 ~~~~~~~~~~~~~~~~~~~~~
 Use the ``resize`` command and
 provide a new cluster size (i.e. number of nodes) as a command line option
-``--size``:
+``--num-nodes``:
 
 .. code-block:: bash
 
    gcloud container clusters resize \
        <YOUR-CLUSTER-NAME> \
-       --size <NEW-SIZE> \
+       --num-nodes <NEW-SIZE> \
        --zone <YOUR-CLUSTER-ZONE>
 
 To display the cluster's name, zone, or current size, use the command:


### PR DESCRIPTION
As of `gcloud` release [260.0.0 (2019-08-27)](https://cloud.google.com/sdk/docs/release-notes#cloud_sdk_12), this warning appears:

> WARNING: The --size flag is now deprecated. Please use `--num-nodes` instead.
