### PR TITLE
CI: reorder ci jobs to provide relevant feedback quickly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,19 +81,24 @@ jobs:
   ## helm versions: https://github.com/helm/helm/releases
   include:
     - stage: test
-      name: chart:k8s-1.19
-
-    - stage: test
-      name: chart:k8s-1.18
-      env: K3S_VERSION=v1.18.9+k3s1
-
-    - stage: test
-      name: chart:k8s-1.17
-      env: K3S_VERSION=v1.17.12+k3s1
-
-    - stage: test
-      name: chart:k8s-1.16
-      env: K3S_VERSION=v1.16.15+k3s1 k3s_disable_command=--no-deploy
+      name: chart:lint-and-validate
+      install:
+        - setup_helm
+        - setup_kubeval
+        - pip install yamllint
+      script:
+        # NOTE: Kubernetes resource validation can only be done against
+        #       Kubernetes versions with schemas available in:
+        #       https://github.com/instrumenta/kubernetes-json-schema
+        #
+        # NOTE: The "helm template" command will evaluate
+        #       .Capabilities.APIVersion.Has in templates based on a Kubernetes
+        #       version associated with the helm binary's version. Since we
+        #       render the templates with a specific helm version, we end up
+        #       rendering templates using a mocked k8s version unrelated to the
+        #       Kubernetes version we want to validate against. This issue has
+        #       made us not validate against versions lower than 1.14.
+        - tools/templates/lint-and-validate.py --kubernetes-versions 1.14.0,1.18.0
 
     - stage: test
       name: chart:install-latest-then-upgrade
@@ -122,24 +127,19 @@ jobs:
         - pytest --verbose --exitfirst ./tests
 
     - stage: test
-      name: chart:lint-and-validate
-      install:
-        - setup_helm
-        - setup_kubeval
-        - pip install yamllint
-      script:
-        # NOTE: Kubernetes resource validation can only be done against
-        #       Kubernetes versions with schemas available in:
-        #       https://github.com/instrumenta/kubernetes-json-schema
-        #
-        # NOTE: The "helm template" command will evaluate
-        #       .Capabilities.APIVersion.Has in templates based on a Kubernetes
-        #       version associated with the helm binary's version. Since we
-        #       render the templates with a specific helm version, we end up
-        #       rendering templates using a mocked k8s version unrelated to the
-        #       Kubernetes version we want to validate against. This issue has
-        #       made us not validate against versions lower than 1.14.
-        - tools/templates/lint-and-validate.py --kubernetes-versions 1.14.0,1.18.0
+      name: chart:k8s-1.19
+
+    - stage: test
+      name: chart:k8s-1.18
+      env: K3S_VERSION=v1.18.9+k3s1
+
+    - stage: test
+      name: chart:k8s-1.17
+      env: K3S_VERSION=v1.17.12+k3s1
+
+    - stage: test
+      name: chart:k8s-1.16
+      env: K3S_VERSION=v1.16.15+k3s1 k3s_disable_command=--no-deploy
 
     - stage: test
       name: docs:link-check


### PR DESCRIPTION
It is typically not relevant feedback for the user to run all the different k8s version checks, but its nice to know that linting is okay, upgrade works, and one normal test works.

With this PR, we put ensure we get that early on.
