### PR TITLE
Add additional liveness and readiness probe properties

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -232,6 +232,8 @@ spec:
           livenessProbe:
             initialDelaySeconds: {{ .Values.hub.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.hub.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.hub.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.hub.livenessProbe.failureThreshold }}
             httpGet:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
               port: http
@@ -240,6 +242,8 @@ spec:
           readinessProbe:
             initialDelaySeconds: {{ .Values.hub.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.hub.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.hub.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.hub.readinessProbe.failureThreshold }}
             httpGet:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
               port: http

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -90,10 +90,14 @@ hub:
     enabled: false
     initialDelaySeconds: 60
     periodSeconds: 10
+    failureThreshold: 3
+    timeoutSeconds: 1
   readinessProbe:
     enabled: true
     initialDelaySeconds: 0
     periodSeconds: 2
+    failureThreshold: 3
+    timeoutSeconds: 1
   # existingSecret: existing-secret
 
 rbac:


### PR DESCRIPTION
This allows one to set failureThreshold and timeoutSeconds for the hub probes.

Related: #1732