### PR TITLE
Add dependabot config to update dependencies automatically

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,3 @@ updates:
     - dependencies
   commit-message:
     prefix: "hub image: "
-- package_manager: "docker"
-  directory: "/"
-  update_schedule: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/images"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  versioning-strategy: lockfile-only
+- package_manager: "docker"
+  directory: "/"
+  update_schedule: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,11 +1,18 @@
+# dependabot.yml reference: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
+# Automatically update python packages for the jupyterhub/k8s-hub image
 - package-ecosystem: pip
-  directory: "/images"
+  directory: "/images/hub"
   schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
+    interval: daily
+  open-pull-requests-limit: 4
   versioning-strategy: lockfile-only
+  labels:
+    - maintenance
+    - dependencies
+  commit-message:
+    prefix: "hub image: "
 - package_manager: "docker"
   directory: "/"
   update_schedule: "weekly"


### PR DESCRIPTION
- Update pip dependencies with `lock-file` versioning strategy 
- Update docker dependencies (EDIT: remove for now)
- Set scheduled dependency checks to weekly (EDIT: daily)

EDIT: May end up closing #1753 if we get this right - keeping it open a while