### PR TITLE
Add annotations to image puller pods

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1163,6 +1163,11 @@ properties:
   prePuller:
     type: object
     properties:
+      annotations:
+        type: object
+        description: |
+          Annotations to apply to the hook and continous image puller pods. One example use case is to
+          disable istio sidecars which could interfere with the image pulling.
       hook:
         description: |
           See the [*optimization

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -35,8 +35,10 @@ spec:
       labels:
         {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+      {{- if ".Values.prePuller.annotations" }}
       annotations:
         {{- toYaml ".Values.prePuller.annotations" | nindent 8 }}
+      {{- end }}
     spec:
       tolerations:
         {{- include "jupyterhub.userTolerations" . | nindent 8 }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -36,7 +36,7 @@ spec:
         {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
       annotations:
-        {{- include ".Values.prePuller.annotations" . | nindent 8 }}
+        {{- toYaml ".Values.prePuller.annotations" | nindent 8 }}
     spec:
       tolerations:
         {{- include "jupyterhub.userTolerations" . | nindent 8 }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -35,9 +35,9 @@ spec:
       labels:
         {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
-      {{- if ".Values.prePuller.annotations" }}
+      {{- with ".Values.prePuller.annotations" }}
       annotations:
-        {{- toYaml ".Values.prePuller.annotations" | nindent 8 }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}
     spec:
       tolerations:

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -35,7 +35,7 @@ spec:
       labels:
         {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
-      {{- with ".Values.prePuller.annotations" }}
+      {{- with .Values.prePuller.annotations }}
       annotations:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -35,6 +35,8 @@ spec:
       labels:
         {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+      annotations:
+        {{- include ".Values.prePuller.annotations" . | nindent 8 }}
     spec:
       tolerations:
         {{- include "jupyterhub.userTolerations" . | nindent 8 }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -24,7 +24,7 @@ spec:
         {{- /* Changes here will cause the Job to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
       annotations:
-        {{- include ".Values.prePuller.annotations" . | nindent 8 }}
+        {{- toYaml ".Values.prePuller.annotations" | nindent 8 }}
     spec:
       restartPolicy: Never
       {{- if .Values.rbac.enabled }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -23,9 +23,9 @@ spec:
       labels:
         {{- /* Changes here will cause the Job to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
-      {{- if ".Values.prePuller.annotations" }}
+      {{- with ".Values.prePuller.annotations" }}
       annotations:
-        {{- toYaml ".Values.prePuller.annotations" | nindent 8 }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}
     spec:
       restartPolicy: Never

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -23,7 +23,7 @@ spec:
       labels:
         {{- /* Changes here will cause the Job to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
-      {{- with ".Values.prePuller.annotations" }}
+      {{- with .Values.prePuller.annotations }}
       annotations:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -23,6 +23,8 @@ spec:
       labels:
         {{- /* Changes here will cause the Job to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+      annotations:
+        {{- include ".Values.prePuller.annotations" . | nindent 8 }}
     spec:
       restartPolicy: Never
       {{- if .Values.rbac.enabled }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -23,8 +23,10 @@ spec:
       labels:
         {{- /* Changes here will cause the Job to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+      {{- if ".Values.prePuller.annotations" }}
       annotations:
         {{- toYaml ".Values.prePuller.annotations" | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: Never
       {{- if .Values.rbac.enabled }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -344,6 +344,7 @@ scheduling:
 
 
 prePuller:
+  annotations: {}
   hook:
     enabled: true
     image:


### PR DESCRIPTION
This PR adds the ability to add annotations to the continuous and hook image puller pods.

Fixes #1627