### PR TITLE
Enable the user scheduler to pay attention to CSI volume count

### DIFF
--- a/jupyterhub/files/userscheduler-defaultpolicy.yaml
+++ b/jupyterhub/files/userscheduler-defaultpolicy.yaml
@@ -11,6 +11,7 @@
     { "name": "MaxEBSVolumeCount" },
     { "name": "MaxGCEPDVolumeCount" },
     { "name": "MaxAzureDiskVolumeCount" },
+    { "name": "MaxCSIVolumeCountPred" },
     { "name": "CheckVolumeBinding" },
     { "name": "NoVolumeZoneConflict" },
     { "name": "MatchInterPodAffinity" }

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -318,7 +318,7 @@ scheduling:
     policy: {}
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
-      tag: v1.18.4
+      tag: v1.16.11
     nodeSelector: {}
     pdb:
       enabled: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -318,7 +318,7 @@ scheduling:
     policy: {}
     image:
       name: gcr.io/google_containers/kube-scheduler-amd64
-      tag: v1.13.12
+      tag: v1.18.4
     nodeSelector: {}
     pdb:
       enabled: true


### PR DESCRIPTION
I've been getting the 0.9.0 chart running on an autoscaling cluster on Digital Ocean.  Most things are working, but it would try to schedule more than seven pods with volumes on a given node.  (Digital Ocean has a relatively low limit of 7 on this.)  This only happened when using the userScheduler; if that was disabled, the limits were respected.

Digital Ocean support pointed out that the scheduler did not have the "MaxCSIVolumeCountPred" predicate, which they use to count the attached volumes.  This appears to be a more general predicate, which will replace the provider specific ones we currently have. (See [here](https://github.com/mjaow/kubernetes/blob/master/pkg/scheduler/algorithm/predicates/predicates.go#L61).)

I could only get this to work with an updated version of the kube-scheduler image.  I don't know what was going wrong with the current version, and I also don't know if it needs to be updated this far.  If we're worried about upgrading this far, I can check some of the previous versions and report back.