### PR TITLE
CI: Add test for singleuser.extraEnv

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -68,6 +68,11 @@ singleuser:
             cidr: 104.28.9.110/32       # jupyter.org 1
         - ipBlock:
             cidr: 104.28.8.110/32       # jupyter.org 2
+  extraEnv:
+    TEST_ENV_FIELDREF_TO_NAMESPACE:
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
 
 prePuller:
   hook:


### PR DESCRIPTION
I had not tested the Z2JH + KubeSpawner integration e2e of the singleuser.extraEnv but relied on template rendering tests for hub.extraEnv and a unit test in KubeSpawner. This addition ensures end to end functionality of singleuser.extraEnv.﻿
