### PR TITLE
netpol: allowedIngressPorts and interNamespaceAccessLabels config added with defaults retaining 0.9.1 current behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Here you can find upgrade changes in between releases and upgrade instructions.
 
 ## [0.10]
 
-### [0.10.0]
+### [0.10.0-beta.1] (UNRELEASED)
 
 #### Breaking changes:
 
@@ -16,16 +16,16 @@ Here you can find upgrade changes in between releases and upgrade instructions.
   known to be needed, with the exception of the user pods outgoing
   communication, where all outgoing communication is allowed by default.
   
-  Note that these network policies only influence network communication in a
+  Note that these NetworkPolicies only influence network communication in a
   Kubernetes cluster if a NetworkPolicy controller enforce them, such as Calico.
-
-  With network policies enabled, you may require additional configuration,
-  especially for deployments that include additional components that access
-  JupyterHub pods directly (i.e. not through the `proxy-public` service).
 
   See the [security
   documentation](https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/security.html#kubernetes-network-policies)
   for more details on this.
+
+- The Helm chart configuration `proxy.networkPolicy` has been deprecated, and
+  `proxy.chp.networkPolicy` (proxy pod) and `proxy.traefik.networkPolicy`
+  (autohttps pod) is recommended to use instead.
 
 ## [0.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ Here you can find upgrade changes in between releases and upgrade instructions.
   documentation](https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/security.html#kubernetes-network-policies)
   for more details on this.
 
-- The Helm chart configuration `proxy.networkPolicy` has been deprecated, and
+- The Helm chart configuration `proxy.networkPolicy` has been removed,
   `proxy.chp.networkPolicy` (proxy pod) and `proxy.traefik.networkPolicy`
-  (autohttps pod) is recommended to use instead.
+  (autohttps pod) must be used instead.
 
 ## [0.9]
 

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -25,13 +25,13 @@ proxy:
     extraEnv:
       - name: LEGO_CA_CERTIFICATES
         value: /etc/pebble/root-cert.pem
-  networkPolicy:
-    egress: []  # overrides allowance of 0.0.0.0/0
   chp:
     resources:
       requests:
         memory: 0
         cpu: 0
+    networkPolicy:
+      egress: []  # overrides allowance of 0.0.0.0/0
 
 hub:
   cookieSecret: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -240,7 +240,7 @@ properties:
               `proxy.chp` and `proxy.traefik`'s networkPolicy configuration is
               `[http, https]`, while it is `[]` for other networkPolicies.
               
-              Note that these port names or numbers targets a Pod's port name or
+              Note that these port names or numbers target a Pod's port name or
               number, not a k8s Service's port name or number.
       db:
         type: object

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -204,11 +204,15 @@ properties:
           ingress:
             type: list
             description: |
-              Additional ingress rules to add.
+              Additional ingress rules to add except those that is known to be needed by the respective pods in the Helm chart.
           egress:
             type: list
             description: |
-              Additional egress rules to add.
+              Additional egress rules to add except those that is known to be needed by  the respective pods in the Helm chart.
+
+              The default value of this egress is to allow all traffic, except for the `singleuser.networkPolicy.egress`, which is also limiting access to a metadata server that can be exploited.
+
+              If you want to restrict egress, you can override this permissive default to be an empty list.
           interNamespaceAccessLabels:
             type: string
             enum:
@@ -216,7 +220,7 @@ properties:
               - ignore
             description: |
               This configuration option determines if both namespaces and pods
-              in other namespaces that have specific access labels, should be
+              in other namespaces, that have specific access labels, should be
               accepted to allow ingress (set to `accept`), or, if the labels are
               to be ignored when applied outside the local namespace (set to
               `ignore`).
@@ -235,6 +239,9 @@ properties:
               what the origin of the request is. The default setting for
               `proxy.chp` and `proxy.traefik`'s networkPolicy configuration is
               `[http, https]`, while it is `[]` for other networkPolicies.
+              
+              Note that these port names or numbers targets a Pod's port name or
+              number, not a k8s Service's port name or number.
       db:
         type: object
         properties:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -191,6 +191,50 @@ properties:
               pullSecrets:
                 - my-k8s-secret-with-image-registry-credentials
               ```
+      networkPolicy: &networkPolicy-spec
+        type: object
+        description: |
+          This configuration regards the creation and configuration of a k8s
+          _NetworkPolicy resource_.
+        properties:
+          enabled:
+            type: bool
+            description: |
+              Toggle the creation of the NetworkPolicy resource for this pod.
+          ingress:
+            type: list
+            description: |
+              Additional ingress rules to add.
+          egress:
+            type: list
+            description: |
+              Additional egress rules to add.
+          interNamespaceAccessLabels:
+            type: string
+            enum:
+              - accept
+              - ignore
+            description: |
+              This configuration option determines if both namespaces and pods
+              in other namespaces that have specific access labels, should be
+              accepted to allow ingress (set to `accept`), or, if the labels are
+              to be ignored when applied outside the local namespace (set to
+              `ignore`).
+
+              The available access labels for respective NetworkPolicy resources
+              are:
+
+              - `hub.jupyter.org/network-access-hub: "true"` (hub)
+              - `hub.jupyter.org/network-access-proxy-http: "true"` (proxy.chp, proxy.traefik)
+              - `hub.jupyter.org/network-access-proxy-api: "true"` (proxy.chp)
+              - `hub.jupyter.org/network-access-singleuser: "true"` (singleuser)
+          allowedIngressPorts:
+            type: list
+            description: |
+              A rule to allow ingress on these ports will be added no matter
+              what the origin of the request is. The default setting for
+              `proxy.chp` and `proxy.traefik`'s networkPolicy configuration is
+              `[http, https]`, while it is `[]` for other networkPolicies.
       db:
         type: object
         properties:
@@ -535,6 +579,7 @@ properties:
           Configure the configurable-http-proxy (chp) pod managed by jupyterhub to route traffic
           both to itself and to user pods.
         properties:
+          networkPolicy: *networkPolicy-spec
           extraCommandLineFlags:
             type: list
             description: |
@@ -806,6 +851,7 @@ properties:
 
               See the [Kubernetes docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
               to learn more about labels.
+          networkPolicy: *networkPolicy-spec
           extraEnv:
             type: object
             description: |
@@ -880,6 +926,7 @@ properties:
     description: |
       Options for customizing the environment that is provided to the users after they log in.
     properties:
+      networkPolicy: *networkPolicy-spec
       podNameTemplate:
         type: string
         description: |

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -38,6 +38,11 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
 {{- end }}
 
 
+{{- if .Values.proxy.networkPolicy }}
+{{- fail "DEPRECATION: proxy.networkPolicy has been renamed to proxy.chp.networkPolicy" }}
+{{- end }}
+
+
 {{- if .Values.hub.extraConfigMap }}{{ println }}
 DEPRECATION: hub.extraConfigMap is deprecated in jupyterhub chart 0.8.
 Use top-level `custom` instead:

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -29,6 +29,14 @@ spec:
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
   #
   ingress:
+    {{- with .Values.hub.networkPolicy.allowedIngressPorts }}
+    # allow incoming traffic to these ports independent of source
+    - ports:
+      {{- range $port := . }}
+      - port: {{ $port }}
+      {{- end }}
+    {{- end }}
+
     # allowed pods (hub.jupyter.org/network-access-hub) --> hub
     - ports:
         - port: http

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -33,14 +33,19 @@ spec:
     - ports:
         - port: http
       from:
+        # source 1 - labelled pods
+        - podSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-hub: "true"
+          namespaceSelector:
+            matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+        # source 2 - pods in labelled namespaces
         - namespaceSelector:
-            matchLabels: {}   # allow the label below to be set on a pod in any namespace
-          podSelector:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
 
     {{- with .Values.hub.networkPolicy.ingress }}
-    # default: nothing --> hub
+    # depends, but default is nothing --> hub
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
 
@@ -62,7 +67,7 @@ spec:
               {{- $_ := merge (dict "componentLabel" "singleuser-server") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
 
-    # hub -> Kubernetes internal DNS
+    # hub --> Kubernetes internal DNS
     - ports:
         - protocol: UDP
           port: 53
@@ -70,7 +75,7 @@ spec:
           port: 53
 
     {{- with .Values.hub.networkPolicy.egress }}
-    # hub --> default: everything
+    # hub --> depends, but the default is everything
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -33,16 +33,27 @@ spec:
     - ports:
         - port: http
       from:
+        {{- with .Values.hub.networkPolicy.interNamespaceIngressForHTTPPort }}
         # source 1 - labelled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
+          {{- if eq . "requireEitherPodOrNamespaceLabel" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+          {{- else if eq . "requireBothPodAndNamespaceLabel" }}
+          namespaceSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-hub: "true"
+          {{- end }}
+
+        {{- if or (eq . "requireEitherPodOrNamespaceLabel") (eq . "requireNamespaceLabel") }}
         # source 2 - pods in labelled namespaces
         - namespaceSelector:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
+        {{- end }}
+        {{- end }}
 
     {{- with .Values.hub.networkPolicy.ingress }}
     # depends, but default is nothing --> hub

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -13,6 +13,21 @@ spec:
     - Ingress
     - Egress
 
+  # IMPORTANT:
+  # NetworkPolicy's ingress "from" and egress "to" rule specifications require
+  # great attention to detail. A quick summary is:
+  #
+  # 1. You can provide "from"/"to" rules that provide access either ports or a
+  #    subset of ports.
+  # 2. You can for each "form"/"to" rule provide any number of
+  #    "sources"/"destinations" of four different kinds.
+  #    - podSelector                        - targets pods with a certain label in the NetworkPolicy's namespace
+  #    - namespaceSelector                  - targets all pods within namespaces with a certain label
+  #    - namespaceSelector and podSelector  - targets pods with a certain label within namespaces with a certain label
+  #    - ipBlock                            - targets network traffic from/to a set of IP address ranges
+  #
+  # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
+  #
   ingress:
     # allowed pods (hub.jupyter.org/network-access-hub) --> hub
     - ports:

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -33,26 +33,17 @@ spec:
     - ports:
         - port: http
       from:
-        {{- with .Values.hub.networkPolicy.interNamespaceIngressForHTTPPort }}
-        # source 1 - labelled pods
+        # source 1 - labeled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
-          {{- if eq . "requireEitherPodOrNamespaceLabel" }}
+        {{- if eq .Values.hub.networkPolicy.interNamespaceLabeledIngress "allow" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
-          {{- else if eq . "requireBothPodAndNamespaceLabel" }}
-          namespaceSelector:
-            matchLabels:
-              hub.jupyter.org/network-access-hub: "true"
-          {{- end }}
-
-        {{- if or (eq . "requireEitherPodOrNamespaceLabel") (eq . "requireNamespaceLabel") }}
-        # source 2 - pods in labelled namespaces
+        # source 2 - pods in labeled namespaces
         - namespaceSelector:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
-        {{- end }}
         {{- end }}
 
     {{- with .Values.hub.networkPolicy.ingress }}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -23,7 +23,7 @@ spec:
   #    "sources"/"destinations" of four different kinds.
   #    - podSelector                        - targets pods with a certain label in the same namespace as the NetworkPolicy
   #    - namespaceSelector                  - targets all pods running in namespaces with a certain label
-  #    - namespaceSelector and podSelector  - targets pods with a certain label within namespaces with a certain label
+  #    - namespaceSelector and podSelector  - targets pods with a certain label running in namespaces with a certain label
   #    - ipBlock                            - targets network traffic from/to a set of IP address ranges
   #
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -45,7 +45,7 @@ spec:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
-        {{- if eq .Values.hub.networkPolicy.interNamespaceLabeledIngress "allow" }}
+        {{- if eq .Values.hub.networkPolicy.interNamespaceAccessLabels "accept" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
         # source 2 - pods in labeled namespaces

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -18,7 +18,9 @@ spec:
     - ports:
         - port: http
       from:
-        - podSelector:
+        - namespaceSelector:
+            matchLabels: {}   # allow the label below to be set on a pod in any namespace
+          podSelector:
             matchLabels:
               hub.jupyter.org/network-access-hub: "true"
 

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -19,10 +19,10 @@ spec:
   #
   # 1. You can provide "from"/"to" rules that provide access either ports or a
   #    subset of ports.
-  # 2. You can for each "form"/"to" rule provide any number of
+  # 2. You can for each "from"/"to" rule provide any number of
   #    "sources"/"destinations" of four different kinds.
-  #    - podSelector                        - targets pods with a certain label in the NetworkPolicy's namespace
-  #    - namespaceSelector                  - targets all pods within namespaces with a certain label
+  #    - podSelector                        - targets pods with a certain label in the same namespace as the NetworkPolicy
+  #    - namespaceSelector                  - targets all pods running in namespaces with a certain label
   #    - namespaceSelector and podSelector  - targets pods with a certain label within namespaces with a certain label
   #    - ipBlock                            - targets network traffic from/to a set of IP address ranges
   #

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -48,7 +48,7 @@ spec:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
-        {{- if eq .Values.proxy.traefik.networkPolicy.interNamespaceLabeledIngress "allow" }}
+        {{- if eq .Values.proxy.traefik.networkPolicy.interNamespaceAccessLabels "accept" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
         # source 2 - pods in labeled namespaces

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -72,7 +72,7 @@ spec:
               {{- $_ := merge (dict "componentLabel" "proxy") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
 
-    # proxy --> Kubernetes internal DNS
+    # autohttps --> Kubernetes internal DNS
     - ports:
       - protocol: UDP
         port: 53
@@ -80,7 +80,7 @@ spec:
         port: 53
 
     {{- with .Values.proxy.traefik.networkPolicy.egress }}
-    # proxy --> depends, but the default is everything
+    # autohttps --> depends, but the default is everything
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -31,12 +31,14 @@ spec:
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
   #
   ingress:
-    {{- if .Values.proxy.traefik.networkPolicy.allowHttpIngressUnconditionally }}
-    # allow any incoming traffic to these ports
+    {{- with .Values.proxy.traefik.networkPolicy.allowedIngressPorts }}
+    # allow incoming traffic to these ports independent of source
     - ports:
-      - port: http
-      - port: https
-    {{- else }}
+      {{- range $port := . }}
+      - port: {{ $port }}
+      {{- end }}
+    {{- end }}
+
     # allowed pods (hub.jupyter.org/network-access-proxy-http) --> proxy (http/https port)
     - ports:
         - port: http
@@ -54,7 +56,6 @@ spec:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
         {{- end }}
-    {{- end }}
 
     {{- with .Values.proxy.traefik.networkPolicy.ingress}}
     # depends, but default is nothing --> proxy

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -1,12 +1,10 @@
 {{- $HTTPS := .Values.proxy.https.enabled -}}
 {{- $autoHTTPS := and $HTTPS (and (eq .Values.proxy.https.type "letsencrypt") .Values.proxy.https.hosts) -}}
-{{- $manualHTTPS := and $HTTPS (eq .Values.proxy.https.type "manual") -}}
-{{- $manualHTTPSwithsecret := and $HTTPS (eq .Values.proxy.https.type "secret") -}}
-{{- if .Values.proxy.chp.networkPolicy.enabled -}}
+{{- if and $autoHTTPS .Values.proxy.traefik.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: proxy
+  name: autohttps
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
@@ -36,15 +34,13 @@ spec:
     # allowed pods (hub.jupyter.org/network-access-proxy-http) --> proxy (http/https port)
     - ports:
         - port: http
-        {{- if or $manualHTTPS $manualHTTPSwithsecret }}
         - port: https
-        {{- end }}
       from:
         # source 1 - labeled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
-        {{- if eq .Values.proxy.chp.networkPolicy.interNamespaceLabeledIngress "allow" }}
+        {{- if eq .Values.proxy.traefik.networkPolicy.interNamespaceLabeledIngress "allow" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
         # source 2 - pods in labeled namespaces
@@ -53,45 +49,19 @@ spec:
               hub.jupyter.org/network-access-proxy-http: "true"
         {{- end }}
 
-    # allowed pods (hub.jupyter.org/network-access-proxy-api) --> proxy (api port)
-    - ports:
-        - port: api
-      from:
-        # source 1 - labeled pods
-        - podSelector:
-            matchLabels:
-              hub.jupyter.org/network-access-proxy-api: "true"
-        {{- if eq .Values.proxy.chp.networkPolicy.interNamespaceLabeledIngress "allow" }}
-          namespaceSelector:
-            matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
-        # source 2 - pods in labeled namespaces
-        - namespaceSelector:
-            matchLabels:
-              hub.jupyter.org/network-access-proxy-api: "true"
-        {{- end }}
-
-    {{- with .Values.proxy.chp.networkPolicy.ingress}}
+    {{- with .Values.proxy.traefik.networkPolicy.ingress}}
     # depends, but default is nothing --> proxy
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
 
   egress:
-    # proxy --> hub
+    # hub --> proxy (http port)
     - ports:
-        - port: 8081
+        - port: 8000
       to:
         - podSelector:
             matchLabels:
-              {{- $_ := merge (dict "componentLabel" "hub") . }}
-              {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
-
-    # proxy --> singleuser-server
-    - ports:
-        - port: 8888
-      to:
-        - podSelector:
-            matchLabels:
-              {{- $_ := merge (dict "componentLabel" "singleuser-server") . }}
+              {{- $_ := merge (dict "componentLabel" "proxy") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
 
     # proxy --> Kubernetes internal DNS
@@ -101,7 +71,7 @@ spec:
       - protocol: TCP
         port: 53
 
-    {{- with .Values.proxy.chp.networkPolicy.egress }}
+    {{- with .Values.proxy.traefik.networkPolicy.egress }}
     # proxy --> depends, but the default is everything
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -21,11 +21,11 @@ spec:
   #
   # 1. You can provide "from"/"to" rules that provide access either ports or a
   #    subset of ports.
-  # 2. You can for each "form"/"to" rule provide any number of
+  # 2. You can for each "from"/"to" rule provide any number of
   #    "sources"/"destinations" of four different kinds.
-  #    - podSelector                        - targets pods with a certain label in the NetworkPolicy's namespace
-  #    - namespaceSelector                  - targets all pods within namespaces with a certain label
-  #    - namespaceSelector and podSelector  - targets pods with a certain label within namespaces with a certain label
+  #    - podSelector                        - targets pods with a certain label in the same namespace as the NetworkPolicy
+  #    - namespaceSelector                  - targets all pods running in namespaces with a certain label
+  #    - namespaceSelector and podSelector  - targets pods with a certain label running in namespaces with a certain label
   #    - ipBlock                            - targets network traffic from/to a set of IP address ranges
   #
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -31,6 +31,12 @@ spec:
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
   #
   ingress:
+    {{- if .Values.proxy.traefik.networkPolicy.allowHttpIngressUnconditionally }}
+    # allow any incoming traffic to these ports
+    - ports:
+      - port: http
+      - port: https
+    {{- else }}
     # allowed pods (hub.jupyter.org/network-access-proxy-http) --> proxy (http/https port)
     - ports:
         - port: http
@@ -48,6 +54,7 @@ spec:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
         {{- end }}
+    {{- end }}
 
     {{- with .Values.proxy.traefik.networkPolicy.ingress}}
     # depends, but default is nothing --> proxy

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -63,7 +63,7 @@ spec:
     {{- end }}
 
   egress:
-    # hub --> proxy (http port)
+    # autohttps --> proxy (http port)
     - ports:
         - port: 8000
       to:

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -40,31 +40,53 @@ spec:
         - port: https
         {{- end }}
       from:
+        {{- with .Values.proxy.networkPolicy.interNamespaceIngressForHTTPPort }}
         # source 1 - labelled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
+          {{- if eq . "requireEitherPodOrNamespaceLabel" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+          {{- else if eq . "requireBothPodAndNamespaceLabel" }}
+          namespaceSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-proxy-http: "true"
+          {{- end }}
+
+        {{- if or (eq . "requireEitherPodOrNamespaceLabel") (eq . "requireNamespaceLabel") }}
         # source 2 - pods in labelled namespaces
         - namespaceSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
+        {{- end }}
+        {{- end }}
 
     # allowed pods (hub.jupyter.org/network-access-proxy-api) --> proxy (api port)
     - ports:
         - port: api
       from:
+        {{- with .Values.proxy.networkPolicy.interNamespaceIngressForAPIPort }}
         # source 1 - labelled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
+          {{- if eq . "requireEitherPodOrNamespaceLabel" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+          {{- else if eq . "requireBothPodAndNamespaceLabel" }}
+          namespaceSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-proxy-api: "true"
+          {{- end }}
+
+        {{- if or (eq . "requireEitherPodOrNamespaceLabel") (eq . "requireNamespaceLabel") }}
         # source 2 - pods in labelled namespaces
         - namespaceSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
+        {{- end }}
+        {{- end }}
 
     {{- with .Values.proxy.networkPolicy.ingress}}
     # depends, but default is nothing --> proxy

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -33,6 +33,12 @@ spec:
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
   #
   ingress:
+    {{- if .Values.proxy.traefik.networkPolicy.allowHttpIngressUnconditionally }}
+    # allow any incoming traffic to these ports
+    - ports:
+      - port: http
+      - port: https
+    {{- else }}
     # allowed pods (hub.jupyter.org/network-access-proxy-http) --> proxy (http/https port)
     - ports:
         - port: http
@@ -52,6 +58,7 @@ spec:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
         {{- end }}
+    {{- end }}
 
     # allowed pods (hub.jupyter.org/network-access-proxy-api) --> proxy (api port)
     - ports:

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -33,12 +33,14 @@ spec:
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
   #
   ingress:
-    {{- if .Values.proxy.traefik.networkPolicy.allowHttpIngressUnconditionally }}
-    # allow any incoming traffic to these ports
+    {{- with .Values.proxy.chp.networkPolicy.allowedIngressPorts }}
+    # allow incoming traffic to these ports independent of source
     - ports:
-      - port: http
-      - port: https
-    {{- else }}
+      {{- range $port := . }}
+      - port: {{ $port }}
+      {{- end }}
+    {{- end }}
+
     # allowed pods (hub.jupyter.org/network-access-proxy-http) --> proxy (http/https port)
     - ports:
         - port: http
@@ -58,7 +60,6 @@ spec:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
         {{- end }}
-    {{- end }}
 
     # allowed pods (hub.jupyter.org/network-access-proxy-api) --> proxy (api port)
     - ports:

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -23,11 +23,11 @@ spec:
   #
   # 1. You can provide "from"/"to" rules that provide access either ports or a
   #    subset of ports.
-  # 2. You can for each "form"/"to" rule provide any number of
+  # 2. You can for each "from"/"to" rule provide any number of
   #    "sources"/"destinations" of four different kinds.
-  #    - podSelector                        - targets pods with a certain label in the NetworkPolicy's namespace
-  #    - namespaceSelector                  - targets all pods within namespaces with a certain label
-  #    - namespaceSelector and podSelector  - targets pods with a certain label within namespaces with a certain label
+  #    - podSelector                        - targets pods with a certain label in the same namespace as the NetworkPolicy
+  #    - namespaceSelector                  - targets all pods running in namespaces with a certain label
+  #    - namespaceSelector and podSelector  - targets pods with a certain label running in namespaces with a certain label
   #    - ipBlock                            - targets network traffic from/to a set of IP address ranges
   #
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -52,7 +52,7 @@ spec:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
-        {{- if eq .Values.proxy.chp.networkPolicy.interNamespaceLabeledIngress "allow" }}
+        {{- if eq .Values.proxy.chp.networkPolicy.interNamespaceAccessLabels "accept" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
         # source 2 - pods in labeled namespaces
@@ -69,7 +69,7 @@ spec:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
-        {{- if eq .Values.proxy.chp.networkPolicy.interNamespaceLabeledIngress "allow" }}
+        {{- if eq .Values.proxy.chp.networkPolicy.interNamespaceAccessLabels "accept" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
         # source 2 - pods in labeled namespaces

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -25,7 +25,9 @@ spec:
         - port: https
         {{- end }}
       from:
-        - podSelector:
+        - namespaceSelector:
+            matchLabels: {}   # allow the label below to be set on a pod in any namespace
+          podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
 
@@ -33,7 +35,9 @@ spec:
     - ports:
         - port: api
       from:
-        - podSelector:
+        - namespaceSelector:
+            matchLabels: {}   # allow the label below to be set on a pod in any namespace
+          podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
 

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -40,9 +40,14 @@ spec:
         - port: https
         {{- end }}
       from:
+        # source 1 - labelled pods
+        - podSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-proxy-http: "true"
+          namespaceSelector:
+            matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+        # source 2 - pods in labelled namespaces
         - namespaceSelector:
-            matchLabels: {}   # allow the label below to be set on a pod in any namespace
-          podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
 
@@ -50,14 +55,19 @@ spec:
     - ports:
         - port: api
       from:
+        # source 1 - labelled pods
+        - podSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-proxy-api: "true"
+          namespaceSelector:
+            matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+        # source 2 - pods in labelled namespaces
         - namespaceSelector:
-            matchLabels: {}   # allow the label below to be set on a pod in any namespace
-          podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
 
     {{- with .Values.proxy.networkPolicy.ingress}}
-    # default: nothing --> proxy
+    # depends, but default is nothing --> proxy
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
 
@@ -80,7 +90,7 @@ spec:
               {{- $_ := merge (dict "componentLabel" "singleuser-server") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
 
-    # proxy -> Kubernetes internal DNS
+    # proxy --> Kubernetes internal DNS
     - ports:
       - protocol: UDP
         port: 53
@@ -88,7 +98,7 @@ spec:
         port: 53
 
     {{- with .Values.proxy.networkPolicy.egress }}
-    # proxy --> default: everything
+    # proxy --> depends, but the default is everything
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -17,6 +17,21 @@ spec:
     - Ingress
     - Egress
 
+  # IMPORTANT:
+  # NetworkPolicy's ingress "from" and egress "to" rule specifications require
+  # great attention to detail. A quick summary is:
+  #
+  # 1. You can provide "from"/"to" rules that provide access either ports or a
+  #    subset of ports.
+  # 2. You can for each "form"/"to" rule provide any number of
+  #    "sources"/"destinations" of four different kinds.
+  #    - podSelector                        - targets pods with a certain label in the NetworkPolicy's namespace
+  #    - namespaceSelector                  - targets all pods within namespaces with a certain label
+  #    - namespaceSelector and podSelector  - targets pods with a certain label within namespaces with a certain label
+  #    - ipBlock                            - targets network traffic from/to a set of IP address ranges
+  #
+  # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
+  #
   ingress:
     # allowed pods (hub.jupyter.org/network-access-proxy-http) --> proxy (http/https port)
     - ports:

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -40,52 +40,34 @@ spec:
         - port: https
         {{- end }}
       from:
-        {{- with .Values.proxy.networkPolicy.interNamespaceIngressForHTTPPort }}
-        # source 1 - labelled pods
+        # source 1 - labeled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
-          {{- if eq . "requireEitherPodOrNamespaceLabel" }}
+        {{- if eq .Values.proxy.networkPolicy.interNamespaceLabeledIngress "allow" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
-          {{- else if eq . "requireBothPodAndNamespaceLabel" }}
-          namespaceSelector:
-            matchLabels:
-              hub.jupyter.org/network-access-proxy-http: "true"
-          {{- end }}
-
-        {{- if or (eq . "requireEitherPodOrNamespaceLabel") (eq . "requireNamespaceLabel") }}
-        # source 2 - pods in labelled namespaces
+        # source 2 - pods in labeled namespaces
         - namespaceSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
-        {{- end }}
         {{- end }}
 
     # allowed pods (hub.jupyter.org/network-access-proxy-api) --> proxy (api port)
     - ports:
         - port: api
       from:
-        {{- with .Values.proxy.networkPolicy.interNamespaceIngressForAPIPort }}
-        # source 1 - labelled pods
+        # source 1 - labeled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
-          {{- if eq . "requireEitherPodOrNamespaceLabel" }}
+        {{- if eq .Values.proxy.networkPolicy.interNamespaceLabeledIngress "allow" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
-          {{- else if eq . "requireBothPodAndNamespaceLabel" }}
-          namespaceSelector:
-            matchLabels:
-              hub.jupyter.org/network-access-proxy-api: "true"
-          {{- end }}
-
-        {{- if or (eq . "requireEitherPodOrNamespaceLabel") (eq . "requireNamespaceLabel") }}
-        # source 2 - pods in labelled namespaces
+        # source 2 - pods in labeled namespaces
         - namespaceSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
-        {{- end }}
         {{- end }}
 
     {{- with .Values.proxy.networkPolicy.ingress}}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -19,7 +19,9 @@ spec:
     - ports:
         - port: notebook-port
       from:
-        - podSelector:
+        - namespaceSelector:
+            matchLabels: {}   # allow the label below to be set on a pod in any namespace
+          podSelector:
             matchLabels:
               hub.jupyter.org/network-access-singleuser: "true"
 

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -20,11 +20,11 @@ spec:
   #
   # 1. You can provide "from"/"to" rules that provide access either ports or a
   #    subset of ports.
-  # 2. You can for each "form"/"to" rule provide any number of
+  # 2. You can for each "from"/"to" rule provide any number of
   #    "sources"/"destinations" of four different kinds.
-  #    - podSelector                        - targets pods with a certain label in the NetworkPolicy's namespace
-  #    - namespaceSelector                  - targets all pods within namespaces with a certain label
-  #    - namespaceSelector and podSelector  - targets pods with a certain label within namespaces with a certain label
+  #    - podSelector                        - targets pods with a certain label in the same namespace as the NetworkPolicy
+  #    - namespaceSelector                  - targets all pods running in namespaces with a certain label
+  #    - namespaceSelector and podSelector  - targets pods with a certain label running in namespaces with a certain label
   #    - ipBlock                            - targets network traffic from/to a set of IP address ranges
   #
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -34,16 +34,27 @@ spec:
     - ports:
         - port: notebook-port
       from:
+        {{- with .Values.singleuser.networkPolicy.interNamespaceIngressForHTTPPort }}
         # source 1 - labelled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-singleuser: "true"
+          {{- if eq . "requireEitherPodOrNamespaceLabel" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+          {{- else if eq . "requireBothPodAndNamespaceLabel" }}
+          namespaceSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-singleuser: "true"
+          {{- end }}
+
+        {{- if or (eq . "requireEitherPodOrNamespaceLabel") (eq . "requireNamespaceLabel") }}
         # source 2 - pods in labelled namespaces
         - namespaceSelector:
             matchLabels:
               hub.jupyter.org/network-access-singleuser: "true"
+        {{- end }}
+        {{- end }}
 
     {{- with .Values.singleuser.networkPolicy.ingress }}
     # depends, but default is nothing --> singleuser-server

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -34,14 +34,19 @@ spec:
     - ports:
         - port: notebook-port
       from:
+        # source 1 - labelled pods
+        - podSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-singleuser: "true"
+          namespaceSelector:
+            matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+        # source 2 - pods in labelled namespaces
         - namespaceSelector:
-            matchLabels: {}   # allow the label below to be set on a pod in any namespace
-          podSelector:
             matchLabels:
               hub.jupyter.org/network-access-singleuser: "true"
 
     {{- with .Values.singleuser.networkPolicy.ingress }}
-    # default: nothing --> singleuser-server
+    # depends, but default is nothing --> singleuser-server
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
 
@@ -55,7 +60,7 @@ spec:
               {{- $_ := merge (dict "componentLabel" "hub") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
 
-    # singleuser-server -> Kubernetes internal DNS
+    # singleuser-server --> Kubernetes internal DNS
     - ports:
         - protocol: UDP
           port: 53
@@ -63,7 +68,7 @@ spec:
           port: 53
 
     {{- with .Values.singleuser.networkPolicy.egress }}
-    # singleuser-server --> default: everything
+    # singleuser-server --> depends, but the default is everything
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -34,26 +34,17 @@ spec:
     - ports:
         - port: notebook-port
       from:
-        {{- with .Values.singleuser.networkPolicy.interNamespaceIngressForHTTPPort }}
-        # source 1 - labelled pods
+        # source 1 - labeled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-singleuser: "true"
-          {{- if eq . "requireEitherPodOrNamespaceLabel" }}
+        {{- if eq .Values.singleuser.networkPolicy.interNamespaceLabeledIngress "allow" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
-          {{- else if eq . "requireBothPodAndNamespaceLabel" }}
-          namespaceSelector:
-            matchLabels:
-              hub.jupyter.org/network-access-singleuser: "true"
-          {{- end }}
-
-        {{- if or (eq . "requireEitherPodOrNamespaceLabel") (eq . "requireNamespaceLabel") }}
-        # source 2 - pods in labelled namespaces
+        # source 2 - pods in labeled namespaces
         - namespaceSelector:
             matchLabels:
               hub.jupyter.org/network-access-singleuser: "true"
-        {{- end }}
         {{- end }}
 
     {{- with .Values.singleuser.networkPolicy.ingress }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -14,6 +14,21 @@ spec:
     - Ingress
     - Egress
 
+  # IMPORTANT:
+  # NetworkPolicy's ingress "from" and egress "to" rule specifications require
+  # great attention to detail. A quick summary is:
+  #
+  # 1. You can provide "from"/"to" rules that provide access either ports or a
+  #    subset of ports.
+  # 2. You can for each "form"/"to" rule provide any number of
+  #    "sources"/"destinations" of four different kinds.
+  #    - podSelector                        - targets pods with a certain label in the NetworkPolicy's namespace
+  #    - namespaceSelector                  - targets all pods within namespaces with a certain label
+  #    - namespaceSelector and podSelector  - targets pods with a certain label within namespaces with a certain label
+  #    - ipBlock                            - targets network traffic from/to a set of IP address ranges
+  #
+  # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
+  #
   ingress:
     # allowed pods (hub.jupyter.org/network-access-singleuser) --> singleuser-server
     - ports:

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -30,6 +30,14 @@ spec:
   # Read more at: https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors
   #
   ingress:
+    {{- with .Values.singleuser.networkPolicy.allowedIngressPorts }}
+    # allow incoming traffic to these ports independent of source
+    - ports:
+      {{- range $port := . }}
+      - port: {{ $port }}
+      {{- end }}
+    {{- end }}
+
     # allowed pods (hub.jupyter.org/network-access-singleuser) --> singleuser-server
     - ports:
         - port: notebook-port

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -46,7 +46,7 @@ spec:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-singleuser: "true"
-        {{- if eq .Values.singleuser.networkPolicy.interNamespaceLabeledIngress "allow" }}
+        {{- if eq .Values.singleuser.networkPolicy.interNamespaceAccessLabels "accept" }}
           namespaceSelector:
             matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
         # source 2 - pods in labeled namespaces

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -98,6 +98,7 @@ hub:
           - ipBlock:
               cidr: 0.0.0.0/0
     interNamespaceLabeledIngress: block
+    allowedIngressPorts: []
   allowNamedServers: false
   namedServerLimitPerUser:
   authenticatePrometheus:
@@ -200,7 +201,7 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceLabeledIngress: allow
-      allowHttpIngressUnconditionally: true
+      allowedIngressPorts: [http, https]
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
   traefik:
@@ -236,7 +237,7 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceLabeledIngress: allow
-      allowHttpIngressUnconditionally: true
+      allowedIngressPorts: [http, https]
   secretSync:
     containerSecurityContext:
       runAsUser: 65534  # nobody user
@@ -332,6 +333,7 @@ singleuser:
               except:
                 - 169.254.169.254/32
     interNamespaceLabeledIngress: block
+    allowedIngressPorts: []
   events: true
   extraAnnotations: {}
   extraLabels:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -200,7 +200,7 @@ proxy:
         - to:
             - ipBlock:
                 cidr: 0.0.0.0/0
-      interNamespaceAccessLabels: accept
+      interNamespaceAccessLabels: ignore
       allowedIngressPorts: [http, https]
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
@@ -236,7 +236,7 @@ proxy:
         - to:
             - ipBlock:
                 cidr: 0.0.0.0/0
-      interNamespaceAccessLabels: accept
+      interNamespaceAccessLabels: ignore
       allowedIngressPorts: [http, https]
   secretSync:
     containerSecurityContext:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -97,7 +97,7 @@ hub:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
-    interNamespaceLabeledIngress: block
+    interNamespaceAccessLabels: ignore
     allowedIngressPorts: []
   allowNamedServers: false
   namedServerLimitPerUser:
@@ -200,7 +200,7 @@ proxy:
         - to:
             - ipBlock:
                 cidr: 0.0.0.0/0
-      interNamespaceLabeledIngress: allow
+      interNamespaceAccessLabels: accept
       allowedIngressPorts: [http, https]
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
@@ -236,7 +236,7 @@ proxy:
         - to:
             - ipBlock:
                 cidr: 0.0.0.0/0
-      interNamespaceLabeledIngress: allow
+      interNamespaceAccessLabels: accept
       allowedIngressPorts: [http, https]
   secretSync:
     containerSecurityContext:
@@ -332,7 +332,7 @@ singleuser:
               cidr: 0.0.0.0/0
               except:
                 - 169.254.169.254/32
-    interNamespaceLabeledIngress: block
+    interNamespaceAccessLabels: ignore
     allowedIngressPorts: []
   events: true
   extraAnnotations: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -97,7 +97,7 @@ hub:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
-    interNamespaceIngressForHTTPPort: deny
+    interNamespaceLabeledIngress: block
   allowNamedServers: false
   namedServerLimitPerUser:
   authenticatePrometheus:
@@ -192,6 +192,14 @@ proxy:
     extraEnv: {}
     nodeSelector: {}
     tolerations: []
+    networkPolicy:
+      enabled: true
+      ingress: []
+      egress:
+        - to:
+            - ipBlock:
+                cidr: 0.0.0.0/0
+      interNamespaceLabeledIngress: allow
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
   traefik:
@@ -219,6 +227,14 @@ proxy:
     extraDynamicConfig: {}
     nodeSelector: {}
     tolerations: []
+    networkPolicy:
+      enabled: true
+      ingress: []
+      egress:
+        - to:
+            - ipBlock:
+                cidr: 0.0.0.0/0
+      interNamespaceLabeledIngress: allow
   secretSync:
     containerSecurityContext:
       runAsUser: 65534  # nobody user
@@ -250,14 +266,6 @@ proxy:
       key: tls.key
       crt: tls.crt
     hosts: []
-  networkPolicy:
-    enabled: true
-    ingress: []
-    egress:
-      - to:
-          - ipBlock:
-              cidr: 0.0.0.0/0
-    interNamespaceIngressForHTTPPort: requireEitherPodOrNamespaceLabel
 
 
 # auth relates to the configuration of JupyterHub's Authenticator class.
@@ -321,7 +329,7 @@ singleuser:
               cidr: 0.0.0.0/0
               except:
                 - 169.254.169.254/32
-    interNamespaceIngressForHTTPPort: deny
+    interNamespaceLabeledIngress: block
   events: true
   extraAnnotations: {}
   extraLabels:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -97,6 +97,7 @@ hub:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
+    interNamespaceIngressForHTTPPort: deny
   allowNamedServers: false
   namedServerLimitPerUser:
   authenticatePrometheus:
@@ -256,6 +257,7 @@ proxy:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
+    interNamespaceIngressForHTTPPort: requireEitherPodOrNamespaceLabel
 
 
 # auth relates to the configuration of JupyterHub's Authenticator class.
@@ -319,6 +321,7 @@ singleuser:
               cidr: 0.0.0.0/0
               except:
                 - 169.254.169.254/32
+    interNamespaceIngressForHTTPPort: deny
   events: true
   extraAnnotations: {}
   extraLabels:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -200,6 +200,7 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceLabeledIngress: allow
+      allowHttpIngressUnconditionally: true
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
   traefik:
@@ -235,6 +236,7 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceLabeledIngress: allow
+      allowHttpIngressUnconditionally: true
   secretSync:
     containerSecurityContext:
       runAsUser: 65534  # nobody user

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -100,7 +100,7 @@ proxy:
     extraPorts:
     - name: ssh
       port: 22
-      targetPort: 22
+      targetPort: ssh
     type: LoadBalancer
     labels:
       MOCK_PROXY_ENV: mock

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -135,6 +135,7 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceLabeledIngress: allow
+      allowHttpIngressUnconditionally: true
   traefik:
     labels:
       hub.jupyter.org/test-label: mock
@@ -166,6 +167,7 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceLabeledIngress: allow
+      allowHttpIngressUnconditionally: true
   secretSync:
     resources:
       requests:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -75,7 +75,7 @@ hub:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
-    interNamespaceLabeledIngress: block
+    interNamespaceAccessLabels: ignore
     allowedIngressPorts: []
   allowNamedServers: true
   nodeSelector:
@@ -135,7 +135,7 @@ proxy:
         - to:
             - ipBlock:
                 cidr: 0.0.0.0/0
-      interNamespaceLabeledIngress: allow
+      interNamespaceAccessLabels: accept
       allowedIngressPorts: [http, https]
   traefik:
     labels:
@@ -167,7 +167,7 @@ proxy:
         - to:
             - ipBlock:
                 cidr: 0.0.0.0/0
-      interNamespaceLabeledIngress: allow
+      interNamespaceAccessLabels: accept
       allowedIngressPorts: [http, https]
   secretSync:
     resources:
@@ -296,7 +296,7 @@ singleuser:
               cidr: 0.0.0.0/0
               except:
                 - 169.254.169.254/32
-    interNamespaceLabeledIngress: block
+    interNamespaceAccessLabels: ignore
     allowedIngressPorts: []
   events: true
   extraLabels: {}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -75,6 +75,7 @@ hub:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
+    interNamespaceIngressForHTTPPort: deny
   allowNamedServers: true
   nodeSelector:
     node-type: mock
@@ -185,6 +186,8 @@ proxy:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
+    interNamespaceIngressForHTTPPort: requireEitherPodOrNamespaceLabel
+    interNamespaceIngressForAPIPort: requireBothPodAndNamespaceLabel
 
 
 auth:
@@ -284,6 +287,7 @@ singleuser:
               cidr: 0.0.0.0/0
               except:
                 - 169.254.169.254/32
+    interNamespaceIngressForHTTPPort: requireNamespaceLabel
   events: true
   extraLabels: {}
   extraEnv: {}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -75,7 +75,7 @@ hub:
       - to:
           - ipBlock:
               cidr: 0.0.0.0/0
-    interNamespaceIngressForHTTPPort: deny
+    interNamespaceLabeledIngress: block
   allowNamedServers: true
   nodeSelector:
     node-type: mock
@@ -128,6 +128,13 @@ proxy:
         operator: "Equal"
         value: "mock-taint-to-tolerates-value"
         effect: "NoExecute"
+    networkPolicy:
+      enabled: true
+      egress:
+        - to:
+            - ipBlock:
+                cidr: 0.0.0.0/0
+      interNamespaceLabeledIngress: allow
   traefik:
     labels:
       hub.jupyter.org/test-label: mock
@@ -152,6 +159,13 @@ proxy:
         operator: "Equal"
         value: "mock-taint-to-tolerates-value"
         effect: "NoExecute"
+    networkPolicy:
+      enabled: true
+      egress:
+        - to:
+            - ipBlock:
+                cidr: 0.0.0.0/0
+      interNamespaceLabeledIngress: allow
   secretSync:
     resources:
       requests:
@@ -180,14 +194,6 @@ proxy:
       key: 'mock-key'
       crt: 'mock-crt'
     hosts: [domain.com]
-  networkPolicy:
-    enabled: true
-    egress:
-      - to:
-          - ipBlock:
-              cidr: 0.0.0.0/0
-    interNamespaceIngressForHTTPPort: requireEitherPodOrNamespaceLabel
-    interNamespaceIngressForAPIPort: requireBothPodAndNamespaceLabel
 
 
 auth:
@@ -287,7 +293,7 @@ singleuser:
               cidr: 0.0.0.0/0
               except:
                 - 169.254.169.254/32
-    interNamespaceIngressForHTTPPort: requireNamespaceLabel
+    interNamespaceLabeledIngress: block
   events: true
   extraLabels: {}
   extraEnv: {}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -76,6 +76,7 @@ hub:
           - ipBlock:
               cidr: 0.0.0.0/0
     interNamespaceLabeledIngress: block
+    allowedIngressPorts: []
   allowNamedServers: true
   nodeSelector:
     node-type: mock
@@ -135,7 +136,7 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceLabeledIngress: allow
-      allowHttpIngressUnconditionally: true
+      allowedIngressPorts: [http, https]
   traefik:
     labels:
       hub.jupyter.org/test-label: mock
@@ -167,7 +168,7 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceLabeledIngress: allow
-      allowHttpIngressUnconditionally: true
+      allowedIngressPorts: [http, https]
   secretSync:
     resources:
       requests:
@@ -296,6 +297,7 @@ singleuser:
               except:
                 - 169.254.169.254/32
     interNamespaceLabeledIngress: block
+    allowedIngressPorts: []
   events: true
   extraLabels: {}
   extraEnv: {}


### PR DESCRIPTION
# PR changes summarized

### Breaking change
- `proxy.networkPolicy` is deprecated, and `proxy.chp.networkPolicy` and `proxy.traefik.networkPolicy` is introduced.

### Restores access to `proxy` pod's http/https ports by default (bugfix)
Since #1670 the proxy pod would not accept incoming traffic from pods in other namespaces, due to a bugfix that caused a breaking change. This can be observed in #1863 for example I think.

```diff
     - ports:
         - port: http
         {{- if or $manualHTTPS $manualHTTPSwithsecret }}
         - port: https
         {{- end }}
-    - from:
+      from:
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-http: "true"
```

The bug fixed was that `hub.jupyter.org/network-access-proxy-http: "true"` was entirely ignored and had no meaning, but now that it got meaning, we ended up restricting access too much. As an example, the proxy would reject incoming traffic from a nginx-ingress-controller pod that terminated TLS in another namespace.

In this PR I introduce the networkPolicy configuration `allowedIngressPorts` as suggested by @manics, and configures it for `proxy.chp.networkPolicy` and `proxy.traefik.networkPolicy` to be set to `[http, https]` by default, while the networkPolicy configuration for hub/singleuser will not allow any of this by default.

This provides us with a configuration concept applicable to all networkPolicy resources we deploy, while retaining ability to work with even finer grained control with network access labels.

### Conditional use of access labels across namespaces (enhancement)
This PR let's the respective `networkPolicy` configuration configure `interNamespaceAccessLabels`. If this configuration option is set to `accept`, the access labels valid for the respective networkPolicy configuration, such as `hub.jupyter.org/network-access-proxy-api: "true"`, will be accepted even on pods in other namespaces, and on entire namespaces, to allow these pods as sources for incoming network traffic.

```diff
+        # source 1 - labelled pods
         - podSelector:
             matchLabels:
               hub.jupyter.org/network-access-proxy-api: "true"
+        {{- if eq .Values.proxy.chp.networkPolicy.interNamespaceAccessLabels "accept" }}
+          namespaceSelector:
+            matchLabels: {}   # without this, the podSelector would only consider pods in the local namespace
+        # source 2 - pods in labeled namespaces
+        - namespaceSelector:
+            matchLabels:
+              hub.jupyter.org/network-access-proxy-api: "true"
+        {{- end }}
```

# Motivation
Network policies are enabled by default as of #1271, and we need ability to configure access in a way that won't force users and maintainers to debug k8s native network policy configuration which is notoriously hard to understand correctly. Closes #1863.

### allowedIngressPorts config
We needed to come up with a solution after #1670, which as described below ended up restricting ingress, for example from a nginx-ingress-controller pod in another namespace, towards the proxy pod. At the same time, we should have a flexible and cohesive configuration of networkPolicies.

### interNamespaceAccessLabels config
`interNamespaceAccessLabels` is ensuring that users are not forced to add fragile workarounds if they need to access something from another namespace in the future, and by avoiding fragile workarounds, we avoid complicated issue reports following the fragile configurations future failures.

# Related
### NetworkPolicy documentation
[This section of the k8s documentation](https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors) is very relevant details on the rules that we can set in a NetworkPolicy from the k8s docs, distinguishing between: a) podSelector, b) namespaceSelector, c) podSelector AND namespaceSelector, and d) ipblock.