### PR TITLE
Add retryable HTTP client to image-awaiter

### DIFF
--- a/images/image-awaiter/Dockerfile
+++ b/images/image-awaiter/Dockerfile
@@ -1,15 +1,17 @@
 # compile the code to an executable using an intermediary image
-FROM golang:1.9.2
+FROM golang:1
 
-COPY *.go /go/
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s' -installsuffix cgo -a -o /go/image-awaiter /go/*.go
-
+RUN mkdir -p /build/
+COPY *.mod *.go *.sum /build/
+WORKDIR /build
+RUN go build
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-w -s' -installsuffix cgo -a -o out/image-awaiter
 
 
 # present the result within a slimmed image
 FROM scratch
 
-COPY --from=0 /go/image-awaiter /image-awaiter
+COPY --from=0 /build/out/image-awaiter /image-awaiter
 
 
 

--- a/images/image-awaiter/Dockerfile
+++ b/images/image-awaiter/Dockerfile
@@ -1,5 +1,5 @@
 # compile the code to an executable using an intermediary image
-FROM golang:1
+FROM golang:1.15
 
 RUN mkdir -p /build/
 COPY *.mod *.go *.sum /build/

--- a/images/image-awaiter/go.mod
+++ b/images/image-awaiter/go.mod
@@ -1,0 +1,5 @@
+module github.com/jupyterhub/zero-to-jupyterhub-k8s/image-awaiter
+
+go 1.15
+
+require github.com/hashicorp/go-retryablehttp v0.6.7

--- a/images/image-awaiter/go.sum
+++ b/images/image-awaiter/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.7 h1:8/CAEZt/+F7kR7GevNHulKkUjLht3CPmn7egmhieNKo=
+github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
Uses https://pkg.go.dev/mod/github.com/hashicorp/go-retryablehttp which is drop-in compatible wrapper around the default Go http client.

Will fix issue where `image-awaiter` never becomes healthy when deployed in a cluster with a service mesh - since the service mesh uses an init container to configure pod networking, the network might not be ready to route connections when `image-awaiter` tries to make a connection on startup, so `image-awaiter` should be a good resilient HTTP client and at least retry a few times.

Example using the retry settings of 5 retries:

```
~/Source/zero-to-jupyterhub-k8s/images/image-awaiter(master*) » docker run -it --rm --net=host yolo:test4 /image-awaiter -debug -namespace default -daemonset hook-image-puller                                                                                          bleggett@bleggett
2020/10/09 19:49:31 [DEBUG] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller
2020/10/09 19:49:31 [ERR] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller request failed: Get "http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller": dial tcp [::1]:8080: connect: connection refused
2020/10/09 19:49:31 [DEBUG] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller: retrying in 5s (5 left)
2020/10/09 19:49:36 [ERR] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller request failed: Get "http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller": dial tcp [::1]:8080: connect: connection refused
2020/10/09 19:49:36 [DEBUG] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller: retrying in 10s (4 left)
2020/10/09 19:49:46 [ERR] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller request failed: Get "http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller": dial tcp [::1]:8080: connect: connection refused
2020/10/09 19:49:46 [DEBUG] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller: retrying in 20s (3 left)
2020/10/09 19:50:06 [ERR] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller request failed: Get "http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller": dial tcp [::1]:8080: connect: connection refused
2020/10/09 19:50:06 [DEBUG] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller: retrying in 30s (2 left)
2020/10/09 19:50:36 [ERR] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller request failed: Get "http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller": dial tcp [::1]:8080: connect: connection refused
2020/10/09 19:50:36 [DEBUG] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller: retrying in 30s (1 left)
2020/10/09 19:51:06 [ERR] GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller request failed: Get "http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller": dial tcp [::1]:8080: connect: connection refused
2020/10/09 19:51:06 GET http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller giving up after 6 attempt(s): Get "http://localhost:8080/apis/apps/v1/namespaces/default/daemonsets/hook-image-puller": dial tcp [::1]:8080: connect: connection refused
```

EDIT: Fixes #1793