### PR TITLE
Relax hook-image-puller to make upgrades more reliable

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -363,7 +363,7 @@ prePuller:
     image:
       name: jupyterhub/k8s-image-awaiter
       tag: 'set-by-chartpress'
-    podSchedulingWaitDuration: -1
+    podSchedulingWaitDuration: 10
   continuous:
     enabled: true
   extraImages: {}


### PR DESCRIPTION
This configuration makes the hook-image-awaiter start comparing the
number of scheduled image-puller pods with the number of ready
image-puller pods, instead of comparing the number of desired
image-puller pods with the ready number of image-puller pods, after a
duration of 10 seconds.

This helps anyone using the hook-image-puller to avoid failures
of running `helm upgrade` that can happen if a node is full packed with
pods and no more pods can be scheduled on it, because then the
image-awaiter would get stuck waiting forever on an image pulling pod
that never successfully schedules to do the actual pulling.

---

@yuvipanda I merged #1763 and created this as a followup to the review comment https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1763#discussion_r493209514 about sticking with the existing behavior until its been tested a while.