### PR TITLE
Set container securityContext by default

### DIFF
--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -20,23 +20,25 @@ Note that this is still an alpha release! If you have questions, feel free to
   3. File issues at https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues
 
 
-{{- if hasKey .Values.singleuser.cloudMetadata "enabled" }}
-
+{{- if hasKey .Values.singleuser.cloudMetadata "enabled" }}{{ println }}
 DEPRECATION: singleuser.cloudMetadata.enabled is deprecated, instead use singleuser.cloudMetadata.blockWithIptables with the inverted value.
 {{- end }}
 
 
 {{- /* Warn about an attempt to configure HTTPS but not having enabled it. */}}
 {{- if eq .Values.proxy.https.enabled false }}
-{{- if or (not (eq .Values.proxy.https.type "letsencrypt")) (not (eq .Values.proxy.https.letsencrypt.contactEmail "")) }}
-
+{{- if or (not (eq .Values.proxy.https.type "letsencrypt")) (not (eq .Values.proxy.https.letsencrypt.contactEmail "")) }}{{ println }}
 WARNING: Configuring proxy.https without setting proxy.https.enabled to true is no longer allowed.
 {{- end }}
 {{- end }}
 
 
-{{- if .Values.hub.extraConfigMap }}
+{{- if .Values.proxy.containerSecurityContext }}
+{{- fail "DEPRECATION: proxy.containerSecurityContext has been renamed to proxy.chp.containerSecurityContext" }}
+{{- end }}
 
+
+{{- if .Values.hub.extraConfigMap }}{{ println }}
 DEPRECATION: hub.extraConfigMap is deprecated in jupyterhub chart 0.8.
 Use top-level `custom` instead:
 
@@ -53,9 +55,8 @@ enable pod priority or stop using the user placeholders to avoid wasting cloud
 resources.
 {{- end }}
 
-{{- if hasKey .Values.hub "uid" }}
 
+{{- if hasKey .Values.hub "uid" }}{{ println }}
 DEPRECATION: hub.uid is deprecated in jupyterhub chart 0.9. Set the hub.containerSecurityContext.runAsUser value
 directly instead.
-
 {{- end }}

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -69,6 +69,7 @@ spec:
         {{ end }}
       {{- end }}
       initContainers:
+        {{- /* --- Pull default image --- */}}
         - name: image-pull-singleuser
           image: {{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}
           {{- with .Values.singleuser.image.pullPolicy }}
@@ -80,6 +81,8 @@ spec:
             - echo "Pulling complete"
           resources:
             {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+
+        {{- /* --- Pull extra containers' images --- */}}
         {{- range $k, $container := .Values.singleuser.extraContainers }}
         - name: image-pull-singleuser-extra-container-{{ $k }}
           image: {{ $container.image }}
@@ -92,7 +95,13 @@ spec:
             - echo "Pulling complete"
           resources:
             {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- with $.Values.prePuller.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
         {{- end }}
+
+        {{- /* --- Conditionally pull profileList images --- */}}
         {{- if .Values.prePuller.pullProfileListImages }}
         {{- range $k, $container := .Values.singleuser.profileList }}
         {{- if $container.kubespawner_override }}
@@ -105,10 +114,16 @@ spec:
             - echo "Pulling complete"
           resources:
             {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- with $.Values.prePuller.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
+
+        {{- /* --- Pull extra images --- */}}
         {{- range $k, $v := .Values.prePuller.extraImages }}
         - name: image-pull-{{ $k }}
           image: {{ $v.name }}:{{ $v.tag }}
@@ -121,10 +136,18 @@ spec:
             - echo "Pulling complete"
           resources:
             {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- with $.Values.prePuller.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
         {{- end }}
       containers:
         - name: pause
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}
           resources:
             {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- with .Values.prePuller.pause.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -44,4 +44,8 @@ spec:
             - -namespace={{ .Release.Namespace }}
             - -daemonset=hook-image-puller
             - -pod-scheduling-wait-duration={{ .Values.prePuller.hook.podSchedulingWaitDuration }}
+          {{- with .Values.prePuller.hook.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/_configmap-traefik.yaml
+++ b/jupyterhub/templates/proxy/autohttps/_configmap-traefik.yaml
@@ -42,11 +42,11 @@ entryPoints:
   # - ACME HTTP-01 challenges
   # - Redirects to HTTPS
   http:
-    address: ':80'
+    address: ':8080'
   # Port 443, used for:
   # - TLS Termination Proxy, where HTTPS transitions to HTTP.
   https:
-    address: ':443'
+    address: ':8443'
     # Configure a high idle timeout for our websockets connections
     transport:
       respondingTimeouts:

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -42,24 +42,28 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
       initContainers:
-      - name: load-acme
-        image: "{{ .Values.proxy.secretSync.image.name }}:{{ .Values.proxy.secretSync.image.tag }}"
-        {{- with .Values.proxy.secretSync.image.pullPolicy }}
-        imagePullPolicy: {{ . }}
-        {{- end }}
-        args:
-          - load
-          - proxy-public-tls-acme
-          - acme.json
-          - /etc/acme/acme.json
-        env:
-        # We need this to get logs immediately
-        - name: PYTHONUNBUFFERED
-          value: "True"
-        {{- include "jupyterhub.extraEnv" .Values.proxy.traefik.extraEnv | nindent 8 }}
-        volumeMounts:
-          - name: certificates
-            mountPath: /etc/acme
+        - name: load-acme
+          image: "{{ .Values.proxy.secretSync.image.name }}:{{ .Values.proxy.secretSync.image.tag }}"
+          {{- with .Values.proxy.secretSync.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          args:
+            - load
+            - proxy-public-tls-acme
+            - acme.json
+            - /etc/acme/acme.json
+          env:
+            # We need this to get logs immediately
+            - name: PYTHONUNBUFFERED
+              value: "True"
+            {{- include "jupyterhub.extraEnv" .Values.proxy.traefik.extraEnv | nindent 12 }}
+          volumeMounts:
+            - name: certificates
+              mountPath: /etc/acme
+          {{- with .Values.proxy.secretSync.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
       containers:
         - name: traefik
           image: "{{ .Values.proxy.traefik.image.name }}:{{ .Values.proxy.traefik.image.tag }}"
@@ -110,4 +114,8 @@ spec:
           volumeMounts:
             - name: certificates
               mountPath: /etc/acme
+          {{- with .Values.proxy.secretSync.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -74,9 +74,9 @@ spec:
             {{- .Values.proxy.traefik.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
             - name: https
-              containerPort: 443
+              containerPort: 8443
           volumeMounts:
             - name: traefik-config
               mountPath: /etc/traefik

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -87,10 +87,6 @@ spec:
           {{- end }}
           resources:
             {{- .Values.proxy.chp.resources | toYaml | trimSuffix "\n" | nindent 12 }}
-          {{- with .Values.proxy.containerSecurityContext }}
-          securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
-          {{- end }}
           env:
             - name: CONFIGPROXY_AUTH_TOKEN
               valueFrom:
@@ -141,4 +137,8 @@ spec:
               port: http
               scheme: HTTP
               {{- end }}
+          {{- end }}
+          {{- with .Values.proxy.chp.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -47,4 +47,8 @@ spec:
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}
           resources:
             {{- include "jupyterhub.resources" . | nindent 12 }}
+          {{- with .Values.scheduling.userPlaceholder.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -72,4 +72,8 @@ spec:
               port: 10251
           resources:
             {{- .Values.scheduling.userScheduler.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- with .Values.scheduling.userScheduler.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -55,6 +55,7 @@ hub:
       memory: 512Mi
   containerSecurityContext:
     runAsUser: 1000
+    runAsGroup: 1000
     allowPrivilegeEscalation: false
   services: {}
   imagePullSecret:
@@ -132,8 +133,6 @@ proxy:
     ##     Error: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     ##     Error: UPGRADE FAILED: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     rollingUpdate:
-  containerSecurityContext:
-    allowPrivilegeEscalation: false
   service:
     type: LoadBalancer
     labels: {}
@@ -144,6 +143,10 @@ proxy:
     loadBalancerIP:
     loadBalancerSourceRanges: []
   chp:
+    containerSecurityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      allowPrivilegeEscalation: false
     image:
       name: jupyterhub/configurable-http-proxy
       tag: 4.2.1
@@ -162,6 +165,10 @@ proxy:
         memory: 512Mi
     extraEnv: {}
   traefik:
+    containerSecurityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      allowPrivilegeEscalation: false
     image:
       name: traefik
       tag: v2.3 # ref: https://hub.docker.com/_/traefik?tab=tags
@@ -175,9 +182,11 @@ proxy:
     extraVolumeMounts: []
     extraStaticConfig: {}
     extraDynamicConfig: {}
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
   secretSync:
+    containerSecurityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      allowPrivilegeEscalation: false
     image:
       name: jupyterhub/k8s-secret-sync
       tag: 'set-by-chartpress'
@@ -335,6 +344,10 @@ scheduling:
           - name: SelectorSpread
         enabled:
           - name: NodeResourcesMostAllocated
+    containerSecurityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      allowPrivilegeEscalation: false
     image:
       name: k8s.gcr.io/kube-scheduler
       tag: v1.19.1
@@ -354,6 +367,10 @@ scheduling:
   userPlaceholder:
     enabled: true
     replicas: 0
+    containerSecurityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      allowPrivilegeEscalation: false
   corePods:
     nodeAffinity:
       matchNodePurpose: prefer
@@ -368,17 +385,29 @@ prePuller:
     requests:
       cpu: 0
       memory: 0
+  containerSecurityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    allowPrivilegeEscalation: false
   hook:
     enabled: true
     image:
       name: jupyterhub/k8s-image-awaiter
       tag: 'set-by-chartpress'
+    containerSecurityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      allowPrivilegeEscalation: false
     podSchedulingWaitDuration: 10
   continuous:
     enabled: true
   pullProfileListImages: true
   extraImages: {}
   pause:
+    containerSecurityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      allowPrivilegeEscalation: false
     image:
       name: k8s.gcr.io/pause
       # Pick version from https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/pause?gcrImageListsize=30

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -144,8 +144,8 @@ proxy:
     loadBalancerSourceRanges: []
   chp:
     containerSecurityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
+      runAsUser: 65534  # nobody user
+      runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
       name: jupyterhub/configurable-http-proxy
@@ -166,8 +166,8 @@ proxy:
     extraEnv: {}
   traefik:
     containerSecurityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
+      runAsUser: 65534  # nobody user
+      runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
       name: traefik
@@ -184,8 +184,8 @@ proxy:
     extraDynamicConfig: {}
   secretSync:
     containerSecurityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
+      runAsUser: 65534  # nobody user
+      runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
       name: jupyterhub/k8s-secret-sync
@@ -345,8 +345,8 @@ scheduling:
         enabled:
           - name: NodeResourcesMostAllocated
     containerSecurityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
+      runAsUser: 65534  # nobody user
+      runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
       name: k8s.gcr.io/kube-scheduler
@@ -368,8 +368,8 @@ scheduling:
     enabled: true
     replicas: 0
     containerSecurityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
+      runAsUser: 65534  # nobody user
+      runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
   corePods:
     nodeAffinity:
@@ -386,8 +386,8 @@ prePuller:
       cpu: 0
       memory: 0
   containerSecurityContext:
-    runAsUser: 65534
-    runAsGroup: 65534
+    runAsUser: 65534  # nobody user
+    runAsGroup: 65534 # nobody group
     allowPrivilegeEscalation: false
   hook:
     enabled: true
@@ -395,8 +395,8 @@ prePuller:
       name: jupyterhub/k8s-image-awaiter
       tag: 'set-by-chartpress'
     containerSecurityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
+      runAsUser: 65534  # nobody user
+      runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     podSchedulingWaitDuration: 10
   continuous:
@@ -405,8 +405,8 @@ prePuller:
   extraImages: {}
   pause:
     containerSecurityContext:
-      runAsUser: 65534
-      runAsGroup: 65534
+      runAsUser: 65534  # nobody user
+      runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
       name: k8s.gcr.io/pause


### PR DESCRIPTION
This can help us avoid usage of root by default which can cause clusters with [PodSecurityPolicy resources](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) to stop the Helm chart from functioning.

In practice, what I do in this PR is to create Helm chart configuration to set all Pod's containers' `securityContext`, and let this configuration default to have a securityContext like this be injected to all of our managed containers within the pods.

```yaml
# some of our k8s Deployment resources
spec:
  template:
    spec:
      containers:
        - image: ...
          # ...
          securityContext:
            runAsUser: 65534
            runAsGroup: 65534
            allowPrivilegeEscalation: false
```

A securityContext of a pod with a `runAsUser` directive will force the container to startup as that user instead of the default: `root`. This can add another layer of security to by letting the containers we run not end up escalating privileges and ending up abusing some k8s vulnerability to do harmful stuff.

Fixes #1386, but not #1408.

## singleuser.containerSecurityContext ?

This PR does not add `singleuser.containerSecurityContext`, yet, because it is quite a bit more complicated at the moment. KubeSpawner expose some configuration that in the end goes into either the pod's securityContext or the container's securityContext. Here is an overview.

KubeSpawner.* | [PodSecurityContex](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core) | [SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core)
-|-|-
`fs_gid` | `fsGroup` | -
`supplemental_gids` | `supplementalGroups` | -
`run_as_uid` | - | `runAsUser`
`run_as_gid` | - | `runAsGroup`
`privileged` | - | `privileged`

## Breaking change
- `proxy.containerSecurityContex` has been renamed to `proxy.chp.containerSecurityContex`

---

I deem that this can be said to close #937 good enough, but only properly by setting `singleuser.cloudMetadata.blockWithIptables: false`.

Closes #1491, Closes #1677