### PR TITLE
[MRG] Add services API tokens in hub-secret

### DIFF
--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -14,6 +14,11 @@ data:
   {{- if .Values.hub.db.password }}
   hub.db.password: {{ .Values.hub.db.password | b64enc | quote }}
   {{- end }}
+  {{- range $key, $service := .Values.hub.services }}
+  {{- if $service.apiToken }}
+  services.token.{{$key}}: {{ $service.apiToken | b64enc | quote }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.auth.state.enabled }}
   auth.state.crypto-key: {{ (required "Encryption key is required for auth state to be persisted!" .Values.auth.state.cryptoKey) | b64enc | quote }}
   {{- end }}


### PR DESCRIPTION
Having an explicit key for the API token of each service is nice because
it allows the service to mount the particular key as an environment
variable.

We used to have this functionality but in #941 we moved the API tokens to the `values.yaml`. This is a bit tricky to use because now your service has to mount that yaml, parse it and get the token out of the yaml (and it gets access to tokens from all services).