### PR TITLE
fix: jupyterhub services without apiToken was ignored

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -20,9 +20,7 @@ data:
 {{- $_ := set $values "hub" (omit $values.hub "cookieSecret" "extraEnv" "extraConfigMap") -}}
 {{- $_ := set $values.hub "services" dict }}
 {{- range $key, $service := .Values.hub.services }}
-  {{- if $service.apiToken }}
-    {{- $_ := set $values.hub.services $key (omit $service "apiToken") }}
-  {{- end }}
+  {{- $_ := set $values.hub.services $key (omit $service "apiToken") }}
 {{- end }}
 {{- /* copy values.singleuser */ -}}
 {{- $_ := set $values "singleuser" (omit .Values.singleuser "imagePullSecret") }}


### PR DESCRIPTION
JupyterHub services that didn't have a apiToken set in the Helm chart configuration hub.services.my-service-name.apiToken didn't render into the configmap.
