### PR TITLE
update kubespawner to 0.12

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -29,7 +29,7 @@ jupyterhub-dummyauthenticator==0.3.1  # via -r requirements.in
 jupyterhub-firstuseauthenticator==0.14.1  # via -r requirements.in
 jupyterhub-hmacauthenticator==0.1  # via -r requirements.in
 jupyterhub-idle-culler==1.0  # via -r requirements.in
-jupyterhub-kubespawner==0.11.1  # via -r requirements.in
+jupyterhub-kubespawner==0.12.0  # via -r requirements.in
 jupyterhub-ldapauthenticator==1.3.0  # via -r requirements.in
 jupyterhub-ltiauthenticator==0.4.0  # via -r requirements.in
 jupyterhub-nativeauthenticator==0.0.5  # via -r requirements.in
@@ -59,6 +59,7 @@ pyrsistent==0.16.0        # via jsonschema
 python-dateutil==2.8.1    # via alembic, jupyterhub, jupyterhub-idle-culler, kubernetes
 python-editor==1.0.4      # via alembic
 python-json-logger==0.1.11  # via jupyter-telemetry
+python-slugify==4.0.1     # via jupyterhub-kubespawner
 pyyaml==5.3.1             # via jupyterhub-kubespawner, kubernetes
 requests-oauthlib==1.3.0  # via kubernetes, mwoauth
 requests==2.24.0          # via globus-sdk, jupyterhub, kubernetes, mwoauth, requests-oauthlib
@@ -68,6 +69,7 @@ ruamel.yaml==0.16.10      # via jupyter-telemetry
 six==1.15.0               # via bcrypt, cryptography, globus-sdk, google-auth, jsonschema, kubernetes, mwoauth, onetimepass, pyopenssl, pyrsistent, python-dateutil, traitlets, websocket-client
 sqlalchemy==1.3.18        # via alembic, jupyterhub
 statsd==3.3.0             # via -r requirements.in
+text-unidecode==1.3       # via python-slugify
 tornado==6.0.4            # via jupyterhub, jupyterhub-idle-culler, jupyterhub-ldapauthenticator
 traitlets==4.3.3          # via jupyter-telemetry, jupyterhub, jupyterhub-ldapauthenticator
 urllib3==1.25.9           # via kubernetes, requests


### PR DESCRIPTION
Main changes:

- changes default named-server template to avoid possible collisions
- use slugs to select profiles