### PR TITLE
hub livenessProbe: bump from 1m to 3m delay before probes are sent

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -88,7 +88,7 @@ hub:
   templateVars: {}
   livenessProbe:
     enabled: false
-    initialDelaySeconds: 60
+    initialDelaySeconds: 180
     periodSeconds: 10
     failureThreshold: 3
     timeoutSeconds: 1


### PR DESCRIPTION
Closes #1800, this is a very safe change to make I think.