### PR TITLE
Add proxy.service.extraPorts to add ports to the k8s Service proxy-public

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -612,7 +612,14 @@ properties:
       service:
         type: object
         description: |
-          Object to configure the service the JupyterHub's proxy will be exposed on by the Kubernetes server.
+          Configuration of the k8s Service `proxy-public` which either will
+          point to the `autohttps` pod running Traefik for TLS termination, or
+          the `proxy` pod running ConfigurableHTTPProxy. Incoming traffic from
+          users on the internet should always go through this k8s Service.
+
+          When this service targets the `autohttps` pod which then routes to the
+          `proxy` pod, a k8s Service named `proxy-http` will be added targeting
+          the `proxy` pod and only accepting HTTP traffic on port 80.
         properties:
           type: 
             type: string
@@ -658,9 +665,12 @@ properties:
           extraPublicPorts:
             type: list
             description: |
-              Extra ports to be exposed on the public service pointing to the proxy.
+              Extra ports the k8s Service should accept incoming traffic on,
+              which will be redirected to either the `autohttps` pod (treafik)
+              or the `proxy` pod (chp).
 
-              See [the Kubernetes documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#serviceport-v1-core)
+              See [the Kubernetes
+              documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#serviceport-v1-core)
               for the structure of the items in this list.
           loadBalancerIP:
             type: string

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -655,6 +655,13 @@ properties:
                 type: integer
                 description: |
                   The HTTPS port the proxy-public service should be exposed on.
+          extraPublicPorts:
+            type: list
+            description: |
+              Extra ports to be exposed on the public service pointing to the proxy.
+
+              See [the Kubernetes documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#serviceport-v1-core)
+              for the structure of the items in this list.
           loadBalancerIP:
             type: string
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -662,7 +662,7 @@ properties:
                 type: integer
                 description: |
                   The HTTPS port the proxy-public service should be exposed on.
-          extraPublicPorts:
+          extraPorts:
             type: list
             description: |
               Extra ports the k8s Service should accept incoming traffic on,

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -63,7 +63,7 @@ spec:
       {{- with .Values.proxy.service.nodePorts.http }}
       nodePort: {{ . }}
       {{- end }}
-    {{- with .Values.proxy.extraPublicPorts }}
+    {{- with .Values.proxy.service.extraPublicPorts }}
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end}}
   type: {{ .Values.proxy.service.type }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -63,7 +63,7 @@ spec:
       {{- with .Values.proxy.service.nodePorts.http }}
       nodePort: {{ . }}
       {{- end }}
-    {{- with .Values.proxy.service.extraPublicPorts }}
+    {{- with .Values.proxy.service.extraPorts }}
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
   type: {{ .Values.proxy.service.type }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -63,6 +63,9 @@ spec:
       {{- with .Values.proxy.service.nodePorts.http }}
       nodePort: {{ . }}
       {{- end }}
+    {{- with .Values.proxy.extraPublicPorts }}
+    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- end}}
   type: {{ .Values.proxy.service.type }}
   {{- with .Values.proxy.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -65,7 +65,7 @@ spec:
       {{- end }}
     {{- with .Values.proxy.service.extraPublicPorts }}
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
-    {{- end}}
+    {{- end }}
   type: {{ .Values.proxy.service.type }}
   {{- with .Values.proxy.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -160,7 +160,7 @@ proxy:
     nodePorts:
       http:
       https:
-    extraPublicPorts: []
+    extraPorts: []
     loadBalancerIP:
     loadBalancerSourceRanges: []
   # chp relates to the proxy pod, which is responsible for routing traffic based

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -160,6 +160,7 @@ proxy:
     nodePorts:
       http:
       https:
+    extraPublicPorts: []
     loadBalancerIP:
     loadBalancerSourceRanges: []
   # chp relates to the proxy pod, which is responsible for routing traffic based

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -96,7 +96,7 @@ rbac:
 proxy:
   secretToken: '0000000000000000000000000000000000000000000000000000000000000000'
   service:
-    extraPublicPorts:
+    extraPorts:
     - name: ssh
       port: 22
       targetPort: 22

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -96,6 +96,10 @@ rbac:
 proxy:
   secretToken: '0000000000000000000000000000000000000000000000000000000000000000'
   service:
+    extraPublicPorts:
+    - name: ssh
+      port: 22
+      targetPort: 22
     type: LoadBalancer
     labels:
       MOCK_PROXY_ENV: mock


### PR DESCRIPTION
Now that we have proxy.traefik.extra(Static|Dynamic)Config,
we can configure traefik to do more proxying. Specifically,
I want it to proxy ssh traffic to an instance of
[jupyterhub-ssh](https://github.com/yuvipanda/jupyterhub-ssh).

This works fine, but we need to have proxy-public expose
port 22 to the world. Currently this is impossible -
this PR allows adding additional ports here.


----

## PR summary by consideRatio
- proxy.service.extraPorts configuration added, influencing the proxy-public service, which goes either to autohttps (traefik) or the proxy pod (chp).
- NetworkPolicy rules for ingress may need to be configured separately to this for the receiving pod to not get this kind of new traffic be blocked.