### PR TITLE
CI: always publish helm chart on push to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ services:
   - docker
 
 stages:
-  - name: test
   - name: publish
     if: tag IS present OR ( branch IN (master) AND type IN (push) )
+  - name: test
 
 before_install:
   # Exit immediately if a command exits with a non-zero status.

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_install:
   # Exit immediately if a command exits with a non-zero status.
   - set -e
   - . ci/common
+  # NOTE: The latest docker python package (4.3.0) requires a more modern docker
+  #       version (newer than 18.06.0-ce / API version: 1.38) which is not yet
+  #       available on travis.
   - pip install "docker~=4.2.0"
 
 # The default install script below will prepare a k8s cluster to work with, but


### PR DESCRIPTION
This relates to the discussion in https://github.com/jupyterhub/team-compass/issues/317.

We now always publish before running tests as the publishing stage that contains the publishing job is ordered before the test stage. Previously, the test stage could fail and the publishing stage would then never run.

﻿- CI: publish chart before running test
- Docs: add note about why docker version was pinned
