### PR TITLE
Add config for hub/proxy/autohttps container's securityContext

### DIFF
--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -37,7 +37,7 @@ enable pod priority or stop using the user placeholders to avoid wasting cloud
 resources.
 {{- end }}
 
-{{- if .Values.hub.uid }}
+{{- if hasKey .Values.hub "uid" }}
 
 DEPRECATION: hub.uid is deprecated in jupyterhub chart 0.9. Set the hub.containerSecurityContext.runAsUser value
 directly instead.

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -36,3 +36,10 @@ WARNING: You are using user placeholders without pod priority enabled, either
 enable pod priority or stop using the user placeholders to avoid wasting cloud
 resources.
 {{- end }}
+
+{{- if .Values.hub.uid }}
+
+DEPRECATION: hub.uid is deprecated in jupyterhub chart 0.9. Set the hub.containerSecurityContext.runAsUser value
+directly instead.
+
+{{- end }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -132,8 +132,16 @@ spec:
           {{- with .Values.hub.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
+          {{- /* Below is deprecation logic of .Values.hub.uid */}}
+          {{- if .Values.hub.containerSecurityContext }}
+          {{- $securityContext := dict }}
+          {{- if hasKey .Values.hub "uid" }}
+          {{- $_ := merge $securityContext (dict "runAsUser" .Values.hub.uid) }}
+          {{- end }}
+          {{- $_ := merge $securityContext .Values.hub.containerSecurityContext }}
           securityContext:
-            {{- .Values.hub.containerSecurityContext | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- $securityContext | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           env:
             - name: PYTHONUNBUFFERED
               value: "1"

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -133,9 +133,7 @@ spec:
           imagePullPolicy: {{ . }}
           {{- end }}
           securityContext:
-            runAsUser: {{ .Values.hub.uid }}
-            # Don't allow any process to execute as root inside the container
-            allowPrivilegeEscalation: false
+            {{- .Values.hub.containerSecurityContext | toYaml | trimSuffix "\n" | nindent 12 }}
           env:
             - name: PYTHONUNBUFFERED
               value: "1"

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -84,6 +84,10 @@ spec:
           env:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
+          {{- with .Values.proxy.traefik.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           readinessProbe:
             tcpSocket:
               port: http

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -84,9 +84,10 @@ spec:
           {{- end }}
           resources:
             {{- .Values.proxy.chp.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- with .Values.proxy.containerSecurityContext }}
           securityContext:
-            # Don't allow any process to execute as root inside the container
-            allowPrivilegeEscalation: false
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           env:
             - name: CONFIGPROXY_AUTH_TOKEN
               valueFrom:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -11,7 +11,7 @@ hub:
   cookieSecret:
   publicURL:
   initContainers: []
-  uid: 1000
+  uid: &hubUid 1000
   fsGid: 1000
   nodeSelector: {}
   concurrentSpawnLimit: 64
@@ -55,6 +55,10 @@ hub:
     requests:
       cpu: 200m
       memory: 512Mi
+  containerSecurityContext:
+    runAsUser: *hubUid
+    # Don't allow any process to execute as root inside the container
+    allowPrivilegeEscalation: false
   services: {}
   imagePullSecret:
     enabled: false

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -11,7 +11,6 @@ hub:
   cookieSecret:
   publicURL:
   initContainers: []
-  uid: &hubUid 1000
   fsGid: 1000
   nodeSelector: {}
   concurrentSpawnLimit: 64
@@ -56,7 +55,7 @@ hub:
       cpu: 200m
       memory: 512Mi
   containerSecurityContext:
-    runAsUser: *hubUid
+    runAsUser: 1000
     # Don't allow any process to execute as root inside the container
     allowPrivilegeEscalation: false
   services: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -56,7 +56,6 @@ hub:
       memory: 512Mi
   containerSecurityContext:
     runAsUser: 1000
-    # Don't allow any process to execute as root inside the container
     allowPrivilegeEscalation: false
   services: {}
   imagePullSecret:
@@ -130,6 +129,8 @@ proxy:
     ##     Error: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     ##     Error: UPGRADE FAILED: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     rollingUpdate:
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
   service:
     type: LoadBalancer
     labels: {}
@@ -169,6 +170,8 @@ proxy:
     extraVolumeMounts: []
     extraStaticConfig: {}
     extraDynamicConfig: {}
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
   secretSync:
     image:
       name: jupyterhub/k8s-secret-sync


### PR DESCRIPTION
This makes it possible to override the `securityContext`
for the hub container spec, similar to how the hub container
`resources` are overridable via `values.yaml`. By default the
`securityContext` is the same as before.

One use case for this is to be able to specify `capabilities`
in order to run py-spy [1] on the hub container.

One downside to this approach is that for anyone overriding the
hub container `securityContext` may need to duplicate the
`runAsUser` and `allowPrivilegeEscalation` entries which means
they could fall out of alignment with the upstream chart. So an
alternative to this full replacement approach is to add an
optional `extraContainerSecurityContext` entry similar to how
`extraVolumeMounts` works. The downside to that is it could
eventually conflict with what is not extra in the parent chart.
Another alternative is just adding a very specific and optional
`containerCapabilities` value which if set *only* sets the
`securityContext.capabilities` value in the container spec.

For simplicity and flexibility this opts for the full replacement
approach assuming the hub container `securityContext` will not change
frequently.

[1] https://github.com/benfred/py-spy#how-do-i-run-py-spy-in-kubernetes

Closes #1677