### PR TITLE
jupyterhub existing image pull secret configuration load bug fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ pyvenv.cfg
 
 # Emacs
 .#*
+
+.idea

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -111,6 +111,7 @@ set_config_if_not_none(
 for trait, cfg_key in (
     ('start_timeout', None),
     ('image_pull_policy', 'image.pullPolicy'),
+    ('image_pull_secrets', 'image.pullSecrets'),
     ('events_enabled', 'events'),
     ('extra_labels', None),
     ('extra_annotations', None),

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -48,8 +48,7 @@ hub:
   image:
     name: jupyterhub/k8s-hub
     tag: 'set-by-chartpress'
-    # pullSecrets:
-    #   - secretName
+    pullSecrets: secretName
   resources:
     requests:
       cpu: 200m

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -48,7 +48,7 @@ hub:
   image:
     name: jupyterhub/k8s-hub
     tag: 'set-by-chartpress'
-    pullSecrets: secretName
+    pullSecrets:
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
When we want to deploy Jupyterhub on Kubernetes, we have had an issue about that singleuser pod spawner which it is also named Kubespawner doesn't use our existing image pull secrets although we had defined on values.yaml. I have found that jupyterhub_config.py configuration doesn't include that config load so anyone can't use existing image pull secrets on their system. Also Kubespawner takes image pull secret name as string not array so that I have changed format of the image pull secret configuration on values.yaml :)