### PR TITLE
Bump traefik (autohttps pod) to v2.3

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -158,10 +158,7 @@ proxy:
   traefik:
     image:
       name: traefik
-      # NOTE: we are pinning to patch version only to ensure we don't use a
-      #       cached old version of v2.2. When we bump this to v2.3 we should
-      #       stop using the patch version.
-      tag: v2.2.4 # ref: https://hub.docker.com/_/traefik?tab=tags
+      tag: v2.3 # ref: https://hub.docker.com/_/traefik?tab=tags
     hsts:
       includeSubdomains: false
       preload: false


### PR DESCRIPTION
This bumps the traefik versions to v2.3 and stops using a specific patch version. The use of a specific patch version was introduced to avoid nodes with a v2.2 downloaded already that wasn't updating to an important fix.﻿
