### PR TITLE
Added a security context to run as non-root user.

### DIFF
--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -47,4 +47,6 @@ spec:
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}
           resources:
             {{- include "jupyterhub.resources" . | nindent 12 }}
+      securityContext:
+        runAsUser: 1000
 {{- end }}


### PR DESCRIPTION
Hello Everyone,

As discussed on the forum with @manics, raising a PR for fixing the security context of the `user-placeholder` pods.

This is my first of many (hopefully) PR on an OSS project. Do let me know in case I missed something.

Regards,
Nachiket