### PR TITLE
CI: fix RTD builds on push to master

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ sphinx:
   configuration: doc/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,5 +1,5 @@
 # Order matters:
-# - myst-parser depends on "sphinx>=2,<3"
+# - myst-parser depends on "sphinx>=2,<4"
 # - pydata-sphinx-theme depends on "sphinx"
 # - sphinx-copybutton depends on "sphinx>=1.8"
 #

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,7 +31,7 @@ def setup(app):
 
 
 # -- Project information -----------------------------------------------------
-# ref: https://www.sphinx-doc.org/en/latest/usage/configuration.html#project-information
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Zero to JupyterHub with Kubernetes'
 copyright = '{year}, Project Jupyter Contributors'.format(year=date.today().year)
@@ -47,14 +47,14 @@ version = chart['version'].split('-', 1)[0]
 release = chart['version']
 
 # Project specific variables
-# ref: https://www.sphinx-doc.org/en/latest/usage/configuration.html#confval-rst_epilog
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-rst_epilog
 rst_epilog = """
 .. |hub_version| replace:: {v}
 """.format(v=chart['appVersion'])
 
 
 # -- General configuration ---------------------------------------------------
-# ref: https://www.sphinx-doc.org/en/latest/usage/configuration.html#general-configuration
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 # Set the default role so we can use `foo` instead of ``foo``
 default_role = 'literal'
@@ -133,7 +133,7 @@ linkcheck_anchors_ignore = [
 
 
 # -- Options for HTML output -------------------------------------------------
-# ref: http://www.sphinx-doc.org/en/latest/usage/configuration.html#options-for-html-output
+# ref: http://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -167,14 +167,14 @@ html_static_path = ['_static']
 
 
 # -- Options for HTML help output ---------------------------------------------
-# ref: https://www.sphinx-doc.org/en/latest/usage/configuration.html#options-for-html-help-output
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-help-output
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ZeroToJupyterhubDoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
-# ref: https://www.sphinx-doc.org/en/latest/usage/configuration.html#options-for-latex-output
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-latex-output
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
@@ -207,7 +207,7 @@ latex_documents = [
 
 
 # -- Options for manual page output ------------------------------------------
-# ref: https://www.sphinx-doc.org/en/latest/usage/configuration.html#options-for-manual-page-output
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-manual-page-output
 
 # One entry per manual page.
 man_pages = [
@@ -222,7 +222,7 @@ man_pages = [
 
 
 # -- Options for Texinfo output ----------------------------------------------
-# ref: https://www.sphinx-doc.org/en/latest/usage/configuration.html#options-for-texinfo-output
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-texinfo-output
 
 # Grouping the document tree into Texinfo files.
 texinfo_documents = [
@@ -239,7 +239,7 @@ texinfo_documents = [
 
 
 # -- Options for epub output -------------------------------------------------
-# ref: https://www.sphinx-doc.org/en/latest/usage/configuration.html#options-for-epub-output
+# ref: https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-epub-output
 
 # Bibliographic Dublin Core info.
 epub_title = project


### PR DESCRIPTION
It appears that when we build the docs in the PR preview, it works. But,
when we push to master, it doesn't any more. It appears that using
pydata_sphinx_theme to build PDFs and/or ePub files makes it crash if we
using sphinx3 rather than sphinx2. Since a doc dependency that
(executablebooks/myst-parser) previously was limited to sphinx 2 but not
longer is, the PDF / ePub build made our builds when pushing to master
fail.

I'd like to avoid maintaining these things, and would like to stop
building PDFs and ePub files. I don't know if they are used, but I'd
like to focus attention to https://z2jh.jupyter.org anyhow I think.

---

I'll self merge this now as to trial that this actually resolved the issue. If we want to have htmlzip / PDF / ePub builds again, I think we can pin sphinx<3 in doc-requirements.txt and configure `formats: all` in `.readthedocs.yml` instead of `formats: []`.

Here is an related issue about the build failure, which stems from the interaction of pydata_sphinx_theme and RTD builds like `htmlzip` it seems: https://github.com/pandas-dev/pydata-sphinx-theme/issues/177