### PR TITLE
try out jupyterhub 1.2.0b1

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -12,7 +12,7 @@ charts:
         valuesPath: hub.image
         buildArgs:
           # NOTE: Also bump the Chart.yaml's appVersion if this is bumped
-          JUPYTERHUB_VERSION: 1.1.0
+          JUPYTERHUB_VERSION: 1.2.0b1
       network-tools:
         valuesPath: singleuser.networkTools.image
       image-awaiter:
@@ -20,4 +20,4 @@ charts:
       singleuser-sample:
         valuesPath: singleuser.image
         buildArgs:
-          JUPYTERHUB_VERSION: 1.1.0
+          JUPYTERHUB_VERSION: 1.2.0b1

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -42,6 +42,7 @@ ARG JUPYTERHUB_VERSION=1.1.*
 
 RUN PYCURL_SSL_LIBRARY=openssl pip3 install --no-cache-dir \
          -r /tmp/requirements.txt \
+ && pip3 install --no-cache-dir \
          $(bash -c 'if [[ $JUPYTERHUB_VERSION == "git"* ]]; then \
             echo ${JUPYTERHUB_VERSION}; \
           else \

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -4,23 +4,21 @@
 #
 #    ./dependencies freeze --upgrade
 #
-aiohttp==3.6.2            # via google-auth
 alembic==1.4.3            # via jupyterhub
 async-generator==1.10     # via jupyterhub, jupyterhub-kubespawner
-async-timeout==3.0.1      # via aiohttp
-attrs==20.2.0             # via aiohttp, jsonschema
+attrs==20.2.0             # via jsonschema
 bcrypt==3.2.0             # via jupyterhub-firstuseauthenticator, jupyterhub-nativeauthenticator
 cachetools==4.1.1         # via google-auth
 certifi==2020.6.20        # via kubernetes, requests
 certipy==0.1.3            # via jupyterhub
 cffi==1.14.3              # via bcrypt, cryptography
-chardet==3.0.4            # via aiohttp, requests
+chardet==3.0.4            # via requests
 cryptography==3.1.1       # via pyjwt, pyopenssl
 entrypoints==0.3          # via jupyterhub
 escapism==1.0.1           # via jupyterhub-kubespawner
 globus-sdk[jwt]==1.9.1    # via -r requirements.in
-google-auth==1.22.0       # via kubernetes
-idna==2.10                # via requests, yarl
+google-auth==1.22.1       # via kubernetes
+idna==2.10                # via requests
 ipython-genutils==0.2.0   # via traitlets
 jinja2==2.11.2            # via jupyterhub, jupyterhub-kubespawner
 jsonschema==3.2.0         # via jupyter-telemetry
@@ -34,12 +32,11 @@ jupyterhub-ldapauthenticator==1.3.2  # via -r requirements.in
 jupyterhub-ltiauthenticator==0.4.0  # via -r requirements.in
 jupyterhub-nativeauthenticator==0.0.5  # via -r requirements.in
 jupyterhub-tmpauthenticator==0.6  # via -r requirements.in
-jupyterhub==1.1.0         # via jupyterhub-firstuseauthenticator, jupyterhub-kubespawner, jupyterhub-ldapauthenticator, jupyterhub-ltiauthenticator, jupyterhub-nativeauthenticator, nullauthenticator, oauthenticator
-kubernetes==11.0.0        # via jupyterhub-kubespawner
+jupyterhub==1.2.0b1       # via jupyterhub-firstuseauthenticator, jupyterhub-kubespawner, jupyterhub-ldapauthenticator, jupyterhub-ltiauthenticator, jupyterhub-nativeauthenticator, nullauthenticator, oauthenticator
+kubernetes==12.0.0        # via jupyterhub-kubespawner
 ldap3==2.8.1              # via jupyterhub-ldapauthenticator
 mako==1.1.3               # via alembic
 markupsafe==1.1.1         # via jinja2, mako
-multidict==4.7.6          # via aiohttp, yarl
 mwoauth==0.3.7            # via -r requirements.in
 nullauthenticator==1.0.0  # via -r requirements.in
 oauthenticator==0.11.0    # via -r requirements.in
@@ -59,7 +56,7 @@ pyopenssl==19.1.0         # via certipy
 pyrsistent==0.17.3        # via jsonschema
 python-dateutil==2.8.1    # via alembic, jupyterhub, jupyterhub-idle-culler, kubernetes
 python-editor==1.0.4      # via alembic
-python-json-logger==2.0.0  # via jupyter-telemetry
+python-json-logger==2.0.1  # via jupyter-telemetry
 python-slugify==4.0.1     # via jupyterhub-kubespawner
 pyyaml==5.3.1             # via jupyterhub-kubespawner, kubernetes
 requests-oauthlib==1.3.0  # via kubernetes, mwoauth
@@ -68,14 +65,13 @@ rsa==4.6                  # via google-auth
 ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via jupyter-telemetry
 six==1.15.0               # via bcrypt, cryptography, globus-sdk, google-auth, jsonschema, kubernetes, mwoauth, onetimepass, pyopenssl, python-dateutil, websocket-client
-sqlalchemy==1.3.19        # via alembic, jupyterhub
+sqlalchemy==1.3.20        # via alembic, jupyterhub
 statsd==3.3.0             # via -r requirements.in
 text-unidecode==1.3       # via python-slugify
 tornado==6.0.4            # via jupyterhub, jupyterhub-idle-culler, jupyterhub-ldapauthenticator
-traitlets==5.0.4          # via jupyter-telemetry, jupyterhub, jupyterhub-ldapauthenticator
+traitlets==5.0.5          # via jupyter-telemetry, jupyterhub, jupyterhub-ldapauthenticator
 urllib3==1.25.10          # via jupyterhub-kubespawner, kubernetes, requests
 websocket-client==0.57.0  # via kubernetes
-yarl==1.6.0               # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: jupyterhub
 version: 0.0.1-set.by.chartpress
-appVersion: 1.1.0
+appVersion: 1.2.0b1
 description: Multi-user Jupyter installation
 home: https://z2jh.jupyter.org
 sources:


### PR DESCRIPTION
and bumps dependencies in hub image

I had to tweak things a bit since our freezing code didn't play nice with the fact that the jupyterhub version is specified both inside requirements.txt and as a separate arg, which results in a conflict when the two versions don't match. I'm not sure what exactly is the best way to deal with that. Perhaps put jupyterhub version in requirements.in instead?

several were removed due to https://github.com/googleapis/google-auth-library-python/pull/619 making aiohttp an optional dependency of google-auth. I *think* this is fine and shouldn't affect us, since this is a transitive dependency and we don't directly use google-auth + aiohttp. Presumably tests will reveal if we should add `google-auth[aiohttp]` as a dependency...