### PR TITLE
Added config prePuller.pullProfileListImages

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1375,6 +1375,18 @@ properties:
         properties:
           enabled:
             type: bool
+      pullProfileListImages:
+        type: bool
+        description: |
+          The singleuser.profileList configuration can let the user choose an
+          image through the selection of a profile. This option determines if
+          those images will be pulled, both by the hook and continuous pullers.
+
+          The reason to disable this, is that if you have for example 10 images
+          which start pulling in order from 1 to 10, a user that arrives and
+          wants to start a pod with image number 10 will need to wait for all
+          images to be pulled, and then it may be preferable to just let the
+          user arriving wait for a single image to be pulled on arrival.
       extraImages:
         type: object
         description: |

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -80,6 +80,19 @@ spec:
             - echo "Pulling complete"
           resources:
             {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+        {{- range $k, $container := .Values.singleuser.extraContainers }}
+        - name: image-pull-singleuser-extra-container-{{ $k }}
+          image: {{ $container.image }}
+          {{- with $container.imagePullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - echo "Pulling complete"
+          resources:
+            {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+        {{- end }}
         {{- if .Values.prePuller.pullProfileListImages }}
         {{- range $k, $container := .Values.singleuser.profileList }}
         {{- if $container.kubespawner_override }}
@@ -100,19 +113,6 @@ spec:
         - name: image-pull-{{ $k }}
           image: {{ $v.name }}:{{ $v.tag }}
           {{- with $v.pullPolicy }}
-          imagePullPolicy: {{ . }}
-          {{- end }}
-          command:
-            - /bin/sh
-            - -c
-            - echo "Pulling complete"
-          resources:
-            {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
-        {{- end }}
-        {{- range $k, $container := .Values.singleuser.extraContainers }}
-        - name: image-pull-singleuser-extra-container-{{ $k }}
-          image: {{ $container.image }}
-          {{- with $container.imagePullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
           command:

--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -80,6 +80,7 @@ spec:
             - echo "Pulling complete"
           resources:
             {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+        {{- if .Values.prePuller.pullProfileListImages }}
         {{- range $k, $container := .Values.singleuser.profileList }}
         {{- if $container.kubespawner_override }}
         {{- if $container.kubespawner_override.image }}
@@ -91,6 +92,7 @@ spec:
             - echo "Pulling complete"
           resources:
             {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -375,6 +375,7 @@ prePuller:
     podSchedulingWaitDuration: 10
   continuous:
     enabled: true
+  pullProfileListImages: true
   extraImages: {}
   pause:
     image:


### PR DESCRIPTION
With a large list of images in the singleuser.profileList, users ended
up with delays caused by images being pulled for so long time that it
blocked what was actually important to pull to get started properly.

This option allows for a long singleuser.profileList with many different
images to be setup, while only pulling the default image, or optionally
those configured under prePuller.extraImages.

Closes #1393, Closes #1739 good enough

---

I also added a commit optimizing the order slightly, where the more likely to be used images are pulled first, in this case i determined that images in singleuser.extraContainers are far more likeley to be used than an image in a profileList