### PR TITLE
enable .Values.proxy.extraEnv

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -474,21 +474,43 @@ properties:
           both to itself and to user pods.
         properties:
           extraEnv:
-            type: array
+            type: object
             description: |
-              Provide extra environment variables to the chp pod. Can be provided as an array or
-              as an object.
-              
-              as an array:
+              Extra environment variables that should be set for the chp pod.
+
+              Environment variables are usually used here to:
+                - override HUB_SERVICE_PORT or HUB_SERVICE_HOST default values
+                - set CONFIGPROXY_SSL_KEY_PASSPHRASE for setting passphrase of SSL keys
+
+              String literals with `$(ENV_VAR_NAME)` will be expanded by Kubelet which
+              is a part of Kubernetes.
+
               ```yaml
-                - name: MY_ENVVAR
-                  value: MY_ENVVAR_VALUE
+              proxy:
+                chp:
+                  extraEnv:
+                    # basic notation (for literal values only)
+                    MY_ENV_VARS_NAME1: "my env var value 1"
+
+                    # explicit notation (the "name" field takes precedence)
+                    CHP_NAMESPACE:
+                      name: CHP_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+
+                    # implicit notation (the "name" field is implied)
+                    PREFIXED_CHP_NAMESPACE:
+                      value: "my-prefix-$(CHP_NAMESPACE)"
+                    SECRET_VALUE:
+                      valueFrom:
+                        secretKeyRef:
+                          name: my-k8s-secret
+                          key: password
               ```
 
-              as an object:
-              ```yaml
-                MY_ENVVAR: MY_ENVVAR_VALUE
-              ```
+              For more information, see the [Kubernetes EnvVar
+              specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
       secretToken:
         type: string
         description: |
@@ -677,21 +699,41 @@ properties:
           Configure the traefik proxy used to terminate TLS when 'autohttps' is enabled
         properties:
           extraEnv:
-            type: array
+            type: object
             description: |
-              Provide extra environment variables to the traefik pod. Can be provided as an array or
-              as an object.
-              
-              as an array:
+              Extra environment variables that should be set for the traefik pod.
+
+              Environment Variables here may be used to configure traefik.
+
+              String literals with `$(ENV_VAR_NAME)` will be expanded by Kubelet which
+              is a part of Kubernetes.
+
               ```yaml
-                - name: MY_ENVVAR
-                  value: MY_ENVVAR_VALUE
+              proxy:
+                traefik:
+                  extraEnv:
+                    # basic notation (for literal values only)
+                    MY_ENV_VARS_NAME1: "my env var value 1"
+
+                    # explicit notation (the "name" field takes precedence)
+                    TRAEFIK_NAMESPACE:
+                      name: TRAEFIK_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+
+                    # implicit notation (the "name" field is implied)
+                    PREFIXED_TRAEFIK_NAMESPACE:
+                      value: "my-prefix-$(TRAEFIK_NAMESPACE)"
+                    SECRET_VALUE:
+                      valueFrom:
+                        secretKeyRef:
+                          name: my-k8s-secret
+                          key: password
               ```
 
-              as an object:
-              ```yaml
-                MY_ENVVAR: MY_ENVVAR_VALUE
-              ```
+              For more information, see the [Kubernetes EnvVar
+              specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
     required:
       - secretToken
   auth:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -467,6 +467,28 @@ properties:
   proxy:
     type: object
     properties:
+      chp:
+        type: object
+        description: |
+          Configure the configurable-http-proxy (chp) pod managed by jupyterhub to route traffic
+          both to itself and to user pods.
+        properties:
+          extraEnv:
+            type: array
+            description: |
+              Provide extra environment variables to the chp pod. Can be provided as an array or
+              as an object.
+              
+              as an array:
+              ```yaml
+                - name: MY_ENVVAR
+                  value: MY_ENVVAR_VALUE
+              ```
+
+              as an object:
+              ```yaml
+                MY_ENVVAR: MY_ENVVAR_VALUE
+              ```
       secretToken:
         type: string
         description: |
@@ -649,6 +671,27 @@ properties:
             type: integer
             description: |
               Minimum number of pods to be available during the voluntary disruptions.
+      traefik:
+        type: object
+        description: |
+          Configure the traefik proxy used to terminate TLS when 'autohttps' is enabled
+        properties:
+          extraEnv:
+            type: array
+            description: |
+              Provide extra environment variables to the traefik pod. Can be provided as an array or
+              as an object.
+              
+              as an array:
+              ```yaml
+                - name: MY_ENVVAR
+                  value: MY_ENVVAR_VALUE
+              ```
+
+              as an object:
+              ```yaml
+                MY_ENVVAR: MY_ENVVAR_VALUE
+              ```
     required:
       - secretToken
   auth:

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -56,6 +56,7 @@ spec:
         # We need this to get logs immediately
         - name: PYTHONUNBUFFERED
           value: "True"
+        {{- include "jupyterhub.extraEnv" .Values.proxy.traefik.extraEnv | nindent 8 }}
         volumeMounts:
           - name: certificates
             mountPath: /etc/acme

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -98,6 +98,7 @@ spec:
                   name: hub-secret
                   {{- end }}
                   key: proxy.token
+            {{- include "jupyterhub.extraEnv" .Values.proxy.extraEnv | nindent 12 }}
           {{- with .Values.proxy.chp.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -98,7 +98,7 @@ spec:
                   name: hub-secret
                   {{- end }}
                   key: proxy.token
-            {{- include "jupyterhub.extraEnv" .Values.proxy.extraEnv | nindent 12 }}
+            {{- include "jupyterhub.extraEnv" .Values.proxy.chp.extraEnv | nindent 12 }}
           {{- with .Values.proxy.chp.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -159,7 +159,7 @@ proxy:
       requests:
         cpu: 200m
         memory: 512Mi
-    extraEnv: []
+    extraEnv: {}
   traefik:
     image:
       name: traefik
@@ -169,7 +169,7 @@ proxy:
       preload: false
       maxAge: 15724800 # About 6 months
     resources: {}
-    extraEnv: []
+    extraEnv: {}
     extraVolumes: []
     extraVolumeMounts: []
     extraStaticConfig: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -159,6 +159,7 @@ proxy:
       requests:
         cpu: 200m
         memory: 512Mi
+    extraEnv: []
   traefik:
     image:
       name: traefik


### PR DESCRIPTION
the values.yaml implies that this option is available, but it is not. this change adds the template to the proxy deployment so `.Values.proxy.extraEnv` is available