### PR TITLE
https: Only expose port 443 if we really have HTTPS on

### DIFF
--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -82,8 +82,6 @@ There are two ways to specify your manual certificate, directly in the config.ya
     proxy:
       https:
         enabled: true
-        hosts:
-          - <your-domain-name>
         type: manual
         manual:
           key: |

--- a/doc/source/administrator/security.md
+++ b/doc/source/administrator/security.md
@@ -41,6 +41,7 @@ changes to your `config.yaml` file:
    ```yaml
    proxy:
      https:
+       enabled: true
        hosts:
          - <your-domain-name>
        letsencrypt:
@@ -80,6 +81,7 @@ There are two ways to specify your manual certificate, directly in the config.ya
     ```yaml
     proxy:
       https:
+        enabled: true
         hosts:
           - <your-domain-name>
         type: manual
@@ -109,6 +111,7 @@ There are two ways to specify your manual certificate, directly in the config.ya
     ```yaml
     proxy:
       https:
+        enabled: true
         hosts:
           - <your-domain-name>
         type: secret

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -1,8 +1,10 @@
 {{- $HTTPS := .Values.proxy.https.enabled -}}
-{{- $autoHTTPS := and $HTTPS (and (eq .Values.proxy.https.type "letsencrypt") .Values.proxy.https.hosts) -}}
-{{- $offloadHTTPS := and $HTTPS (eq .Values.proxy.https.type "offload") -}}
+# Automatic HTTPS via Let's Encrypt requires list of hostnames to be turned on
+{{- $autoHTTPS := and $HTTPS and (eq .Values.proxy.https.type "letsencrypt") .Values.proxy.https.hosts) -}}
+# Manual HTTPS with user provided certs does not require list of hostnames
 {{- $manualHTTPS := and $HTTPS (eq .Values.proxy.https.type "manual") -}}
-{{- $manualHTTPSwithsecret := and $HTTPS (eq .Values.proxy.https.type "secret") -}}
+# Offloading HTTPS to external LoadBalancer does not require list of hostnames either
+{{- $offloadHTTPS := and $HTTPS (eq .Values.proxy.https.type "offload") -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,9 +42,12 @@ spec:
     {{- end }}
     release: {{ .Release.Name }}
   ports:
-    {{- if $HTTPS }}
+    {{- if or $autoHTTPS (or $manualHTTPS $offloadHTTPS) }}
     - name: https
       port: 443
+      # When HTTPS is handled outside our helm chart, pass traffic
+      # coming in via port 443 to port 80. Termination happens
+      # outside of kubernetes somehow
       {{- if $offloadHTTPS }}
       targetPort: http
       {{- else }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -1,6 +1,6 @@
 {{- $HTTPS := .Values.proxy.https.enabled -}}
 # Automatic HTTPS via Let's Encrypt requires list of hostnames to be turned on
-{{- $autoHTTPS := and $HTTPS and (eq .Values.proxy.https.type "letsencrypt") .Values.proxy.https.hosts) -}}
+{{- $autoHTTPS := and $HTTPS (and (eq .Values.proxy.https.type "letsencrypt") .Values.proxy.https.hosts) -}}
 # Manual HTTPS with user provided certs does not require list of hostnames
 {{- $manualHTTPS := and $HTTPS (eq .Values.proxy.https.type "manual") -}}
 # Offloading HTTPS to external LoadBalancer does not require list of hostnames either

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -182,7 +182,7 @@ proxy:
     enabled: true
     minAvailable: 1
   https:
-    enabled: true
+    enabled: false
     type: letsencrypt
     #type: letsencrypt, manual, offload, secret
     letsencrypt:


### PR DESCRIPTION
For HTTPS, we want to expose port 443 on our service, but
only if it is 'turned on'. Unfortunately, in v 0.9, the
default was set to 'enabled' but it didn't act as enabled
unless hostnames were actually set. This exposed port 443
in proxy-public regardless of wether we were actually
set up for HTTPS or not. This caused weird issues with
AWS, since it was health checking all exposed ports. Since
we didn't have automatic HTTPS setup (since that needs
hostnames), this broke all installs on AWS!

This tries to be backwards compatible change, exposing
port 443 only if we *really* have https running. This
should fix issues with AWS, and be more 'correct'.

Manual HTTPS doesn't actually need hosts lists to be set,
so we remove that from our documentation.

We also re-introduce 'https.enabled' in our documentation -
manual action (DNS) is needed to enable HTTPS, so this
being explicit is IMO a good thing.

Fixes #1637