### PR TITLE
Added config option: proxy.chp.extraCommandLineFlags

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -473,6 +473,26 @@ properties:
           Configure the configurable-http-proxy (chp) pod managed by jupyterhub to route traffic
           both to itself and to user pods.
         properties:
+          extraCommandLineFlags:
+            type: list
+            description: |
+              A list of strings to be added as command line options when
+              starting
+              [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy#command-line-options)
+              that will be expanded with Helm's template function `tpl` which
+              can render Helm template logic inside curly braces (`{{ ... }}`).
+
+              ```yaml
+              proxy:
+                chp:
+                  extraCommandLineFlags:
+                    - "--auto-rewrite"
+                    - "--custom-header {{ .Values.myCustomStuff }}"
+              ```
+
+              Note that these will be appended last, and if you provide the same
+              flag twice, the last flag will be used, which mean you can
+              override the default flag values as well.
           extraEnv:
             type: object
             description: |

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -76,6 +76,9 @@ spec:
             {{- if .Values.debug.enabled }}
             - --log-level=debug
             {{- end }}
+            {{- range .Values.proxy.chp.extraCommandLineFlags }}
+            - {{ tpl . $ }}
+            {{- end }}
           {{- if or $manualHTTPS $manualHTTPSwithsecret }}
           volumeMounts:
             - name: tls-secret

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -147,6 +147,7 @@ proxy:
     image:
       name: jupyterhub/configurable-http-proxy
       tag: 4.2.1
+    extraCommandLineFlags: []
     livenessProbe:
       enabled: true
       initialDelaySeconds: 60

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -83,6 +83,9 @@ proxy:
       http:
       https:
   chp:
+    extraCommandLineFlags:
+      - "--auto-rewrite"
+      - "--mock-flag {{ .Values.proxy.chp.resources.requests.memory }}"
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Closes #1302, thanks for documenting this request well and exploring what happens if you provide a flag twice @ivan-gomes, and as usual @manics - thank you for your presence! I love it :heart:!