### PR TITLE
hub.extraEnv / singleuser.extraEnv in dict format to support k8s EnvVar spec

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -308,20 +308,38 @@ properties:
         description: |
           Extra environment variables that should be set for the hub pod.
 
+          Environment variables are usually used to:
+            - Pass parameters to some custom code in `hub.extraConfig`.
+            - Configure code running in the hub pod, such as an authenticator or
+              spawner.
+
           ```yaml
           hub:
             extraEnv:
-              MY_ENV_VARS_NAME: "my env vars value"
+              # short notation, only for hardcoded string values
+              MY_ENV_VARS_NAME1: "my env var value 1"
+
+              # long notation, Kubernetes native syntax
+              dummyKey1:
+                name: HUB_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              dummyKey2:
+                name: PREFIXED_HUB_NAMESPACE
+                value: "my-prefix-$(HUB_NAMESPACE)"
+              dummyKey3:
+                name: SECRET_VALUE
+                valueFrom:
+                  secretKeyRef:
+                    name: my-k8s-secret
+                    key: password
           ```
 
-          **NOTE**: We still support this field being a list of
-          [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core)
-          objects as well.
-
-          These are usually used in two circumstances:
-            - Passing parameters to some custom code specified with `extraConfig`
-            - Passing parameters to an authenticator or spawner that can be directly customized
-              by environment variables (rarer)
+          In the long notation, you can provide any [Kubernetes
+          EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core)
+          specification, and the name of the key (`dummyKey1`) will have no
+          impact.
       extraConfig:
         type: object
         description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -313,7 +313,7 @@ properties:
             - Configure code running in the hub pod, such as an authenticator or
               spawner.
 
-          String literals with $(ENV_VAR_NAME) will be expanded by Kubelet which
+          String literals with `$(ENV_VAR_NAME)` will be expanded by Kubelet which
           is a part of Kubernetes.
 
           ```yaml
@@ -896,10 +896,10 @@ properties:
         description: |
           Extra environment variables that should be set for the user pods.
 
-          String literals with $(ENV_VAR_NAME) will be expanded by Kubelet which
+          String literals with `$(ENV_VAR_NAME)` will be expanded by Kubelet which
           is a part of Kubernetes. Note that the user pods will already have
           access to a set of environment variables that you can use, like
-          JUPYTERHUB_USER and JUPYTERHUB_HOST. For more information about these
+          `JUPYTERHUB_USER` and `JUPYTERHUB_HOST`. For more information about these
           inspect [this source
           code](https://github.com/jupyterhub/jupyterhub/blob/cc8e7806530466dce8968567d1bbd2b39a7afa26/jupyterhub/spawner.py#L763).
 

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -313,33 +313,34 @@ properties:
             - Configure code running in the hub pod, such as an authenticator or
               spawner.
 
+          String literals with $(ENV_VAR_NAME) will be expanded by Kubelet which
+          is a part of Kubernetes.
+
           ```yaml
           hub:
             extraEnv:
-              # short notation, only for hardcoded string values
+              # basic notation (for literal values only)
               MY_ENV_VARS_NAME1: "my env var value 1"
 
-              # long notation, Kubernetes native syntax
-              dummyKey1:
+              # explicit notation (the "name" field takes precedence)
+              HUB_NAMESPACE:
                 name: HUB_NAMESPACE
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.namespace
-              dummyKey2:
-                name: PREFIXED_HUB_NAMESPACE
+
+              # implicit notation (the "name" field is implied)
+              PREFIXED_HUB_NAMESPACE:
                 value: "my-prefix-$(HUB_NAMESPACE)"
-              dummyKey3:
-                name: SECRET_VALUE
+              SECRET_VALUE:
                 valueFrom:
                   secretKeyRef:
                     name: my-k8s-secret
                     key: password
           ```
 
-          In the long notation, you can provide any [Kubernetes
-          EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core)
-          specification, and the name of the key (`dummyKey1`) will have no
-          impact.
+          For more information, see the [Kubernetes EnvVar
+          specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core).
       extraConfig:
         type: object
         description: |
@@ -890,6 +891,43 @@ properties:
         description: |
           Deprecated and no longer does anything. Use the user-scheduler instead
           in order to accomplish a good packing of the user pods.
+      extraEnv:
+        type: object
+        description: |
+          Extra environment variables that should be set for the user pods.
+
+          String literals with $(ENV_VAR_NAME) will be expanded by Kubelet which
+          is a part of Kubernetes. Note that the user pods will already have
+          access to a set of environment variables that you can use, like
+          JUPYTERHUB_USER and JUPYTERHUB_HOST. For more information about these
+          inspect [this source
+          code](https://github.com/jupyterhub/jupyterhub/blob/cc8e7806530466dce8968567d1bbd2b39a7afa26/jupyterhub/spawner.py#L763).
+
+          ```yaml
+          singleuser:
+            extraEnv:
+              # basic notation (for literal values only)
+              MY_ENV_VARS_NAME1: "my env var value 1"
+
+              # explicit notation (the "name" field takes precedence)
+              USER_NAMESPACE:
+                name: USER_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+
+              # implicit notation (the "name" field is implied)
+              PREFIXED_USER_NAMESPACE:
+                value: "my-prefix-$(USER_NAMESPACE)"
+              SECRET_VALUE:
+                valueFrom:
+                  secretKeyRef:
+                    name: my-k8s-secret
+                    key: password
+          ```
+
+          For more information, see the [Kubernetes EnvVar
+          specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core).
       extraTolerations:
         type: list
         description: |

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -205,30 +205,7 @@ spec:
                   key: hub.db.password
             {{- end }}
             {{- end }}
-            {{- if .Values.hub.extraEnv }}
-            {{- $extraEnvType := typeOf .Values.hub.extraEnv }}
-            {{- /* If hub.extraEnv is a list, we inject it as it is. */}}
-            {{- if eq $extraEnvType "[]interface {}" }}
-            {{- .Values.hub.extraEnv | toYaml | trimSuffix "\n" | nindent 12 }}
-            {{- /* If hub.extraEnv is a map, we differentiate two cases:
-              - If hub.extraEnv.someKey has a map value, then we add the value
-                as a list element and ignore the key.
-              - If hub.extraEnv.someKey has a string value, then we use the
-                key as the environment variable name for the value.
-            */}}
-            {{- else if eq $extraEnvType "map[string]interface {}" }}
-            {{- range $key, $value := .Values.hub.extraEnv }}
-            {{- if eq (typeOf $value) "map[string]interface {}" }}
-            {{- $value | list | toYaml | nindent 12 }}
-            {{- else if eq (typeOf $value) "string" }}
-            - name: {{ $key | quote }}
-              value: {{ $value | quote }}
-            {{- else }}
-            {{ printf "hub.extraEnv.%s had an unexpected type (%s)" $key (typeOf $value) | fail }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
+            {{- include "jupyterhub.extraEnv" .Values.hub.extraEnv | nindent 12 }}
           ports:
             - name: http
               containerPort: 8081

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -207,14 +207,25 @@ spec:
             {{- end }}
             {{- if .Values.hub.extraEnv }}
             {{- $extraEnvType := typeOf .Values.hub.extraEnv }}
-            {{- /* If we have a list, embed that here directly. This allows for complex configuration from configmap, downward API, etc. */}}
+            {{- /* If hub.extraEnv is a list, we inject it as it is. */}}
             {{- if eq $extraEnvType "[]interface {}" }}
             {{- .Values.hub.extraEnv | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- /* If hub.extraEnv is a map, we differentiate two cases:
+              - If hub.extraEnv.someKey has a map value, then we add the value
+                as a list element and ignore the key.
+              - If hub.extraEnv.someKey has a string value, then we use the
+                key as the environment variable name for the value.
+            */}}
             {{- else if eq $extraEnvType "map[string]interface {}" }}
-            {{- /* If we have a map, treat those as key-value pairs. */}}
             {{- range $key, $value := .Values.hub.extraEnv }}
+            {{- if eq (typeOf $value) "map[string]interface {}" }}
+            {{- $value | list | toYaml | nindent 12 }}
+            {{- else if eq (typeOf $value) "string" }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
+            {{- else }}
+            {{ printf "hub.extraEnv.%s had an unexpected type (%s)" $key (typeOf $value) | fail }}
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -40,11 +40,10 @@ hub:
   extraConfigMap:
     mock.entry: mock-config-map-entry
   extraEnv:
-    dummyMergeKey1:
+    IGNORED_KEY_NAME:
       name: MOCK_ENV_VAR_NAME1
       value: MOCK_ENV_VAR_VALUE1
-    dummyMergeKey2:
-      name: MOCK_ENV_VAR_NAME2
+    MOCK_ENV_VAR_NAME2:
       value: MOCK_ENV_VAR_VALUE2
   extraContainers: []
   extraVolumes: []

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -40,7 +40,12 @@ hub:
   extraConfigMap:
     mock.entry: mock-config-map-entry
   extraEnv:
-    MOCK_HUB_ENV: mock
+    dummyMergeKey1:
+      name: MOCK_ENV_VAR_NAME1
+      value: MOCK_ENV_VAR_VALUE1
+    dummyMergeKey2:
+      name: MOCK_ENV_VAR_NAME2
+      value: MOCK_ENV_VAR_VALUE2
   extraContainers: []
   extraVolumes: []
   extraVolumeMounts: []

--- a/tools/templates/lint-and-validate.py
+++ b/tools/templates/lint-and-validate.py
@@ -4,16 +4,22 @@ Lints and validates the chart's template files and their rendered output without
 any cluster interaction. For this script to function, you must install yamllint
 and kubeval.
 
-- https://github.com/adrienverge/yamllint
+USAGE:
 
-pip install yamllint
+  tools/templates/lint-and-validate.py
 
-- https://github.com/instrumenta/kubeval
+DEPENDENCIES:
 
-LATEST=curl --silent "https://api.github.com/repos/instrumenta/kubeval/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
-wget https://github.com/instrumenta/kubeval/releases/download/$LATEST/kubeval-linux-amd64.tar.gz
-tar xf kubeval-darwin-amd64.tar.gz
-mv kubeval /usr/local/bin
+yamllint: https://github.com/adrienverge/yamllint
+
+  pip install yamllint
+
+kubeval: https://github.com/instrumenta/kubeval
+
+  LATEST=$(curl --silent "https://api.github.com/repos/instrumenta/kubeval/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  wget https://github.com/instrumenta/kubeval/releases/download/$LATEST/kubeval-linux-amd64.tar.gz
+  tar xf kubeval-linux-amd64.tar.gz
+  sudo mv kubeval /usr/local/bin
 """
 
 import os


### PR DESCRIPTION
# Background
In short, specifying an environment variable for the JupyterHub pod or the user pods could only be done in a limited fashion that excluded specifying an environment variable that got its value from some Kubernetes ConfigMap/Secret or similar. This has only been only possible with intrusive workarounds. This PR closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1103 and an associated KubeSpawner PR has already closed https://github.com/jupyterhub/kubespawner/issues/306#issuecomment-474934945.

## hub.extraEnv advanced syntax support

This PR enables `hub.extraEnv` to function with a format either exactly like Kubernetes [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core) specification or a shorthand where a `name: ...` is implied. This format is now also documented in the configuration reference ([docs preview](https://zero-to-jupyterhub--1757.org.readthedocs.build/en/1757/reference/reference.html#hub-extraenv)).

## singleuser.extraEnv advanced syntax support

This PR doesn't fully close https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1103 because this only enables the new syntax support for `hub.extraEnv` but _not also for `singleuser.extraEnv`_. https://github.com/jupyterhub/kubespawner/pull/426 is now merged which takes care of the `singleuser.extraEnv` part.

### Technical breakdown regarding singleuser.extraEnv

The Helm chart configuration `singleuser.extraEnv` propegates without issues to `c.KubeSpawner.environment` which is [defined in the Spawner base class](https://github.com/jupyterhub/jupyterhub/blob/29de00ee3c7f1ad60f869e2e3877fb5ab923c60e/jupyterhub/spawner.py#L453), so  it turned out that no changes were needed in this repo. Below are still some of the notes I made along the way to ensure that was the case and to develop the PR (https://github.com/jupyterhub/kubespawner/pull/426) in KubeSpawner that fixed it over there.

1. Either directly configuring `c.KubeSpawner.environment` or doing it through `singleuser.extraEnv` should be fine even if we use the new syntax.
2. KubeSpawner references the `environment` traitlet from the end of the [`jupyterhub.Spawner.get_env` function](https://github.com/jupyterhub/jupyterhub/blob/cc8e7806530466dce8968567d1bbd2b39a7afa26/jupyterhub/spawner.py#L726).
3. The `get_env` function is [then called](https://github.com/jupyterhub/kubespawner/blob/bf1fdca48a4a73278e629bffa6f749136edd5f86/kubespawner/spawner.py#L1435) to provide the `env` argument to the `make_pod` function.
4. The `make_pod` function [use the the passed env vars once](https://github.com/jupyterhub/kubespawner/blob/3d9519ba2c1894a4a8f5e6b211fa92c12fcdb78d/kubespawner/objects.py#L282), that assuming support for new syntax should be able to get a `dummyKey1` with a value of `{name: "MY_ENV", value: "my-value"}` passed to it.
5. The [`V1EnvVar` constructor](https://github.com/kubernetes-client/python/blob/bc79976edfe01b028aef0b93bde54e002b113443/kubernetes/client/models/v1_env_var.py#L47) allows for name/value/value_from, but is only used to pass a name/value combination rather than the possible name/valueFrom combination.
6. The issue found in the point above is fixed in https://github.com/jupyterhub/kubespawner/pull/426
7. Documentation is also added in this PR to use singleuser.extraEnv with this new syntax.

Relevant references for this tech breakdown are the [k8s api specs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core) and the [Python API for Kubernetes](https://github.com/kubernetes-client/python).

## Discussion

- @minrk considered the implementation options in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1103#issuecomment-454336736.
- @manics suggested the implicit syntax where `name: ...` is implied. This is now supported.

## Todo
- [x] Get KubeSpawner 0.13.0 releaased (https://github.com/jupyterhub/kubespawner/pull/429)
- [x] Bump the KubeSpawner version in the hub image we build in this Helm chart (https://travis-ci.org/github/jupyterhub/zero-to-jupyterhub-k8s/builds/724045064)

## Related
- Closing #1462 in favor of this as the added documentation regards the no longer needed workaround.