### PR TITLE
Unindent lines to fix the bug in "Specify certificate through Secret resource"

### DIFF
--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -112,8 +112,8 @@ There are two ways to specify your manual certificate, directly in the config.ya
         hosts:
           - <your-domain-name>
         type: secret
-          secret:
-            name: example-tls
+        secret:
+          name: example-tls
     ```
 
 3. Apply the config changes by running helm upgrade ....


### PR DESCRIPTION
Ran the [local doc development](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/doc/README.md) instructions to make sure the tabbing looked correct, and it does.

Closes #1750 .