### PR TITLE
k8s api compatibility: add conditional to ingress apiVersion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,18 @@ jobs:
         - setup_kubeval
         - pip install yamllint
       script:
-        - tools/templates/lint-and-validate.py --kubernetes-versions 1.11.0,1.14.0,1.18.0
+        # NOTE: Kubernetes resource validation can only be done against
+        #       Kubernetes versions with schemas available in:
+        #       https://github.com/instrumenta/kubernetes-json-schema
+        #
+        # NOTE: The "helm template" command will evaluate
+        #       .Capabilities.APIVersion.Has in templates based on a Kubernetes
+        #       version associated with the helm binary's version. Since we
+        #       render the templates with a specific helm version, we end up
+        #       rendering templates using a mocked k8s version unrelated to the
+        #       Kubernetes version we want to validate against. This issue has
+        #       made us not validate against versions lower than 1.14.
+        - tools/templates/lint-and-validate.py --kubernetes-versions 1.14.0,1.18.0
 
     - stage: test
       name: docs:link-check

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -1,11 +1,9 @@
 {{- if .Values.ingress.enabled -}}
-## FUTURE: When k8s 1.20 is released or when we can assume k8s 1.14, switch from
-##         apiVersion: extensions/v1beta1 to using apiVersion:
-##         networking.k8s.io/v1beta1.
-##
-## ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
-##
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: jupyterhub

--- a/tools/templates/lint-and-validate.py
+++ b/tools/templates/lint-and-validate.py
@@ -60,30 +60,25 @@ def lint(yamllint_config, values, kubernetes_versions, output_dir, debug):
         helm_lint_cmd.append('--debug')
     check_call(helm_lint_cmd)
 
+    print("### 2/4 - helm template: generate kubernetes resources")
+    helm_template_cmd = [
+        'helm', 'template', '../../jupyterhub',
+        '--values', values,
+        '--output-dir', output_dir
+    ]
+    if debug:
+        helm_template_cmd.append('--debug')
+    check_call(helm_template_cmd)
+
+    print("### 3/4 - yamllint: yaml lint generated kubernetes resources")
+    check_call([
+        'yamllint', '-c', yamllint_config, output_dir
+    ])
+
+    print("### 4/4 - kubeval: validate generated kubernetes resources")
     for kubernetes_version in kubernetes_versions.split(","):
         print("#### kubernetes_version ", kubernetes_version)
-        version_output_dir = output_dir + '/' + kubernetes_version
-        check_call([
-            'mkdir', '-p', version_output_dir,
-        ])
-        print("### 2/4 - helm template: generate kubernetes resources")
-        helm_template_cmd = [
-            'helm', 'template', '../../jupyterhub',
-            '--values', values,
-            '--kube-version', kubernetes_version,
-            '--output-dir', version_output_dir
-        ]
-        if debug:
-            helm_template_cmd.append('--debug')
-        check_call(helm_template_cmd)
-
-        print("### 3/4 - yamllint: yaml lint generated kubernetes resources")
-        check_call([
-            'yamllint', '-c', yamllint_config, version_output_dir
-        ])
-
-        print("### 4/4 - kubeval: validate generated kubernetes resources")
-        for filename in glob.iglob(version_output_dir + '/**/*.yaml', recursive=True):
+        for filename in glob.iglob(output_dir + '/**/*.yaml', recursive=True):
             check_call([
                 'kubeval', filename,
                 '--kubernetes-version', kubernetes_version,


### PR DESCRIPTION
Rather than have a TODO about the deprecation of the ingress, use a dynamic definition of the ingress `apiVersion`. It makes the chart a little messier, but makes it dynamic.