### PR TITLE
Add support for setting hub-wide notebook config

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -246,6 +246,18 @@ elif storage_type == 'static':
 c.KubeSpawner.volumes.extend(get_config('singleuser.storage.extraVolumes', []))
 c.KubeSpawner.volume_mounts.extend(get_config('singleuser.storage.extraVolumeMounts', []))
 
+if get_config('singleuser.etcJupyter'):
+    c.KubeSpawner.volumes.extend({
+        'name': 'user-etc-jupyter',
+        'configMap': {
+            'name': 'user-etc-jupyter'
+        }
+    })
+
+    c.KubeSpawner.volume_mounts.extend({
+        'name': 'user-etc-jupyter',
+        'mountPath': '/etc/jupyter'
+    })
 # Gives spawned containers access to the API of the hub
 c.JupyterHub.hub_connect_ip = os.environ['HUB_SERVICE_HOST']
 c.JupyterHub.hub_connect_port = int(os.environ['HUB_SERVICE_PORT'])

--- a/jupyterhub/templates/jupyter-notebook-config.yaml
+++ b/jupyterhub/templates/jupyter-notebook-config.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.singleuser.etcJupyter }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: user-etc-jupyter
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4}}
+data:
+  {{- range $name, $content := .Values.singleuser.etcJupyter }}
+  {{- if eq (typeOf $content) "string" }}
+  {{ $name }}: |
+    {{- $content | nindent 4 }}
+  {{- else }}
+  {{ $name }}: {{ $content | toJson | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -218,6 +218,7 @@ auth:
 
 
 singleuser:
+  etcJupyter: {}
   extraTolerations: []
   nodeSelector: {}
   extraNodeAffinity:


### PR DESCRIPTION
Sometimes you want to set some notebook server configurations
for all your users. On mybinder.org, we do this for
tornado settings & idle culler settings
(https://github.com/jupyterhub/mybinder.org-deploy/blob/master/mybinder/values.yaml#L5)

This is generally useful, so I've ported that from mybinder.org
here. Once this gets merged, we can migrate the mybinder.org
config to use this.