### PR TITLE
docs: myst-parser deprecation adjustment

### DIFF
--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,14 +1,14 @@
 # Order matters:
-# - myst-parser[sphinx] depends on "sphinx>=2,<3"
+# - myst-parser depends on "sphinx>=2,<3"
 # - pydata-sphinx-theme depends on "sphinx"
 # - sphinx-copybutton depends on "sphinx>=1.8"
 #
 # Listing either pydata-sphinx-theme or sphinx-copybutton first will make the
-# myst-parser[sphinx] constraints on sphinx be ignored, so myst-parser should go
+# myst-parser constraints on sphinx be ignored, so myst-parser should go
 # first. This is only relevant if sphinx==1.* is already installed in the
 # environment, which it is on ReadTheDocs.
 #
-myst-parser[sphinx]
+myst-parser
 pydata-sphinx-theme
 pyyaml
 sphinx-autobuild


### PR DESCRIPTION
The extra requirement specified like myst-parser[sphinx] is no longer needed, as it's now included by default in myst-parser and that's the deprecation fixed.