### PR TITLE
Update Google auth to use a list for hosted_domain

### DIFF
--- a/doc/source/administrator/authentication.rst
+++ b/doc/source/administrator/authentication.rst
@@ -124,7 +124,8 @@ For more information on authenticating with Google oauth, see the :ref:`google_o
        clientId: "yourlongclientidstring.apps.googleusercontent.com"
        clientSecret: "adifferentlongstring"
        callbackUrl: "http://<your_jupyterhub_host>/hub/oauth_callback"
-       hostedDomain: "youruniversity.edu"
+       hostedDomain:
+         - "youruniversity.edu"
        loginService: "Your University"
 
 CILogon


### PR DESCRIPTION
I was getting this error with v0.9.0 and the change in the commit attached fixed it:

```
traitlets.traitlets.TraitError: The 'hosted_domain' trait of a GoogleOAuthenticator instance must be a list, but a value of class 'str'
```