### PR TITLE
values: rename rbac.enabled to rbac.create

### DIFF
--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -37,6 +37,10 @@ enable pod priority or stop using the user placeholders to avoid wasting cloud
 resources.
 {{- end }}
 
+{{- if eq (.Values.rbac.enabled | default true) false }}
+{{ fail "DEPRECATION: rbac.enabled has been renamed to rbac.create" }}
+{{- end }}
+
 {{- if hasKey .Values.hub "uid" }}
 
 DEPRECATION: hub.uid is deprecated in jupyterhub chart 0.9. Set the hub.containerSecurityContext.runAsUser value

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -12,7 +12,7 @@
 
   When you ask a helper to render its content, one often forward the current
   scope to the helper in order to allow it to access .Release.Name,
-  .Values.rbac.enabled and similar values.
+  .Values.rbac.create and similar values.
 
   #### Example - Passing the current scope
   {{ include "jupyterhub.commonLabels" . }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           persistentVolumeClaim:
             claimName: hub-db-dir
         {{- end }}
-      {{- if .Values.rbac.enabled }}
+      {{- if .Values.rbac.create }}
       serviceAccountName: hub
       {{- end }}
       securityContext:

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
     spec:
       restartPolicy: Never
-      {{- if .Values.rbac.enabled }}
+      {{- if .Values.rbac.create }}
       serviceAccountName: hook-image-awaiter
       {{- end }}
       containers:

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -2,7 +2,7 @@
 Permissions to be used by the hook-image-awaiter job
 */}}
 {{- if .Values.prePuller.hook.enabled }}
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.create }}
 {{- /*
 This service account...
 */ -}}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         # entrypoint of all network traffic.
         checksum/static-config: {{ include "jupyterhub.traefik.yaml" . | fromYaml | merge .Values.proxy.traefik.extraStaticConfig | toYaml | sha256sum }}
     spec:
-      {{- if .Values.rbac.enabled }}
+      {{- if .Values.rbac.create }}
       serviceAccountName: autohttps
       {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -1,6 +1,6 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
-{{- if (and $autoHTTPS .Values.rbac.enabled) -}}
+{{- if (and $autoHTTPS .Values.rbac.create) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.rbac.enabled }}
+      {{- if .Values.rbac.create }}
       serviceAccountName: user-scheduler
       {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -101,7 +101,7 @@ hub:
   # existingSecret: existing-secret
 
 rbac:
-  enabled: true
+  create: true
 
 
 proxy:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -68,7 +68,7 @@ hub:
 
 
 rbac:
-  enabled: true
+  create: true
 
 
 proxy:


### PR DESCRIPTION
This is a breaking change for anyone having rbac.enabled set to false. The reason to rename this is only to align with other Helm charts' conventions.

It is very possible to add logic to make this a non-breaking change, my experience with the GitLab Helm chart makes me love these clear "fix this" messages during upgrades before anything has actually changes though, so I like the idea of instead doing that and not cluttering the Helm template logic.

This PR is not at all important, but it feels good to align with other Helm charts.

Closes #921, and closes #616