### PR TITLE
Revert recent removal of image-pulling related to cloudMetadata blocker

### DIFF
--- a/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -69,6 +69,22 @@ spec:
         {{ end }}
       {{- end }}
       initContainers:
+        {{- /* --- Conditionally pull an image all user pods will use in an initContainer --- */}}
+        {{- $blockWithIptables := hasKey .Values.singleuser.cloudMetadata "enabled" | ternary (not .Values.singleuser.cloudMetadata.enabled) .Values.singleuser.cloudMetadata.blockWithIptables }}
+        {{- if $blockWithIptables }}
+        - name: image-pull-metadata-block
+          image: {{ .Values.singleuser.networkTools.image.name }}:{{ .Values.singleuser.networkTools.image.tag }}
+          {{- with .Values.singleuser.networkTools.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - echo "Pulling complete"
+          resources:
+            {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+        {{- end }}
+
         {{- /* --- Pull default image --- */}}
         - name: image-pull-singleuser
           image: {{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}


### PR DESCRIPTION
I previously removed this logic because it was messy to implement the
deprecation logic, and the container would be so very small anyhow. But,
I realized that the size may only be a smaller part if this matters or
not. Each image needs to be pulled, and if they end up being pulled in
the wrong order, it can be very troublesome.

What could happen without this change, is that the image puller pods
could spend time pulling multiple images, then a user pod arrives to the
node and its image is already pulled and it only needs to pull the small
cloudMetadata blocker image, but, pulling that is blocked currenlty.
Because images are pulled in a sequence as I understand it, so the user
pod arriving may end up needing to wait for its little initContainer
image to be pulled and that is just bad.

So, the it matters if we pull this small image, and it matters when we
pull it. We should pull it the first thing we do.

