### PR TITLE
Fix same functionality for proxy.traefik.extraEnv as other extraEnv

### DIFF
--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -83,7 +83,7 @@ spec:
             {{- end }}
           {{- with .Values.proxy.traefik.extraEnv }}
           env:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- include "jupyterhub.extraEnv" . | nindent 12 }}
           {{- end }}
           {{- with .Values.proxy.traefik.containerSecurityContext }}
           securityContext:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -95,6 +95,9 @@ proxy:
       limits:
         cpu: 200m
         memory: 1Gi
+    extraEnv:
+      - name: LEGO_CA_CERTIFICATES
+        value: /etc/pebble/root-cert.pem
   secretSync:
     resources:
       requests:


### PR DESCRIPTION
This is a remnant change following #1757 to ensure all of our extraEnv configuration support the same syntax.