### PR TITLE
Fix legacy version in DigitalOcean Kubernetes setup doc

### DIFF
--- a/doc/source/digital-ocean/step-zero-digital-ocean.rst
+++ b/doc/source/digital-ocean/step-zero-digital-ocean.rst
@@ -35,7 +35,7 @@ If you prefer to use the Digital Ocean portal see the `Digital Ocean Get Started
    .. code-block:: bash
 
       export DIGITALOCEAN_ENABLE_BETA=1
-      doctl k8s cluster create jupyter-kubernetes --region lon1 --version 1.12.1-do.2 --node-pool="name=worker-pool;count=3
+      doctl k8s cluster create jupyter-kubernetes --region lon1 --version 1.18.8-do.0 --node-pool="name=worker-pool;count=3"
 
 #. Export your cluster config.
    You can change the default location from $HOME/.kube by setting the KUBECONFIG environment variable.


### PR DESCRIPTION
In the [Kubernetes on Digital Ocean](https://zero-to-jupyterhub.readthedocs.io/en/latest/digital-ocean/step-zero-digital-ocean.html) doc page, there are two minor issues.

![image](https://user-images.githubusercontent.com/1064036/94336019-6bb60880-ffa5-11ea-90e7-b9cec01d665a.png)

The `doctl k8s cluster create` command is using an outdated Kubernetes version. Using `1.12.1-do.2` throws a 422 validation error.<br />
![image](https://user-images.githubusercontent.com/1064036/94336043-9a33e380-ffa5-11ea-8ad4-73cadd9aeffd.png)
![image](https://user-images.githubusercontent.com/1064036/94336045-9c963d80-ffa5-11ea-96c5-8cf165d07680.png)

When creating a Kubernetes cluster through Digital Ocean's dashboard, only versions 1.16.14 and up seem to be supported.
![image](https://user-images.githubusercontent.com/1064036/94336034-84262300-ffa5-11ea-8e23-a1a0d386f86e.png)

I've replaced the legacy version with latest `1.18.8-do.0`.
<br />
The `doctl k8s cluster create` command is also missing a double quote at the end. I've added the missing double quote.

Confirmed by testing in Ubuntu 20.04:
![image](https://user-images.githubusercontent.com/1064036/94336137-5097c880-ffa6-11ea-8584-b714a0eff4a3.png)

