### PR TITLE
Make continuous image puller pods evictable

### DIFF
--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -33,13 +33,19 @@ spec:
   template:
     metadata:
       labels:
-        {{- /* Changes here will cause the DaemonSet to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
       {{- with .Values.prePuller.annotations }}
       annotations:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}
     spec:
+      {{- /*
+        continuous-image-puller pods are made evictable to save on the k8s pods
+        per node limit all k8s clusters have.
+      */}}
+      {{- if and (not .hook) .Values.scheduling.podPriority.enabled }}
+      priorityClassName: {{ .Release.Name }}-user-placeholder-priority
+      {{- end }}
       tolerations:
         {{- include "jupyterhub.userTolerations" . | nindent 8 }}
       nodeSelector: {{ toJson .Values.singleuser.nodeSelector }}


### PR DESCRIPTION
This was discussed in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1760. The gist of this PR which was only part of the discussion, is to allow the continuous image puller pods to be evictable in order to prefer letting a user pod schedule than a puller pod if the node becomes full. Sometimes a node can become full because of the sheer number of pods as k8s limits this as there is a limit of IPs for each node.﻿
