### PR TITLE
WIP: Add internal ssl support

### DIFF
--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -159,6 +159,22 @@ security report generator. Use the following URL structure to test your domain:
 http://ssllabs.com/ssltest/analyze.html?d=<YOUR-DOMAIN>
 ```
 
+### Internal JupyterHub TLS
+
+By default the internal communication of the Proxy, JupyterHub, and user notebooks are not encrypted by TLS.
+
+- Set `hub.https.enabled` to true
+- Set `hub.https.extraAltNames` to your public facing JupyterHub hostname.
+
+```yaml
+hub:
+  https:
+    enabled: true
+    extraAltNames:
+      - "DNS:jupyterhub.example.com"
+```
+
+
 ## Secure access to Helm
 
 In its default configuration, helm pretty much allows root access to all other

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get update && \
       sqlite3 \
       curl \
       dnsutils \
+      jq \
+      apt-transport-https \
+      gnupg2 \
       # libc-bin explicitly added and pinned 2020-06-10 for a CVE found with trivy
       # ref: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1712#issuecomment-656425028
       libc-bin=2.27-3ubuntu1.2 \
@@ -28,7 +31,11 @@ RUN apt-get update && \
         echo nodejs=8.10.0~dfsg-2ubuntu0.2 nodejs-dev=8.10.0~dfsg-2ubuntu0.2 npm; \
       fi') \
       && \
-    apt-get purge && apt-get clean
+      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - &&\
+      echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends kubectl && \
+      apt-get purge && apt-get clean
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -60,6 +60,9 @@ RUN PYCURL_SSL_LIBRARY=openssl pip3 install --no-cache-dir \
             echo jupyterhub==${JUPYTERHUB_VERSION}; \
           fi')
 
+# Use custom version of kubespawner with internal_ssl support
+RUN pip uninstall -y jupyterhub-kubespawner && pip install git+https://github.com/chancez/kubespawner.git@internal-ssl#egg=jupyterhub-kubespawner
+
 WORKDIR /srv/jupyterhub
 
 # So we can actually write a db file here

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -63,6 +63,9 @@ RUN PYCURL_SSL_LIBRARY=openssl pip3 install --no-cache-dir \
 # Use custom version of kubespawner with internal_ssl support
 RUN pip uninstall -y jupyterhub-kubespawner && pip install git+https://github.com/chancez/kubespawner.git@internal-ssl#egg=jupyterhub-kubespawner
 
+# use version of jupyterhub-idle-culler with internal_ssl support
+RUN pip uninstall -y jupyterhub-idle-culler && pip install git+https://github.com/chancez/jupyterhub-idle-culler.git@support_internal_ssl#egg=jupyterhub-idle-culler
+
 # Install fork of jupyterhub with fix for internal SSL + OAuth2 auth server TLS verification
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -63,6 +63,14 @@ RUN PYCURL_SSL_LIBRARY=openssl pip3 install --no-cache-dir \
 # Use custom version of kubespawner with internal_ssl support
 RUN pip uninstall -y jupyterhub-kubespawner && pip install git+https://github.com/chancez/kubespawner.git@internal-ssl#egg=jupyterhub-kubespawner
 
+# Install fork of jupyterhub with fix for internal SSL + OAuth2 auth server TLS verification
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        nodejs=8.10.0~dfsg-2ubuntu0.2 nodejs-dev=8.10.0~dfsg-2ubuntu0.2 npm \
+    && \
+    apt-get purge && apt-get clean
+RUN pip uninstall -y jupyterhub && pip install git+https://github.com/chancez/jupyterhub.git@fix_ssl_http_client#egg=jupyterhub
+
 WORKDIR /srv/jupyterhub
 
 # So we can actually write a db file here

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -409,6 +409,10 @@ if get_config('cull.enabled', False):
         '--url=' + protocol + '://localhost:8081' + url_path_join(base_url, 'hub/api')
     )
 
+    if https_enabled:
+        cull_cmd.append('--ssl-enabled')
+        cull_cmd.append('--internal-certs-location=%s' % c.JupyterHub.internal_certs_location)
+
     cull_timeout = get_config('cull.timeout')
     if cull_timeout:
         cull_cmd.append('--timeout=%s' % cull_timeout)

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -1,16 +1,20 @@
+#!/usr/bin/env python3
 import os
 import re
 import sys
 
 from tornado.httpclient import AsyncHTTPClient
-from kubernetes import client
+
 from jupyterhub.utils import url_path_join
+from kubernetes import client
 
 # Make sure that modules placed in the same directory as the jupyterhub config are added to the pythonpath
 configuration_directory = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, configuration_directory)
 
 from z2jh import get_config, set_config_if_not_none
+
+namespace = os.getenv("POD_NAMESPACE", "default")
 
 # Configure JupyterHub to use the curl backend for making HTTP requests,
 # rather than the pure-python implementations. The default one starts
@@ -21,8 +25,8 @@ AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
 c.JupyterHub.spawner_class = 'kubespawner.KubeSpawner'
 
 # Connect to a proxy running in a different pod
-c.ConfigurableHTTPProxy.api_url = 'http://{}:{}'.format(os.environ['PROXY_API_SERVICE_HOST'], int(os.environ['PROXY_API_SERVICE_PORT']))
 c.ConfigurableHTTPProxy.should_start = False
+
 
 # Do not shut down user pods when hub is restarted
 c.JupyterHub.cleanup_servers = False
@@ -35,6 +39,31 @@ c.JupyterHub.tornado_settings = {
     'slow_spawn_timeout': 0,
 }
 
+# Handle SSL options
+https_enabled = get_config('hub.https.enabled', False)
+protocol = "https" if https_enabled else "http"
+
+c.ConfigurableHTTPProxy.api_url = f"{protocol}://proxy-api.{namespace}.svc.cluster.local:8001"
+c.JupyterHub.hub_connect_url = f"{protocol}://hub.{namespace}.svc.cluster.local:8081"
+
+c.JupyterHub.bind_url = f"{protocol}://0.0.0.0:8081"
+c.JupyterHub.hub_bind_url = f"{protocol}://0.0.0.0:8081"
+
+c.JupyterHub.internal_ssl = https_enabled
+c.JupyterHub.internal_certs_location = '/srv/jupyterhub-internal-ssl/internal-ssl'
+
+# Set default trusted_alt_names even if internal_ssl isn't enabled, so that we
+# can generate certificates with the correct SANs prior to enabling it on the
+# hub pod.
+c.JupyterHub.trusted_alt_names = [
+  "IP:127.0.0.1",
+  "DNS:localhost",
+  f"DNS:hub.{namespace}.svc.cluster.local",
+  f"DNS:proxy-api.{namespace}.svc.cluster.local",
+  f"DNS:proxy-public.{namespace}.svc.cluster.local",
+  # wildcard for per-user subdomains
+  f"DNS:*.{namespace}.svc.cluster.local",
+] + get_config('hub.https.extraAltNames', [])
 
 def camelCaseify(s):
     """convert snake_case to camelCase
@@ -74,8 +103,8 @@ for trait, cfg_key in (
         cfg_key = camelCaseify(trait)
     set_config_if_not_none(c.JupyterHub, trait, 'hub.' + cfg_key)
 
-c.JupyterHub.ip = os.environ['PROXY_PUBLIC_SERVICE_HOST']
-c.JupyterHub.port = int(os.environ['PROXY_PUBLIC_SERVICE_PORT'])
+c.JupyterHub.ip = "0.0.0.0"
+c.JupyterHub.port = 8000
 
 # the hub should listen on all interfaces, so the proxy can access it
 c.JupyterHub.hub_ip = '0.0.0.0'
@@ -98,7 +127,7 @@ release = get_config('Release.Name')
 if release:
     common_labels['release'] = release
 
-c.KubeSpawner.namespace = os.environ.get('POD_NAMESPACE', 'default')
+c.KubeSpawner.namespace = namespace
 
 # Max number of consecutive failures before the Hub restarts itself
 # requires jupyterhub 0.9.2
@@ -246,10 +275,6 @@ elif storage_type == 'static':
 c.KubeSpawner.volumes.extend(get_config('singleuser.storage.extraVolumes', []))
 c.KubeSpawner.volume_mounts.extend(get_config('singleuser.storage.extraVolumeMounts', []))
 
-# Gives spawned containers access to the API of the hub
-c.JupyterHub.hub_connect_ip = os.environ['HUB_SERVICE_HOST']
-c.JupyterHub.hub_connect_port = int(os.environ['HUB_SERVICE_PORT'])
-
 # Allow switching authenticators easily
 auth_type = get_config('auth.type')
 email_domain = 'local'
@@ -379,8 +404,9 @@ if get_config('cull.enabled', False):
         'jupyterhub_idle_culler'
     ]
     base_url = c.JupyterHub.get('base_url', '/')
+
     cull_cmd.append(
-        '--url=http://localhost:8081' + url_path_join(base_url, 'hub/api')
+        '--url=' + protocol + '://localhost:8081' + url_path_join(base_url, 'hub/api')
     )
 
     cull_timeout = get_config('cull.timeout')

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -54,6 +54,11 @@ spec:
           persistentVolumeClaim:
             claimName: hub-db-dir
         {{- end }}
+        {{- if .Values.hub.https.enabled }}
+        - name: hub-internal-ssl
+          persistentVolumeClaim:
+            claimName: hub-internal-ssl
+        {{- end }}
       {{- if .Values.rbac.enabled }}
       serviceAccountName: hub
       {{- end }}
@@ -69,9 +74,59 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- if .Values.hub.initContainers }}
+      {{- if or .Values.hub.initContainers .Values.hub.https.enabled }}
       initContainers:
+        {{- if .Values.hub.https.enabled }}
+        - name: init-tls
+          image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              jupyterhub -f /etc/jupyterhub/jupyterhub_config.py --generate-certs
+              cd /srv/jupyterhub-internal-ssl/internal-ssl/
+              kubectl create secret generic \
+                --namespace $POD_NAMESPACE \
+                jupyterhub-certs \
+                --from-file=certipy.json \
+                --from-file=services-ca/services-ca.key \
+                --from-file=services-ca/services-ca.crt \
+                --from-file=notebooks-ca/notebooks-ca.key \
+                --from-file=notebooks-ca/notebooks-ca.crt \
+                --from-file=proxy-api-ca/proxy-api-ca.key \
+                --from-file=proxy-api-ca/proxy-api-ca.crt \
+                --from-file=proxy-client-ca/proxy-client-ca.key \
+                --from-file=proxy-client-ca/proxy-client-ca.crt \
+                --from-file=hub-ca/hub-ca.key \
+                --from-file=hub-ca/hub-ca.crt \
+                --from-file=hub-ca_trust.crt \
+                --from-file=proxy-api-ca_trust.crt \
+                --from-file=proxy-client-ca_trust.crt \
+                --from-file=notebooks-ca_trust.crt \
+                --from-file=services-ca_trust.crt \
+                --from-file=hub-internal/hub-internal.key \
+                --from-file=hub-internal/hub-internal.crt \
+                --from-file=proxy-api/proxy-api.key \
+                --from-file=proxy-api/proxy-api.crt \
+                --from-file=proxy-client/proxy-client.key \
+                --from-file=proxy-client/proxy-client.crt \
+                --dry-run -o yaml > jupyterhub-certs-secret.yaml
+                kubectl --namespace $POD_NAMESPACE create -f jupyterhub-certs-secret.yaml || kubectl --namespace $POD_NAMESPACE replace -f jupyterhub-certs-secret.yaml
+          env:
+            {{- include "jupyterhub.hub.env" . | nindent 12 }}
+          volumeMounts:
+            {{- include "jupyterhub.hub.volumeMounts" . | nindent 12 }}
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 200m
+            limits:
+              memory: 256Mi
+              cpu: 200m
+        {{- end }}
+        {{- if .Values.hub.initContainers  }}
         {{- .Values.hub.initContainers | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         {{- if .Values.hub.extraContainers }}
@@ -106,27 +161,10 @@ spec:
             - --upgrade-db
             {{- end }}
             {{- end }}
+          env:
+            {{- include "jupyterhub.hub.env" . | nindent 12 }}
           volumeMounts:
-            - mountPath: /etc/jupyterhub/jupyterhub_config.py
-              subPath: jupyterhub_config.py
-              name: config
-            - mountPath: /etc/jupyterhub/z2jh.py
-              subPath: z2jh.py
-              name: config
-            - mountPath: /etc/jupyterhub/config/
-              name: config
-            - mountPath: /etc/jupyterhub/secret/
-              name: secret
-            {{- if .Values.hub.extraVolumeMounts }}
-            {{- .Values.hub.extraVolumeMounts | toYaml | trimSuffix "\n" | nindent 12 }}
-            {{- end }}
-            {{- if eq .Values.hub.db.type "sqlite-pvc" }}
-            - mountPath: /srv/jupyterhub
-              name: hub-db-dir
-              {{- if .Values.hub.db.pvc.subPath }}
-              subPath: {{ .Values.hub.db.pvc.subPath | quote }}
-              {{- end }}
-            {{- end }}
+            {{- include "jupyterhub.hub.volumeMounts" . | nindent 12 }}
           resources:
             {{- .Values.hub.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- with .Values.hub.image.pullPolicy }}
@@ -142,82 +180,6 @@ spec:
           securityContext:
             {{- $securityContext | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
-          env:
-            - name: PYTHONUNBUFFERED
-              value: "1"
-            - name: HELM_RELEASE_NAME
-              value: {{ .Release.Name | quote }}
-            {{- if .Values.hub.cookieSecret }}
-            - name: JPY_COOKIE_SECRET
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.hub.existingSecret }}
-                  name: {{ .Values.hub.existingSecret }}
-                  {{- else }}
-                  name: hub-secret
-                  {{- end }}
-                  key: hub.cookie-secret
-            {{- end }}
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIGPROXY_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.hub.existingSecret }}
-                  name: {{ .Values.hub.existingSecret }}
-                  {{- else }}
-                  name: hub-secret
-                  {{- end }}
-                  key: proxy.token
-            {{- if .Values.auth.state.enabled }}
-            - name: JUPYTERHUB_CRYPT_KEY
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.hub.existingSecret }}
-                  name: {{ .Values.hub.existingSecret }}
-                  {{- else }}
-                  name: hub-secret
-                  {{- end }}
-                  key: auth.state.crypto-key
-            {{- end }}
-            {{- if .Values.hub.db.password }}
-            {{- if eq .Values.hub.db.type "mysql" }}
-            - name: MYSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.hub.existingSecret }}
-                  name: {{ .Values.hub.existingSecret }}
-                  {{- else }}
-                  name: hub-secret
-                  {{- end }}
-                  key: hub.db.password
-            {{- else if eq .Values.hub.db.type "postgres" }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if .Values.hub.existingSecret }}
-                  name: {{ .Values.hub.existingSecret }}
-                  {{- else }}
-                  name: hub-secret
-                  {{- end }}
-                  key: hub.db.password
-            {{- end }}
-            {{- end }}
-            {{- if .Values.hub.extraEnv }}
-            {{- $extraEnvType := typeOf .Values.hub.extraEnv }}
-            {{- /* If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc. */}}
-            {{- if eq $extraEnvType "[]interface {}" }}
-            {{- .Values.hub.extraEnv | toYaml | trimSuffix "\n" | nindent 12 }}
-            {{- else if eq $extraEnvType "map[string]interface {}" }}
-            {{- /* If we have a map, treat those as key-value pairs. */}}
-            {{- range $key, $value := .Values.hub.extraEnv }}
-            - name: {{ $key | quote }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
           ports:
             - name: http
               containerPort: 8081
@@ -232,15 +194,13 @@ spec:
           livenessProbe:
             initialDelaySeconds: {{ .Values.hub.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.hub.livenessProbe.periodSeconds }}
-            httpGet:
-              path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
+            tcpSocket:
               port: http
           {{- end }}
           {{- if .Values.hub.readinessProbe.enabled }}
           readinessProbe:
             initialDelaySeconds: {{ .Values.hub.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.hub.readinessProbe.periodSeconds }}
-            httpGet:
-              path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
+            tcpSocket:
               port: http
           {{- end }}

--- a/jupyterhub/templates/hub/pvc.yaml
+++ b/jupyterhub/templates/hub/pvc.yaml
@@ -23,3 +23,29 @@ spec:
     requests:
       storage: {{ .Values.hub.db.pvc.storage | quote }}
 {{- end }}
+---
+{{- if .Values.hub.https.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: hub-internal-ssl
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- if .Values.hub.https.pvc.annotations }}
+  annotations:
+    {{- .Values.hub.https.pvc.annotations | toYaml | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.hub.https.pvc.selector }}
+  selector:
+    {{- .Values.hub.https.pvc.selector | toYaml | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
+  {{- if typeIs "string" .Values.hub.https.pvc.storageClassName }}
+  storageClassName: {{ .Values.hub.https.pvc.storageClassName | quote }}
+  {{- end }}
+  accessModes:
+    {{- .Values.hub.https.pvc.accessModes | toYaml | trimSuffix "\n" | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.hub.https.pvc.storage | quote }}
+{{- end }}

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -14,8 +14,8 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]       # "" indicates the core API group
-    resources: ["pods", "persistentvolumeclaims"]
-    verbs: ["get", "watch", "list", "create", "delete"]
+    resources: ["pods", "persistentvolumeclaims", "secrets", "services"]
+    verbs: ["get", "watch", "list", "create", "delete", "patch", "update"]
   - apiGroups: [""]       # "" indicates the core API group
     resources: ["events"]
     verbs: ["get", "watch", "list"]

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -37,16 +37,20 @@ spec:
       {{- end }}
       nodeSelector: {{ toJson .Values.proxy.nodeSelector }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
-      {{- if $manualHTTPS }}
       volumes:
+      {{- if $manualHTTPS }}
         - name: tls-secret
           secret:
             secretName: proxy-manual-tls
       {{- else if $manualHTTPSwithsecret }}
-      volumes:
         - name: tls-secret
           secret:
             secretName: {{ .Values.proxy.https.secret.name }}
+      {{- end }}
+      {{- if .Values.hub.https.enabled }}
+        - name: internal-tls-secret
+          secret:
+            secretName: {{ .Values.proxy.https.internalSecret.name }}
       {{- end }}
       containers:
         - name: chp
@@ -56,8 +60,24 @@ spec:
             - '--ip=::'
             - '--api-ip=::'
             - --api-port=8001
+            {{- if .Values.hub.https.enabled }}
+            - --default-target=https://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
+            - --error-target=https://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)/hub/error
+            - --ssl-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            - --api-ssl-key=/etc/chp/internal/{{ .Values.proxy.https.internalSecret.api.key }}
+            - --api-ssl-cert=/etc/chp/internal/{{ .Values.proxy.https.internalSecret.api.crt }}
+            - --api-ssl-ca=/etc/chp/internal/{{ .Values.proxy.https.internalSecret.api.ca }}
+            - --api-ssl-request-cert
+            - --api-ssl-reject-unauthorized
+            - --client-ssl-key=/etc/chp/internal/{{ .Values.proxy.https.internalSecret.client.key }}
+            - --client-ssl-cert=/etc/chp/internal/{{ .Values.proxy.https.internalSecret.client.crt }}
+            - --client-ssl-ca=/etc/chp/internal/{{ .Values.proxy.https.internalSecret.client.ca }}
+            - --client-ssl-request-cert
+            - --client-ssl-reject-unauthorized
+            {{- else }}
             - --default-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)
             - --error-target=http://$(HUB_SERVICE_HOST):$(HUB_SERVICE_PORT)/hub/error
+            {{- end }}
             {{- if $manualHTTPS }}
             - --port=8443
             - --redirect-port=8000
@@ -76,10 +96,15 @@ spec:
             {{- if .Values.debug.enabled }}
             - --log-level=debug
             {{- end }}
-          {{- if or $manualHTTPS $manualHTTPSwithsecret }}
           volumeMounts:
+          {{- if or $manualHTTPS $manualHTTPSwithsecret }}
             - name: tls-secret
               mountPath: /etc/chp/tls
+              readOnly: true
+          {{- end }}
+          {{- if .Values.hub.https.enabled }}
+            - name: internal-tls-secret
+              mountPath: /etc/chp/internal
               readOnly: true
           {{- end }}
           resources:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -7,6 +7,16 @@ hub:
     ports:
       nodePort:
     loadBalancerIP:
+  https:
+    enabled: false
+    pvc:
+      annotations: {}
+      selector: {}
+      accessModes:
+        - ReadWriteOnce
+      storage: 1Gi
+      subPath:
+      storageClassName:
   baseUrl: /
   cookieSecret:
   publicURL:
@@ -47,7 +57,7 @@ hub:
   extraVolumeMounts: []
   image:
     name: jupyterhub/k8s-hub
-    tag: 'set-by-chartpress'
+    tag: '0.9.0'
     # pullSecrets:
     #   - secretName
   resources:
@@ -99,7 +109,6 @@ hub:
 
 rbac:
   enabled: true
-
 
 proxy:
   secretToken: ''
@@ -178,7 +187,7 @@ proxy:
   secretSync:
     image:
       name: jupyterhub/k8s-secret-sync
-      tag: 'set-by-chartpress'
+      tag: '0.9.0'
     resources: {}
   labels: {}
   nodeSelector: {}
@@ -200,6 +209,16 @@ proxy:
       name: ''
       key: tls.key
       crt: tls.crt
+    internalSecret:
+      name: jupyterhub-certs
+      api:
+        key: proxy-api.key
+        crt: proxy-api.crt
+        ca: proxy-api-ca_trust.crt
+      client:
+        key: proxy-client.key
+        crt: proxy-client.crt
+        ca: proxy-client-ca_trust.crt
     hosts: []
   networkPolicy:
     enabled: false
@@ -208,7 +227,6 @@ proxy:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
-
 
 auth:
   type: dummy
@@ -228,7 +246,6 @@ auth:
     enabled: false
     cryptoKey:
 
-
 singleuser:
   extraTolerations: []
   nodeSelector: {}
@@ -244,7 +261,7 @@ singleuser:
   networkTools:
     image:
       name: jupyterhub/k8s-network-tools
-      tag: 'set-by-chartpress'
+      tag: '0.9.0'
   cloudMetadata:
     enabled: false
     ip: 169.254.169.254
@@ -252,7 +269,7 @@ singleuser:
     enabled: false
     ingress: []
     egress:
-    # Required egress is handled by other rules so it's safe to modify this
+      # Required egress is handled by other rules so it's safe to modify this
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
@@ -286,7 +303,7 @@ singleuser:
       storageAccessModes: [ReadWriteOnce]
   image:
     name: jupyterhub/k8s-singleuser-sample
-    tag: 'set-by-chartpress'
+    tag: '0.9.0'
     pullPolicy: IfNotPresent
     # pullSecrets:
     #   - secretName
@@ -309,7 +326,6 @@ singleuser:
   cmd: jupyterhub-singleuser
   defaultUrl:
   extraPodConfig: {}
-
 
 scheduling:
   userScheduler:
@@ -351,14 +367,13 @@ scheduling:
     nodeAffinity:
       matchNodePurpose: prefer
 
-
 prePuller:
   annotations: {}
   hook:
     enabled: true
     image:
       name: jupyterhub/k8s-image-awaiter
-      tag: 'set-by-chartpress'
+      tag: '0.9.0'
   continuous:
     enabled: true
   extraImages: {}
@@ -367,14 +382,12 @@ prePuller:
       name: gcr.io/google_containers/pause
       tag: '3.1'
 
-
 ingress:
   enabled: false
   annotations: {}
   hosts: []
   pathSuffix: ''
   tls: []
-
 
 cull:
   enabled: true
@@ -384,7 +397,6 @@ cull:
   every: 600
   concurrency: 10
   maxAge: 0
-
 
 debug:
   enabled: false


### PR DESCRIPTION
Automates provisioning of SSL certificates for jupyterhub, CHP, and singleuser-notebook servers using an initContainer in the hub pod during startup.

Current issues:
- Uses a custom version of `kubespawner` with the changes from https://github.com/jupyterhub/kubespawner/pull/409
- Uses a custom version of `jupyterhub` 1.1.0 with the changes in https://github.com/jupyterhub/jupyterhub/pull/3140 added. This fixes OAuth2 when using internal SSL.
- Uses a custom version of `jupyterhub_cull_idle` with changes from https://github.com/jupyterhub/jupyterhub-idle-culler/pull/11
- Requires you use a custom CHP image with the changes from https://github.com/jupyterhub/configurable-http-proxy/pull/254

Closes #1520 