### PR TITLE
deprecation: warn when proxy.https is modified and proxy.https.enabled=true

### DIFF
--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -25,6 +25,16 @@ DEPRECATION: singleuser.cloudMetadata.enabled is deprecated, instead of singleus
 
 {{- end }}
 
+
+{{- /* Warn about an attempt to configure HTTPS but not having enabled it. */ }}
+{{- if eq .Values.proxy.https.enabled false }}
+{{- if or (not (eq .Values.proxy.https.type "letsencrypt")) (not (eq .Values.proxy.https.letsencrypt.contactEmail "")) }}
+
+WARNING: Configuring proxy.https without setting proxy.https.enabled to true is no longer allowed.
+{{- end }}
+{{- end }}
+
+
 {{- if .Values.hub.extraConfigMap }}
 
 DEPRECATION: hub.extraConfigMap is deprecated in jupyterhub chart 0.8.

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -19,10 +19,10 @@ Note that this is still an alpha release! If you have questions, feel free to
   2. Chat with us at https://gitter.im/jupyterhub/jupyterhub
   3. File issues at https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues
 
+
 {{- if hasKey .Values.singleuser.cloudMetadata "enabled" }}
 
-DEPRECATION: singleuser.cloudMetadata.enabled is deprecated, instead of singleuser.cloudMetadata.blockWithIptables
-
+DEPRECATION: singleuser.cloudMetadata.enabled is deprecated, instead use singleuser.cloudMetadata.blockWithIptables with the inverted value.
 {{- end }}
 
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -26,7 +26,7 @@ DEPRECATION: singleuser.cloudMetadata.enabled is deprecated, instead use singleu
 {{- end }}
 
 
-{{- /* Warn about an attempt to configure HTTPS but not having enabled it. */ }}
+{{- /* Warn about an attempt to configure HTTPS but not having enabled it. */}}
 {{- if eq .Values.proxy.https.enabled false }}
 {{- if or (not (eq .Values.proxy.https.type "letsencrypt")) (not (eq .Values.proxy.https.letsencrypt.contactEmail "")) }}
 


### PR DESCRIPTION
## Update

I'm making this PR to emit a warning instead of forcing the template rendering to `fail` as part of `helm upgrade` or `helm install`.

## Original PR

This checks for attempts to configure proxy.https without explicitly setting proxy.https.enable to true, and if so, let the template rendering fail. This is meant to help users that configured https retain the expected functionality by forcing them to use the configuration that is required to maintain such functionality.

The default value was changed in #1758.

This PR implements the idea in #1806 and thereby closes #1806.

---

In this PR I included a commit fixing a warning in our CI system.