### PR TITLE
Fix broken link to Jupyter contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome dear open source colleague! As this is a [Jupyter](https://jupyter.org)
 project please start by looking at the [Jupyter contributor
-guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html),
+guide](https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html),
 and follow [Project Jupyter's Code of
 Conduct](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md)
 to help us sustain a warm and welcoming collaborative environment.


### PR DESCRIPTION
This PR fixes the broken link to the Jupyter contributor guide in `CONTRIBUTING.md`