### PR TITLE
fixing broken links

### DIFF
--- a/doc/source/administrator/advanced.md
+++ b/doc/source/administrator/advanced.md
@@ -200,8 +200,8 @@ The items in this list must be valid kubernetes
 ### Specifying suitable hub storage
 
 By default, the hub's sqlite-pvc setting will dynamically create a disk to store
-the sqlite database. It is possible to [configure other storage
-classes](reference/reference.html#hub-db-type) under hub.db.pvc, but make sure
+the sqlite database. It is possible to {ref}`configure other storage classes <schema:hub.db.type>`
+under hub.db.pvc, but make sure
 to choose one that the hub can write quickly and safely to. Slow or higher
 latency storage classes can cause hub operations to lag which may ultimately
 lead to HTTP errors in user environments.

--- a/doc/source/administrator/authentication.rst
+++ b/doc/source/administrator/authentication.rst
@@ -143,7 +143,7 @@ CILogon
 In order to overcome the `caveats <https://github.com/jupyterhub/oauthenticator/blob/master/oauthenticator/cilogon.py>`_ of implementing CILogon OAuthAuthenticator for JupyterHub,
 i.e. default username_claim of ePPN does not work for all providers, e.g. generic OAuth such as Google, Use c.CILogonOAuthenticator.username_claim = 'email' to use email instead of ePPN as the JupyterHub username:
 
-Add to your config.yaml file to `inject extra python based configuration that should be in jupyterhub_config.py </reference/reference.html#hub-extraconfig>`_ as below:
+Add to your config.yaml file to :ref:`inject extra python based configuration that should be in jupyterhub_config.py <schema:hub.extraConfig>` as below:
 
 .. code-block:: yaml
 

--- a/doc/source/administrator/optimization.md
+++ b/doc/source/administrator/optimization.md
@@ -211,11 +211,12 @@ For further discussion about user placeholders, see [@MinRK's excellent
 post](https://discourse.jupyter.org/t/planning-placeholders-with-jupyterhub-helm-chart-0-8-tested-on-mybinder-org/213)
 where he analyzed its introduction on mybinder.org.
 
-**IMPORTANT**: Further settings may be required for successful use of the pod
+```{important}
+Further settings may be required for successful use of the pod
 priority depending on how your cluster autoscaler is configured. This is known
 to work on GKE, but we don't know how it works on other cloud providers or
-kubernetes. See the [configuration
-reference](/reference/reference.html#scheduling-podpriority) for more details.
+kubernetes. See the {ref}`configuration reference <schema:scheduling.podPriority>`) for more details.
+```
 
 ### Scaling down efficiently
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -98,6 +98,7 @@ def parse_schema(d, md=[], depth=0, pre=''):
         depth += 1
         # Create markdown headers for each schema level
         for key, val in d['properties'].items():
+            md.append("(schema:%s)=" % (pre + key))
             md.append('#'*(depth + 1) + ' ' + pre + key)
             md.append('')
             if 'description' in val:

--- a/doc/source/google/step-zero-gcp.rst
+++ b/doc/source/google/step-zero-gcp.rst
@@ -8,7 +8,7 @@ Kubernetes on `Google Cloud <https://cloud.google.com/>`_ (GKE)
 up a Kubernetes Cluster. You may be able to receive `free credits
 <https://cloud.google.com/free/>`_ for trying it out (though note that a
 free account `comes with limitations
-<https://cloud.google.com/free/docs/gcp-free-tier#always-free-usage-limits>`_).
+<https://cloud.google.com/free/docs/gcp-free-tier#free-tier-usage-limits>`_).
 Either way, you will need to connect your credit card or other payment method to
 your google cloud account.
 
@@ -84,20 +84,20 @@ your google cloud account.
    * ``--zone`` specifies the data center zone where your cluster will be created.
      You can pick something from `this list
      <https://cloud.google.com/compute/docs/regions-zones/#available>`_
-     that is not too far away from your users.                   
+     that is not too far away from your users.
    *  .. note::
-         
-         A region in GCP is a geographical region with at least three zones, where each zone is representing a datacenter with servers etc.                                     
-      
+
+         A region in GCP is a geographical region with at least three zones, where each zone is representing a datacenter with servers etc.
+
          * A regional cluster creates pods across zones in a region(three by default), distributing Kubernetes resources across multiple zones in the region. This is different from the default cluster, which has all its resources within a single zone(as shown above).
-         
+
          * A regional cluster has Highly Available (HA) kubernetes api-servers, this allows jupyterhub which uses them to have no downtime during upgrades of kubernetes itself.
-         
-         * They also increase control plane uptime to 99.95%. 
-         
+
+         * They also increase control plane uptime to 99.95%.
+
          * To avoid tripling the number of nodes while still having HA kubernetes, the ``--node-locations`` flag can be used to specify a single zone to use.
-              
-                
+
+
 
 
 


### PR DESCRIPTION
This fixes some broken links that we were manually hardcoding to specific headers on the reference page. Instead we are now programmatically adding Sphinx labels to each section of that page so that we can reference them in a URL-agnostic way.

The new Sphinx labels have the structure:

```
schema:<object>
```

For example, 

```
schema:scheduling.podPriority
```

So you can refer to them directly like `` Here is my sentence and now I :ref:`refer to pod priority in rST <schema:scheduling.podPriority>` `` .

closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1717