### PR TITLE
Provide a way to disable default hub configmap

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -303,6 +303,10 @@ properties:
                 image: busybox:1.28
                 command: ['sh', '-c', 'command2']
           ```
+      enableConfigMap:
+        type: boolean
+        description: |
+          Whether the configmaps are created and used for the hub deployment.
       extraEnv:
         type: object
         description: |

--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hub.enableConfigMap }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -8,3 +9,4 @@ data:
   {{- /* Glob files to allow them to be mounted by the hub pod */ -}}
   {{- /* key=filename: value=content */ -}}
   {{- (.Files.Glob "files/hub/*").AsConfig | nindent 2 }}
+{{- end }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -37,9 +37,11 @@ spec:
       tolerations: {{ toJson .Values.hub.tolerations }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       volumes:
+        {{- if .Values.hub.enableConfigMap }}
         - name: config
           configMap:
             name: hub-config
+        {{- end }}
         - name: secret
           secret:
             {{- if .Values.hub.existingSecret }}
@@ -108,6 +110,7 @@ spec:
             {{- end }}
             {{- end }}
           volumeMounts:
+            {{- if .Values.hub.enableConfigMap }}
             - mountPath: /etc/jupyterhub/jupyterhub_config.py
               subPath: jupyterhub_config.py
               name: config
@@ -116,6 +119,7 @@ spec:
               name: config
             - mountPath: /etc/jupyterhub/config/
               name: config
+            {{- end }}
             - mountPath: /etc/jupyterhub/secret/
               name: secret
             {{- if .Values.hub.extraVolumeMounts }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -47,6 +47,7 @@ hub:
     password:
   labels: {}
   annotations: {}
+  enableConfigMap: true
   extraConfig: {}
   extraConfigMap: {}
   extraEnv: {}


### PR DESCRIPTION
The jupyterhub chart is ultra-configurable and good for deploying
my other jupyterhub environments.  But it provides no way to not
use the default jupyterhub_config.py via the configmap.  I want
to be able to use the extraConfigMaps to mount my own configmap
that contains the jupyterhub_config.py and not include the original
jupyterhub_config.py.