### PR TITLE
hub.command and hub.args configuration added

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -4,6 +4,29 @@ properties:
   hub:
     type: object
     properties:
+      command:
+        type: string
+        description: |
+          The command to start jupyterhub, used in the deployment to set the
+          commandline, along with args and other flags set by the chart.
+      args:
+        type: list
+        description: |
+          A list of strings to be used as the command line arguments for JupyterHub
+          that will be expanded with Helm's template function `tpl` which
+          can render Helm template logic inside curly braces (`{{ ... }}`).
+
+          ```yaml
+          hub:
+            args:
+              - "--config"
+              - "/etc/jupyterhub/jupyterhub_config.py"
+          ```
+
+          Note that these replace the command line arguments provided by default,
+          but not those added by using other helm options.
+
+          The default args in values.yaml provides the typical behavior.
       cookieSecret:
         type:
           - string

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -5,28 +5,62 @@ properties:
     type: object
     properties:
       command:
-        type: string
+        type: list
         description: |
-          The command to start jupyterhub, used in the deployment to set the
-          commandline, along with args and other flags set by the chart.
+          A list of strings to be used to replace the JupyterHub image's
+          `ENTRYPOINT` entry. Note that in k8s lingo, the Dockerfile's
+          `ENTRYPOINT` is called `command`. The list of strings will be expanded
+          with Helm's template function `tpl` which can render Helm template
+          logic inside curly braces (`{{... }}`).
+
+          This could be useful to wrap the invocation of JupyterHub itself in
+          some custom way.
+
+          For more details, see the [Kubernetes
+          documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes).
       args:
         type: list
         description: |
-          A list of strings to be used as the command line arguments for JupyterHub
-          that will be expanded with Helm's template function `tpl` which
-          can render Helm template logic inside curly braces (`{{ ... }}`).
+          A list of strings to be used to replace the JupyterHub image's `CMD`
+          entry as well as the Helm chart's default way to start JupyterHub.
+          Note that in k8s lingo, the Dockerfile's `CMD` is called `args`. The
+          list of strings will be expanded with Helm's template function `tpl`
+          which can render Helm template logic inside curly braces (`{{... }}`).
+
+          ```{warning}
+          By replacing the entire configuration file, which is mounted to
+          `/etc/jupyterhub/jupyterhub_config.py` by the Helm chart, instead of
+          appending to it with `hub.extraConfig`, you expose your deployment for
+          issues stemming from getting out of sync with the Helm chart's config
+          file.
+
+          These kind of issues will be significantly harder to debug and
+          diagnose, and can due to this could cause a lot of time expenditure
+          for both the community maintaining the Helm chart as well as yourself,
+          even if this wasn't the reason for the issue.
+          
+          Due to this, we ask that you do your _absolute best to avoid replacing
+          the default provided `jupyterhub_config.py` file. It can often be
+          possible. For example, if your goal is to have a dedicated .py file
+          for more extensive additions that you can syntax highlight and such
+          and feel limited by passing code in `hub.extraConfig` which is part of
+          a YAML file, you can use [this
+          trick](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1580#issuecomment-707776237)
+          instead.
+          ```
 
           ```yaml
           hub:
             args:
+              - "jupyterhub"
               - "--config"
               - "/etc/jupyterhub/jupyterhub_config.py"
+              - "--debug"
+              - "--upgrade-db"
           ```
 
-          Note that these replace the command line arguments provided by default,
-          but not those added by using other helm options.
-
-          The default args in values.yaml provides the typical behavior.
+          For more details, see the [Kubernetes
+          documentation](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes).
       cookieSecret:
         type:
           - string

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -81,9 +81,10 @@ spec:
         - name: hub
           image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
           command:
-            - jupyterhub
-            - --config
-            - /etc/jupyterhub/jupyterhub_config.py
+            - {{ .Values.hub.command }}
+            {{- range .Values.hub.args }}
+            - {{ tpl . $ }}
+            {{- end }}
             {{- if .Values.debug.enabled }}
             - --debug
             {{- end }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -80,11 +80,24 @@ spec:
         {{- end }}
         - name: hub
           image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
+          {{- with .Values.hub.command }}
           command:
-            - {{ .Values.hub.command }}
+            {{- range . }}
+            - {{ tpl . $ }}
+            {{- end }}
+          {{- end }}
+          args:
+            {{- /* .Values.hub.args overrides everything the Helm chart otherside would set */}}
+            {{- if .Values.hub.args }}
             {{- range .Values.hub.args }}
             - {{ tpl . $ }}
             {{- end }}
+
+            {{- /* .Values.hub.args didn't replace the default logic */}}
+            {{- else }}
+            - jupyterhub
+            - --config
+            - /etc/jupyterhub/jupyterhub_config.py
             {{- if .Values.debug.enabled }}
             - --debug
             {{- end }}
@@ -106,6 +119,7 @@ spec:
             {{- /* .Values.hub.db.upgrade is nil */}}
             {{- if eq .Values.hub.db.type "sqlite-pvc" }}
             - --upgrade-db
+            {{- end }}
             {{- end }}
             {{- end }}
           volumeMounts:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -47,6 +47,10 @@ hub:
     password:
   labels: {}
   annotations: {}
+  command: jupyterhub
+  args:
+    - --config
+    - /etc/jupyterhub/jupyterhub_config.py
   extraConfig: {}
   extraConfigMap: {}
   extraEnv: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -47,10 +47,8 @@ hub:
     password:
   labels: {}
   annotations: {}
-  command: jupyterhub
-  args:
-    - --config
-    - /etc/jupyterhub/jupyterhub_config.py
+  command: []
+  args: []
   extraConfig: {}
   extraConfigMap: {}
   extraEnv: {}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -34,6 +34,10 @@ hub:
   initContainers:
     - name: mock-init-container-name
       image: mock-init-container-image
+  command: mock
+  args:
+    - "--mock-flag"
+    - "{{ .Values.hub.baseUrl }}"
   extraConfig:
     test: |-
       c.Spawner.cmd = 'mock'

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -34,8 +34,10 @@ hub:
   initContainers:
     - name: mock-init-container-name
       image: mock-init-container-image
-  command: mock
+  command:
+    - tini
   args:
+    - jupyterhub
     - "--mock-flag"
     - "{{ .Values.hub.baseUrl }}"
   extraConfig:


### PR DESCRIPTION
This allows the chart to override the JupyterHub commandline.
While I started doing an extraCommandLineArguments idea, that
did not work as specifying the config option twice will not
allow the hub to start.  So this makes the command line in
general overrideable.