### PR TITLE
CI: Try to improve test stability and autohttps cert aquisition reliability

### DIFF
--- a/ci/common
+++ b/ci/common
@@ -187,4 +187,12 @@ full_namespace_report () {
         '
     ) | xargs --max-args 1 --no-run-if-empty --max-lines \
     sh -c 'printf "\nPending user pod detected ($0)\n - Logs of deploy/user-scheduler:\n"; kubectl logs --all-containers deploy/user-scheduler'
+
+    echo ""
+    echo "Just while debugging intermittent issue, lets output the logs of the hub."
+    kubectl logs --all-containers deploy/hub
+
+    echo ""
+    echo "Just while debugging intermittent issue, lets output the logs of the proxy pod."
+    kubectl logs --all-containers deploy/proxy
 }

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -200,7 +200,7 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: traefik
-      tag: v2.3 # ref: https://hub.docker.com/_/traefik?tab=tags
+      tag: v2.3.0 # ref: https://hub.docker.com/_/traefik?tab=tags
       pullPolicy: ''
       pullSecrets: []
     hsts:

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -166,11 +166,11 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
     r = api_request.post("/users/" + jupyter_user + "/server")
     assert r.status_code in (201, 202)
     try:
+        # check successfull spawn
         server_model = _wait_for_user_to_spawn(
             api_request, jupyter_user, request_data["test_timeout"]
         )
         assert server_model
-        print(server_model)
         pod_name = server_model["state"]["pod_name"]
 
         c = subprocess.run([
@@ -218,6 +218,7 @@ def _wait_for_user_to_spawn(api_request, jupyter_user, timeout):
         # server will be set when ready
         if "" not in user_model["servers"]:
             # spawn failed!
+            print(user_model)
             raise RuntimeError("Server never started!")
 
         server_model = user_model["servers"][""]

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -214,16 +214,14 @@ def _wait_for_user_to_spawn(api_request, jupyter_user, timeout):
         r.raise_for_status()
         user_model = r.json()
 
-        # will be pending while starting,
-        # server will be set when ready
-        if "" not in user_model["servers"]:
-            # spawn failed!
-            print(user_model)
-            raise RuntimeError("Server never started!")
-
-        server_model = user_model["servers"][""]
-        if server_model["ready"]:
-            return server_model
+        # Note that JupyterHub has a concept of named servers, so the default
+        # server is named "", a blank string.
+        if "" in user_model["servers"]:
+            server_model = user_model["servers"][""]
+            if server_model["ready"]:
+                return server_model
+        else:
+            print("Awaiting server info to be part of user_model...")
 
         time.sleep(1)
     return False


### PR DESCRIPTION
Meant to fix #1853.

## Pr changes
1. Additional logs on CI failures
2. Traefik pinned to v2.3.0
   The motivation is to see if there is a race condition in v2.3.0 specifically, because we have run into some issues in v2.3.1 as can be seen in https://travis-ci.org/github/jupyterhub/zero-to-jupyterhub-k8s/jobs/737397758.
3. Bugfix in the check if a user server has started up.
   I think I used a faulty assumption before.