### PR TITLE
Match initialDelaySeconds for all hub probes

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -94,7 +94,7 @@ hub:
     timeoutSeconds: 1
   readinessProbe:
     enabled: true
-    initialDelaySeconds: 0
+    initialDelaySeconds: 60
     periodSeconds: 2
     failureThreshold: 3
     timeoutSeconds: 1


### PR DESCRIPTION
Right now, k8s starts checking if the hub is up as soon
as it starts. If the hub isn't fully up in about 10s,
it *restarts the hub*, which then has top start initializing
all over again! If you're lucky, the hub will actually be
able to finish initializing before CrashLoopBackoff, but
very easy to be stuck in CrashLoopBackoff with even a moderately
large hub.