### PR TITLE
userScheduler: only render associated PDB resource if userScheduler itself is enabled

### DIFF
--- a/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scheduling.userScheduler.pdb.enabled -}}
+{{- if and .Values.scheduling.userScheduler.enabled .Values.scheduling.userScheduler.pdb.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
Closes #1282 - thank you @rokroskar for reporting this!