### PR TITLE
Minimal and explicit resource requests for image-puller pods

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1181,6 +1181,16 @@ properties:
         description: |
           Annotations to apply to the hook and continous image puller pods. One example use case is to
           disable istio sidecars which could interfere with the image pulling.
+      resources:
+        type: object
+        description: |
+          These are standard Kubernetes resources with requests and limits for
+          cpu and memory. They will be used on the containers in the pods
+          pulling images. These should be set extremely low as the containers
+          shut down directly or is a pause container that just idles.
+
+          They were made configurable as usage of ResourceQuota may require
+          containers in the namespace to have explicit resources set.
       hook:
         description: |
           See the [*optimization

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -72,6 +72,8 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          resources:
+            {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
         {{- range $k, $container := .Values.singleuser.profileList }}
         {{- if $container.kubespawner_override }}
         {{- if $container.kubespawner_override.image }}
@@ -81,6 +83,8 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          resources:
+            {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -94,6 +98,8 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          resources:
+            {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
         {{- end }}
         {{- range $k, $v := .Values.prePuller.extraImages }}
         - name: image-pull-{{ $k }}
@@ -105,6 +111,8 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          resources:
+            {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
         {{- end }}
         {{- range $k, $container := .Values.singleuser.extraContainers }}
         - name: image-pull-singleuser-extra-container-{{ $k }}
@@ -116,8 +124,12 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          resources:
+            {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
         {{- end }}
       containers:
         - name: pause
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}
+          resources:
+            {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -350,6 +350,13 @@ scheduling:
 
 prePuller:
   annotations: {}
+  resources:
+    requests:
+      cpu: 0
+      memory: 0
+    limits:
+      cpu: 10m
+      memory: 10Mi
   hook:
     enabled: true
     image:


### PR DESCRIPTION
If a k8s cluster has a LimitRange resource, it may end up for example
allocating 100m CPU for containers which is a waste of resources. This
would be a waste as the running container only does `sh -c "Done!"`
anyhow. While there is image pulling happening, that is done before the
actual container starts so its worth noting we don't need any resources
specified for that.

Another reason for specifying resources, and making them configurable,
is that sometimes there is a ResourceQuota resource that requires the
resources to be explicitly specified on pods.

Related:
- Default CPU requests - https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/
- LimitRange https://kubernetes.io/docs/concepts/policy/limit-range/
- ResourceQuota - https://kubernetes.io/docs/concepts/policy/resource-quotas/

Closes #1761
