### PR TITLE
Autohttps reliability fix: bump traefik version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ __Install Pebble__
 ```shell
 helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
 helm repo update
-helm install pebble jupyterhub/pebble --values dev-config-pebble.yaml
+helm upgrade --install pebble jupyterhub/pebble --cleanup-on-fail --values dev-config-pebble.yaml
 ```
 
 ## 4: Build images, update values, install chart

--- a/ci/common
+++ b/ci/common
@@ -138,13 +138,20 @@ await_autohttps_tls_cert_acquisition() {
     if [ "$acquired_cert" != "true" ]; then
         echo "Certificate acquisition failed!"
         kubectl get service,networkpolicy,configmap,pod
-        kubectl describe pod -l app.kubernetes.io/name=pebble
-        kubectl logs deploy/pebble --all-containers # --prefix
         kubectl describe pod -l app.kubernetes.io/name=pebble-coredns
         kubectl logs deploy/pebble-coredns --all-containers # --prefix
+        kubectl describe pod -l app.kubernetes.io/name=pebble
+        kubectl logs deploy/pebble --all-containers # --prefix
         kubectl describe pod -l component=autohttps
         kubectl logs deploy/autohttps --all-containers # --prefix
         exit 1
+    else
+        # REMOVE ME SOON: show logs even during success for comparison
+        kubectl get service,networkpolicy,configmap,pod
+        kubectl describe pod -l app.kubernetes.io/name=pebble
+        kubectl logs deploy/pebble --all-containers # --prefix
+        kubectl describe pod -l component=autohttps
+        kubectl logs deploy/autohttps --all-containers # --prefix
     fi
     # a precausion as pebble logs is a bad indicator of the readiness state of
     # Traefik's readiness to use the cert for TLS termination.

--- a/ci/common
+++ b/ci/common
@@ -138,20 +138,13 @@ await_autohttps_tls_cert_acquisition() {
     if [ "$acquired_cert" != "true" ]; then
         echo "Certificate acquisition failed!"
         kubectl get service,networkpolicy,configmap,pod
-        kubectl describe pod -l app.kubernetes.io/name=pebble-coredns
-        kubectl logs deploy/pebble-coredns --all-containers # --prefix
         kubectl describe pod -l app.kubernetes.io/name=pebble
         kubectl logs deploy/pebble --all-containers # --prefix
+        kubectl describe pod -l app.kubernetes.io/name=pebble-coredns
+        kubectl logs deploy/pebble-coredns --all-containers # --prefix
         kubectl describe pod -l component=autohttps
         kubectl logs deploy/autohttps --all-containers # --prefix
         exit 1
-    else
-        # REMOVE ME SOON: show logs even during success for comparison
-        kubectl get service,networkpolicy,configmap,pod
-        kubectl describe pod -l app.kubernetes.io/name=pebble
-        kubectl logs deploy/pebble --all-containers # --prefix
-        kubectl describe pod -l component=autohttps
-        kubectl logs deploy/autohttps --all-containers # --prefix
     fi
     # a precausion as pebble logs is a bad indicator of the readiness state of
     # Traefik's readiness to use the cert for TLS termination.

--- a/dev-config-pebble.yaml
+++ b/dev-config-pebble.yaml
@@ -1,7 +1,25 @@
 # This configuration is meant to map lookups of local.jovyan.org to the
 # ClusterIP of JupyterHub's proxy-public service
+#
+# ref: https://github.com/jupyterhub/pebble-helm-chart/blob/master/pebble/values.yaml
+#
 coredns:
   corefileSegment: |-
     template ANY ANY local.jovyan.org {
       answer "{{ .Name }} 60 IN CNAME proxy-public.{$PEBBLE_NAMESPACE}.svc.cluster.local"
     }
+
+pebble:
+  env:
+    ## ref: https://github.com/letsencrypt/pebble#testing-at-full-speed
+    - name: PEBBLE_VA_NOSLEEP
+      value: "1"
+    ## ref: https://github.com/letsencrypt/pebble#invalid-anti-replay-nonce-errors
+    - name: PEBBLE_WFE_NONCEREJECT
+      value: "0"
+    ## ref: https://github.com/letsencrypt/pebble#authorization-reuse
+    - name: PEBBLE_AUTHZREUSE
+      value: "0"
+    # ## ref: https://github.com/letsencrypt/pebble#skipping-validation
+    # - name: PEBBLE_VA_ALWAYS_VALID
+    #   value: "0"

--- a/dev-config-pebble.yaml
+++ b/dev-config-pebble.yaml
@@ -12,8 +12,19 @@ coredns:
 pebble:
   env:
     ## ref: https://github.com/letsencrypt/pebble#testing-at-full-speed
+    ##
+    ## WARNING: PEBBLE_VA_NOSLEEP=1 or a low value of PEBBLE_VA_SLEEPTIME make
+    ##          Traefik unstable. As the SLEEPTIME setting is a upper limit of a
+    ##          random variable, no value is really safe.
+    ##
+    ##          - PEBBLE_VA_SLEEPTIME=1 made it fail 7/50 times
+    ##          - PEBBLE_VA_SLEEPTIME=3 made it fail 1/50 times
+    ##          - PEBBLE_VA_SLEEPTIME=5 made it fail 0/100 times
+    ##          - PEBBLE_VA_SLEEPTIME=10 made it fail 0/100 times
     - name: PEBBLE_VA_NOSLEEP
-      value: "1"
+      value: "0"
+    - name: PEBBLE_VA_SLEEPTIME
+      value: "10"
     ## ref: https://github.com/letsencrypt/pebble#invalid-anti-replay-nonce-errors
     - name: PEBBLE_WFE_NONCEREJECT
       value: "0"

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -159,7 +159,10 @@ proxy:
   traefik:
     image:
       name: traefik
-      tag: v2.2.2 # ref: https://hub.docker.com/_/traefik?tab=tags
+      # NOTE: we are pinning to patch version only to ensure we don't use a
+      #       cached old version of v2.2. When we bump this to v2.3 we should
+      #       stop using the patch version.
+      tag: v2.2.4 # ref: https://hub.docker.com/_/traefik?tab=tags
     hsts:
       includeSubdomains: false
       preload: false


### PR DESCRIPTION
I [recently pinned](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/commit/66b917d98ba877d9fad70351dba07b9e08af65a2) v2.2.2 of traefik (running in our autohttps pod) from v2.2 as v2.2.2 contain [a fix](https://github.com/containous/traefik/pull/6939) to [an issue](https://github.com/containous/traefik/issues/6871) that will make our autohttps system stop malfunction randomly in our CI system and with users trying to acquire certificates.

Now I noted that [Traefik released v2.2.3 / 2.2.4](https://github.com/containous/traefik/releases/tag/v2.2.4) to fix a regression, so this PR bumps it once again. The docker image [will soon be out](https://hub.docker.com/_/traefik?tab=tags) but isn't yet. When its out, we restart this test and merge on success.