### PR TITLE
docs: fix linkcheck warning

### DIFF
--- a/doc/source/customizing/user-environment.rst
+++ b/doc/source/customizing/user-environment.rst
@@ -102,11 +102,9 @@ JupyterLab with the following config in your :term:`config.yaml`:
 
 .. note::
 
-   You need the `jupyterlab <https://github.com/jupyterlab/jupyterlab>`_
-   package (installable via ``pip`` or ``conda``) for this to work.
-   All images in the `jupyter/docker-stacks repository
-   <https://github.com/jupyter/docker-stacks/>`_ come pre-installed with
-   it.
+   You need the ``jupyterlab`` package (installable via ``pip`` or ``conda``)
+   for this to work. All images in the `jupyter/docker-stacks repository
+   <https://github.com/jupyter/docker-stacks/>`_ come pre-installed with it.
 
 
 .. _custom-docker-image:


### PR DESCRIPTION
The linkcheck gave a warning about two separate links both referencing
`jupyterlab`, which in turn made the linkcheck job on travis fail as it
is configured to fail on any warning.

I removed the second link, it wasn't important anyhow.
