### PR TITLE
hook-image-puller: -pod-scheduling-wait-duration flag added for reliability during helm upgrades

### DIFF
--- a/images/image-awaiter/daemonset.go
+++ b/images/image-awaiter/daemonset.go
@@ -8,12 +8,22 @@ import (
 	"net/http"
 )
 
-// Partial structure of a Kubernetes DaemonSet object
-// Only contains fields we will actively be using, to make JSON parsing nicer
+// Partial structure of a Kubernetes DaemonSet object. Note that we want to use
+// the non-optional fields of the Status struct only to ensure this is a robust
+// implementation.
+//
+// ref: https://github.com/kubernetes/kubernetes/blob/e23d83eead3b5ae57731afb0209f4a2aaa4009dd/pkg/apis/apps/types.go#L590
 type DaemonSet struct {
 	Kind   string `json:"kind"`
 	Status struct {
+		// The number of nodes that are running at least 1
+		// daemon pod and are supposed to run the daemon pod.
+		CurrentNumberScheduled int `json:"currentNumberScheduled"`
+		// The number of nodes that are running the daemon pod, but are
+		// not supposed to run the daemon pod.
 		DesiredNumberScheduled int `json:"desiredNumberScheduled"`
+		// The number of nodes that should be running the daemon pod and have one
+		// or more of the daemon pod running and ready.
 		NumberReady            int `json:"numberReady"`
 	} `json:"status"`
 }
@@ -54,11 +64,18 @@ func getDaemonSet(transportPtr *http.Transport, server string, headers map[strin
 	return ds, err
 }
 
-func isImagesPresent(ds *DaemonSet) bool {
+// Return a bool indicating if the provided DaemonSet's _currently_ scheduled
+// pods (which does the image pulling) are ready, or in the case of a
+// strictCheck, if the _desired_ number of scheduled pods are ready.
+func areDaemonSetPodsReady(ds *DaemonSet, strictCheck bool) bool {
+	current := ds.Status.CurrentNumberScheduled
 	desired := ds.Status.DesiredNumberScheduled
 	ready := ds.Status.NumberReady
 
-	log.Printf("%d of %d nodes currently has the required images.", ready, desired)
-
-	return desired == ready
+	log.Printf("%d image puller pods are ready out of the %d currently scheduled and %d desired number scheduled.", ready, current, desired)
+	if strictCheck {
+		return ready == desired
+	} else {
+		return ready >= current
+	}
 }

--- a/images/image-awaiter/daemonset.go
+++ b/images/image-awaiter/daemonset.go
@@ -67,13 +67,13 @@ func getDaemonSet(transportPtr *http.Transport, server string, headers map[strin
 // Return a bool indicating if the provided DaemonSet's _currently_ scheduled
 // pods (which does the image pulling) are ready, or in the case of a
 // strictCheck, if the _desired_ number of scheduled pods are ready.
-func areDaemonSetPodsReady(ds *DaemonSet, strictCheck bool) bool {
+func areDaemonSetPodsReady(ds *DaemonSet, waitForPodsToSchedule bool) bool {
 	current := ds.Status.CurrentNumberScheduled
 	desired := ds.Status.DesiredNumberScheduled
 	ready := ds.Status.NumberReady
 
 	log.Printf("%d image puller pods are ready out of the %d currently scheduled and %d desired number scheduled.", ready, current, desired)
-	if strictCheck {
+	if waitForPodsToSchedule {
 		return ready == desired
 	} else {
 		return ready >= current

--- a/images/image-awaiter/main.go
+++ b/images/image-awaiter/main.go
@@ -85,8 +85,8 @@ func main() {
 	flag.StringVar(&daemonSet, "daemonset", "hook-image-puller", "The name DaemonSet that will perform image pulling")
 	var debug bool
 	flag.BoolVar(&debug, "debug", false, "Communicate through a 'kubectl proxy --port 8080' setup instead.")
-	var strictCheckDuration int
-	flag.IntVar(&strictCheckDuration, "strict-check-duration", 10, "Duration of seconds to wait for the desired number of scheduled pods to be ready until transitioning to wait for the currently scheduled pods to be ready instead. Set to -1 for an infinite duration.")
+	var podSchedulingWaitDuration int
+	flag.IntVar(&podSchedulingWaitDuration, "pod-scheduling-wait-duration", 10, "Duration of seconds to await the desired number of scheduled pods to become ready until transitioning to awaiting the currently scheduled pods to become ready instead. Set to -1 for an infinite duration.")
 
 	flag.Parse()
 
@@ -110,8 +110,8 @@ func main() {
 			log.Fatal(err)
 		}
 
-		strictCheck := strictCheckDuration == -1 || i < strictCheckDuration
-		if areDaemonSetPodsReady(ds, strictCheck) {
+		waitForPodsToSchedule := podSchedulingWaitDuration == -1 || i < podSchedulingWaitDuration
+		if areDaemonSetPodsReady(ds, waitForPodsToSchedule) {
 			log.Printf("Image download on nodes awaited successfully: shutting down!")
 			break
 		}

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1190,6 +1190,19 @@ properties:
         properties:
           enabled:
             type: bool
+          strictCheckDuration:
+            description: |
+              In this initial duration, the `hook-image-awaiter` has the
+              criteria to await all the pods to finish image pulling. After this
+              duration the criteria switch to await all pods that have scheduled
+              to finish image pulling. This is useful as sometimes pods fail to
+              schedule because a node is maxed out on pods.
+
+              The default value is 10 seconds which gives ample time for the
+              pods that can schedule to actually schedule. For an infinite
+              duration, configure the value `-1`.
+            type: int
+
       continuous:
         description: |
           See the [*optimization

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1190,17 +1190,22 @@ properties:
         properties:
           enabled:
             type: bool
-          strictCheckDuration:
+          podSchedulingWaitDuration:
             description: |
-              In this initial duration, the `hook-image-awaiter` has the
-              criteria to await all the pods to finish image pulling. After this
-              duration the criteria switch to await all pods that have scheduled
-              to finish image pulling. This is useful as sometimes pods fail to
-              schedule because a node is maxed out on pods.
+              The `hook-image-awaiter` has a criteria to await all the
+              `hook-image-puller` DaemonSet's pods to both schedule and finish
+              their image pulling. This flag can be used to relax this criteria
+              to instead only await the pods that _has already scheduled_ to
+              finish image pulling after a certain duration.
 
-              The default value is 10 seconds which gives ample time for the
-              pods that can schedule to actually schedule. For an infinite
-              duration, configure the value `-1`.
+              The value of this is that sometimes the newly created
+              `hook-image-puller` pods cannot be scheduled because nodes are
+              full, and then it probably won't make sense to block a `helm
+              upgrade`.
+
+              An infinite duration to wait for pods to schedule can be
+              represented by `-1`. This was the default behavior of version
+              0.9.0 and earlier.
             type: int
 
       continuous:

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -43,4 +43,5 @@ spec:
             - -api-server-address=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
             - -namespace={{ .Release.Namespace }}
             - -daemonset=hook-image-puller
+            - -strict-check-duration={{ .Values.prePuller.hook.strictCheckDuration }}
 {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -43,5 +43,5 @@ spec:
             - -api-server-address=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
             - -namespace={{ .Release.Namespace }}
             - -daemonset=hook-image-puller
-            - -strict-check-duration={{ .Values.prePuller.hook.strictCheckDuration }}
+            - -pod-scheduling-wait-duration={{ .Values.prePuller.hook.podSchedulingWaitDuration }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -355,7 +355,7 @@ prePuller:
     image:
       name: jupyterhub/k8s-image-awaiter
       tag: 'set-by-chartpress'
-    podSchedulingWaitDuration: 10
+    podSchedulingWaitDuration: -1
   continuous:
     enabled: true
   extraImages: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -355,6 +355,7 @@ prePuller:
     image:
       name: jupyterhub/k8s-image-awaiter
       tag: 'set-by-chartpress'
+    strictCheckDuration: 10
   continuous:
     enabled: true
   extraImages: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -355,7 +355,7 @@ prePuller:
     image:
       name: jupyterhub/k8s-image-awaiter
       tag: 'set-by-chartpress'
-    strictCheckDuration: 10
+    podSchedulingWaitDuration: 10
   continuous:
     enabled: true
   extraImages: {}


### PR DESCRIPTION
## PR Summary

This PR address a risk of `helm upgrade` failing for a bad reason - that the hook-image-puller pods fail to schedule because the nodes cannot accept more pods on them.

### How `helm upgrade` currently can fail for a bad reason

When `helm upgrade` is run, certain k8s resources are rendered and deployed before others using [Chart hooks](https://helm.sh/docs/topics/charts_hooks/). We deploy a `hook-image-awaiter` Pod and a `hook-image-puller` daemonset. The `hook-image-awaiter` pod awaits the pods of the `hook-image-puller` daemonset to become ready, as they do when they have been scheduled and pulled all images in dummy init containers.one node

The failure we can avoid is when the `hook-image-awaiter` pod get stuck waiting for one of the image puller pods that fails to schedule on a node, because a node is out of capacity to schedule more pods - probably mostly because a maximum pod per node constraint.

GKE has a max 110 pods per node for example, and there is no workaround for this limit as far as I know.

### How this PR address the issue

This PR updates the logic of the `hook-image-awaiter` pod's binary which we have written ourselves in Go. Before this PR it is waiting for all image puller pods to scheduled, start, and get the main container running/ready. But in this PR, it is made to await only the pods that actually have scheduled, but only to do that after an initial duration which is configurable with a `-pod-scheduling-wait-duration`.

We can accomplish this by using the status set on the hook-image-puller DaemonSet resource that describes `CurrentNumberScheduled`, `DesiredNumberScheduled`, and `NumberReady`.

### Configuration added

This duration is configurable with `prePuller.hook.podSchedulingWaitDuration` and defaults to `-1`. It can be configured to be an infinite duration with `-1`.