### PR TITLE
user-scheduler: tweak modern configuration

### DIFF
--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -22,8 +22,10 @@ data:
           {{- else }}
           score:
             disabled:
+              - name: ImageLocality
               - name: NodeResourcesLeastAllocated
               - name: NodeResourcesBalancedAllocation
+              - name: SelectorSpread
             enabled:
               - name: NodeResourcesMostAllocated
           {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -17,18 +17,7 @@ data:
     profiles:
       - schedulerName: {{ .Release.Name }}-user-scheduler
         plugins:
-          {{- if .Values.scheduling.userScheduler.plugins }}
           {{- .Values.scheduling.userScheduler.plugins | toYaml | trimSuffix "\n" | nindent 10 }}
-          {{- else }}
-          score:
-            disabled:
-              - name: ImageLocality
-              - name: NodeResourcesLeastAllocated
-              - name: NodeResourcesBalancedAllocation
-              - name: SelectorSpread
-            enabled:
-              - name: NodeResourcesMostAllocated
-          {{- end }}
 
   {{- $defaultPolicy := .Files.Get "files/userscheduler-defaultpolicy.yaml" | fromYaml }}
   policy.cfg: {{ .Values.scheduling.userScheduler.policy | default $defaultPolicy | toJson | quote }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -316,7 +316,15 @@ scheduling:
     enabled: true
     replicas: 2
     logLevel: 4
-    plugins: {}
+    plugins:
+      score:
+        disabled:
+          - name: ImageLocality
+          - name: NodeResourcesLeastAllocated
+          - name: NodeResourcesBalancedAllocation
+          - name: SelectorSpread
+        enabled:
+          - name: NodeResourcesMostAllocated
     image:
       name: k8s.gcr.io/kube-scheduler
       tag: v1.19.1


### PR DESCRIPTION
This is a followup on #1778 which didn't ensure that pods are scheduled on the most used node correctly because there were some remnant competing logic. This PR disables the competition that makes sense to give lower priority to than the `NodeResourcesMostAllocated` critiera.

See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1778#issuecomment-696079664 for a discussion on this PR.

As this PR is a complementary fix to #1778 recently merged, I'll go ahead and merge this directly if tests succeeds.﻿
