### PR TITLE
Fix travis by pinning docker python package version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   # Exit immediately if a command exits with a non-zero status.
   - set -e
   - . ci/common
+  - pip install "docker~=4.2.0"
 
 # The default install script below will prepare a k8s cluster to work with, but
 # not install JupyterHub itself, as upgrade tests may want to make multiple


### PR DESCRIPTION
4.3.0 was just released (https://github.com/docker/docker-py/releases/tag/4.3.0) and changed
the default API version to v1.39 and apparently this is breaking CI.
(See here: https://travis-ci.org/github/jupyterhub/zero-to-jupyterhub-k8s/jobs/716638776#L374)