### PR TITLE
Add maintainers / owners to register with Artifact Hub

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -3,3 +3,5 @@
 owners: # (optional, used to claim repository ownership)
   - name: Erik Sundell
     email: erik@sundellopensource.se
+  - name: Simon Li
+    email: orpheus+devel@gmail.com

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,5 @@
+# Artifact Hub repository metadata file
+# repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
+owners: # (optional, used to claim repository ownership)
+  - name: Erik Sundell
+    email: erik@sundellopensource.se

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -12,6 +12,9 @@ icon: https://jupyter.org/assets/hublogo.svg
 kubeVersion: '>=1.11.0-0'
 tillerVersion: '>=2.11.0-0'
 maintainers:
+  # Since it is a requirement of Artifact Hub to have specific maintainers
+  # listed, we have added some below, but in practice the entire JupyterHub team
+  # contributes to the maintenance of this Helm chart.
   - name: Erik Sundell
     email: erik@sundellopensource.se
   - name: Simon Li

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -14,3 +14,5 @@ tillerVersion: '>=2.11.0-0'
 maintainers:
   - name: Erik Sundell
     email: erik@sundellopensource.se
+  - name: Simon Li
+    url: https://github.com/manics/

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,3 +1,5 @@
+# Chart.yaml v1 reference: https://v2.helm.sh/docs/developing_charts/#the-chart-yaml-file
+# Chart.yaml v2 reference: https://helm.sh/docs/topics/charts/#the-chartyaml-file
 apiVersion: v1
 name: jupyterhub
 version: 0.0.1-set.by.chartpress
@@ -9,3 +11,6 @@ sources:
 icon: https://jupyter.org/assets/hublogo.svg
 kubeVersion: '>=1.11.0-0'
 tillerVersion: '>=2.11.0-0'
+maintainers:
+  - name: Erik Sundell
+    email: erik@sundellopensource.se


### PR DESCRIPTION
This will allow us to register with the distribution center for Helm charts: [Artifact Hub](https://artifacthub.io/). Helm Hub is automatically redirecting there now.

I suggest others in the @jupyterhub/jupyterhubteam that wants to add themselves here as owners/maintainers in the Chart.yaml as well, if not for you please do it for me so it doesn't look like the only maintainer in this collaborative project involving so many parts from the JupyterHub ecosystem!

This relates to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1517.