### PR TITLE
Offloaded HTTPS: Redirect HTTP port traffic to HTTPS

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $manualHTTPS := and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual") -}}
 {{- $manualHTTPSwithsecret := and .Values.proxy.https.enabled (eq .Values.proxy.https.type "secret") -}}
+{{- $offloadHTTPS := and .Values.proxy.https.enabled (eq .Values.proxy.https.type "offload") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,6 +71,10 @@ spec:
             - --redirect-to=443
             - --ssl-key=/etc/chp/tls/{{ .Values.proxy.https.secret.key }}
             - --ssl-cert=/etc/chp/tls/{{ .Values.proxy.https.secret.crt }}
+            {{- else if $offloadHTTPS }}
+            - --port=8443
+            - --redirect-port=8000
+            - --redirect-to=443
             {{- else }}
             - --port=8000
             {{- end }}
@@ -103,7 +108,7 @@ spec:
           imagePullPolicy: {{ . }}
           {{- end }}
           ports:
-            {{- if or $manualHTTPS $manualHTTPSwithsecret }}
+            {{- if or (or $manualHTTPS $manualHTTPSwithsecret) $offloadHTTPS }}
             - name: https
               containerPort: 8443
             {{- end }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -45,14 +45,7 @@ spec:
     {{- if $HTTPS }}
     - name: https
       port: 443
-      # When HTTPS termination is handled outside our helm chart, pass traffic
-      # coming in via this Service's port 443 to targeted pod's port meant for
-      # HTTP traffic.
-      {{- if $offloadHTTPS }}
-      targetPort: http
-      {{- else }}
       targetPort: https
-      {{- end }}
       {{- with .Values.proxy.service.nodePorts.https }}
       nodePort: {{ . }}
       {{- end }}


### PR DESCRIPTION
# Summary

In #1190 the question was raised if there was a way for this Helm chart to take care of HTTP -> HTTPS redirections when `proxy.https.type=offload`. I concluded that _this was possible in theory_, but would _require some changes_ because currently we mash all incoming traffic on port 80 and 443 to port 8000 on the CHP pod, and then we can't rely on the ports to know how to redirect.

We don't have CI tests for this, and I have never worked with a `proxy.https.type=offload` deployment, so I'd really love for someone with experience with those to contribute with a review.

Closes #1190.

# Exploratory notes

I'm not sure if we can do this redirect, all traffic in the application goes through the proxy-public k8s service, and if we have configured offloading the HTTPS part, then the proxy-public service will go to the pod named `proxy` and run the ConfigurableHTTPProxy (CHP) NodeJS server running outside and separate to the `hub` pod, so perhaps that can be configured to send out a 301 redirect on HTTP traffic.

In the CHP changelog i found [indication of this would be possible](https://github.com/jupyterhub/configurable-http-proxy/blob/764b891203b0467c790c644de8a23892ee794f55/CHANGELOG.md#410---2019-04-01).

In the CHP readme I found confirmation of this would be possible:

```
  --redirect-port <redirect-port>    Redirect HTTP requests on this port to the server on HTTPS
  --redirect-to <port>               Redirect HTTP requests from --redirect-port to this port
  --auto-rewrite                     Rewrite the Location header host/port in redirect responses
  --protocol-rewrite <proto>         Rewrite the Location header protocol in redirect responses to the specified protocol
```

In the configuration of the CHP pod I found the configuration was determined like this:

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/a2c3ef80932d4ae45cde562823c76155ccfc8897/jupyterhub/templates/proxy/deployment.yaml#L52-L78

But there is a crux now that I think of it, and that is that if all traffic arriving to the CHP server is either originally HTTP, or originally HTTPS decrypted and now HTTP, this still requires the traffic to arrive to different ports, because if not, this logic would just redirect even the HTTPS traffic that has been redirected already.

## Networking investigation
How does traffic flow to the CHP server within Kubernetes?

We need to consider the `proxy-public` Service, and the Pod, assuming `proxy.https.type=offload`.

1. the Service's (redirecting traffic to the pod) `port` and `targetPort` redirections
2. the Pod's container's port definitions, describing named Pod->Container port redirection

### 1 - `proxy-public` Service -> CHP Pod
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/a2c3ef80932d4ae45cde562823c76155ccfc8897/jupyterhub/templates/proxy/service.yaml#L44-L65

### 2 - CHP Pod -> CHP container
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/a2c3ef80932d4ae45cde562823c76155ccfc8897/jupyterhub/templates/proxy/deployment.yaml#L105-L113

### Conclusion
Traffic arriving to both the entrypoint of the Helm chart, the proxy-public service, at either the `443` port and `80` port, when the chart is configured with `proxy.https.type=offload` is redirecting traffic to the port name `http`, which is port 8000. Due to this, we cannot configure CHP with flags to redirect HTTP to HTTPS, because all traffic is the same port-wise.

### Solution idea - PR needed
The gist is to ensure, when proxy.https.type=offload, that we have a network route of traffic that is decrypted HTTPS separate from a network route that is original HTTP traffic, where the decrypted HTTPS traffic flow under the 443 or 8443 ports, and the original HTTP traffic flow under the 80 or 8000 ports.
- [x] To open the `https` named port `8443` on the CHP pod.
- [x] To not redirect both `https` port traffic and `http` port traffic to the same CHP pod port in the `proxy-public` service, but let `https/443` map to `https/8443`, and `http/80` map to `http/8000`.
- [x] To configure CHP using command line flags to redirect port `http/8000` to a location which is the same, but with the HTTPS scheme.

This change is a bit sensitive, because we don't have a CI system to verify we don't break functionality for those with `proxy.https.type=offload` configurations. I think the change makes a lot of sense, but since its theory all the way rather than based on practical experience if I would create this PR, it would be really good to have feedback from those with offload deployments already running.

# Review considerations
Assuming `proxy.https.type=offload`, what happens if...

- [x] Another pod sends traffic to the internal service IP and `$PROXY_PUBLIC_SERVICE_PORT`? I think nothing would change, instead of traffic going through the k8s Service port 443 to the Pods port 8000 it goes to the Pods port 8443.
- [x] Another pod sends traffic to the internal service IP and `$PROXY_PUBLIC_SERVICE_HTTP_PORT`? I think this will mean a redirect is added, and assuming the sender tried to send HTTPS traffic it will fail because the actual TLS termination is further out, so unless CHP is configured to know its public URL, it won't be able to redirect to itself properly when working internally. I think this is okay.
- [x] What was the original intent of having a `proxy.https.type=offload` configuration? What does it do? I think the answer is that it simply accepts HTTP traffic on another port in the Service (443). But, what was that meant to accomplish? Is it a workaround for logic outside the Helm chart, or for logic within the Helm chart?