### PR TITLE
Remove memory / cpu limits for pre-puller

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -358,9 +358,6 @@ prePuller:
     requests:
       cpu: 0
       memory: 0
-    limits:
-      cpu: 10m
-      memory: 10Mi
   hook:
     enabled: true
     image:


### PR DESCRIPTION
This memory limit seems to include pod overhead, which
can be variable based on cluster config. In my cluster (AKS)
with Calico enabled, the memory limit was too low and kept
crashing these pods with very weird reasons - the usual
reasons aren't reported since it's not *our* process that
is causing OOM kills, but the cluster's overhead.

By removing the default resource limits, we prevent thi
from being a problem. Theoretically this would let the pods
have unbounded memory - but since we control the contents,
it wouldn't be the case.

We leave the explicit default requests be, for reasons
outlined in
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1764.
The capacity for admins to specify their own limits is
still in place, in case you want that for your cluster.