### PR TITLE
DO NOT MERGE: testing intermitt errors with traefik

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - await_pebble  # jupyterhub's autohttps communicates with it as the ACME server
 script:
   # Install JupyterHub
-  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.3.0
+  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.3.1
   - await_jupyterhub
   - await_autohttps_tls_cert_acquisition
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ install:
   - await_pebble  # jupyterhub's autohttps communicates with it as the ACME server
 script:
   # Install JupyterHub
-  - helm install jupyterhub ./jupyterhub --values dev-config.yaml
+  - helm install jupyterhub ./jupyterhub --values dev-config.yaml \
+        --set proxy.traefik.image.tag=v2.3.2
   - await_jupyterhub
   - await_autohttps_tls_cert_acquisition
 
@@ -81,33 +82,6 @@ jobs:
 
   ## define individual jobs that can rely on defaults from above
   include:
-    - stage: test
-      name: chart:install-latest-then-upgrade
-      script:
-        ## NOTE: To use Pebble in Travis CI, we require the ability to mount a
-        ##       certificate on the autohttps pod, but we can't because that
-        ##       configuration ability was added after 0.9.0. Due to this
-        ##       autohttps is disabled here.
-        ##       The current dev-config.yaml require network policies to contain
-        ##       more pre-defined defaults to reach the DNS server not present
-        ##       in 0.9.0, and are due to this disabled.
-        - |
-            helm install jupyterhub jupyterhub/jupyterhub --values dev-config.yaml \
-                --set proxy.https.enabled=false \
-                --set hub.networkPolicy.enabled=false \
-                --set proxy.networkPolicy.enabled=false \
-                --set singleuser.networkPolicy.enabled=false \
-                --set proxy.traefik.image.tag=v2.3.2
-        - await_jupyterhub
-
-        # Upgrade JupyterHub to what's locally available
-        - helm upgrade jupyterhub ./jupyterhub --values dev-config.yaml
-        - await_jupyterhub
-        - await_autohttps_tls_cert_acquisition
-
-        # Run tests
-        - pytest --verbose --exitfirst ./tests || (full_namespace_report && exit 1)
-
     ## k3s versions:  https://github.com/rancher/k3s/releases
     - stage: test
       name: intermittency-test-01

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
 script:
   # Install JupyterHub
   - helm install jupyterhub ./jupyterhub --values dev-config.yaml \
-        --set proxy.traefik.image.tag=v2.3.2
+        --set proxy.traefik.image.tag=v2.2.11
   - await_jupyterhub
   - await_autohttps_tls_cert_acquisition
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,8 @@ script:
   - await_autohttps_tls_cert_acquisition
 
   # Run tests
-  - pytest --verbose --exitfirst ./tests || (full_namespace_report && exit 1)
+  # DISABLED FOR INTERMITTENCY TESTING OF AUTOHTTPS CERT ACQUISITION
+  # - pytest --verbose --exitfirst ./tests || (full_namespace_report && exit 1)
 
 env:
   ## Global environment variables will act as defaults, jobs will override them
@@ -81,26 +82,6 @@ jobs:
   ## define individual jobs that can rely on defaults from above
   include:
     - stage: test
-      name: chart:lint-and-validate
-      install:
-        - setup_helm
-        - setup_kubeval
-        - pip install yamllint
-      script:
-        # NOTE: Kubernetes resource validation can only be done against
-        #       Kubernetes versions with schemas available in:
-        #       https://github.com/instrumenta/kubernetes-json-schema
-        #
-        # NOTE: The "helm template" command will evaluate
-        #       .Capabilities.APIVersion.Has in templates based on a Kubernetes
-        #       version associated with the helm binary's version. Since we
-        #       render the templates with a specific helm version, we end up
-        #       rendering templates using a mocked k8s version unrelated to the
-        #       Kubernetes version we want to validate against. This issue has
-        #       made us not validate against versions lower than 1.14.
-        - tools/templates/lint-and-validate.py --kubernetes-versions 1.14.0,1.18.0
-
-    - stage: test
       name: chart:install-latest-then-upgrade
       script:
         ## NOTE: To use Pebble in Travis CI, we require the ability to mount a
@@ -115,7 +96,8 @@ jobs:
                 --set proxy.https.enabled=false \
                 --set hub.networkPolicy.enabled=false \
                 --set proxy.networkPolicy.enabled=false \
-                --set singleuser.networkPolicy.enabled=false
+                --set singleuser.networkPolicy.enabled=false \
+                --set proxy.traefik.image.tag=v2.3.2
         - await_jupyterhub
 
         # Upgrade JupyterHub to what's locally available
@@ -128,41 +110,200 @@ jobs:
 
     ## k3s versions:  https://github.com/rancher/k3s/releases
     - stage: test
-      name: chart:k8s-1.19
+      name: intermittency-test-01
 
+    ## k3s versions:  https://github.com/rancher/k3s/releases
     - stage: test
-      name: chart:k8s-1.18
-      env: K3S_VERSION=v1.18.10+k3s1
+      name: intermittency-test-02
 
+    ## k3s versions:  https://github.com/rancher/k3s/releases
     - stage: test
-      name: chart:k8s-1.17
-      env: K3S_VERSION=v1.17.13+k3s1
+      name: intermittency-test-03
 
+    ## k3s versions:  https://github.com/rancher/k3s/releases
     - stage: test
-      name: chart:k8s-1.16
-      env: K3S_VERSION=v1.16.15+k3s1 k3s_disable_command=--no-deploy
+      name: intermittency-test-04
 
+    ## k3s versions:  https://github.com/rancher/k3s/releases
     - stage: test
-      name: docs:link-check
-      install:
-        - pip install --no-cache-dir -r doc/doc-requirements.txt
-      script:
-        - cd doc
-        - make html SPHINXOPTS='-W --keep-going'
-        - make linkcheck
+      name: intermittency-test-05
 
-    - stage: publish
-      name: publish:helm-chart
-      install:
-        - pip install --no-cache-dir -r dev-requirements.txt
-      script:
-        - setup_helm
-        - remove_docker_mirror_on_travis
-        - ./ci/publish
-      env:
-        ## encrypted environment variables DOCKER_USERNAME and DOCKER_PASSWORD,
-        ## used in the publish script to push built docker images to docker hub.
-        ##
-        ## ref: https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables
-        - secure: jpFpbMccpjGP+otWH2Z03VFdtR9AAu2vzrNxsoZ3IvJvrO4MfzYJ3uSCDQuB0NG9gBgaAscpTJtliPTEi7njXHLcsFeWXLUmeBEHLozYxfzDQzMvW3EYdNWcC7oVAAt3de0i0ojw9rGswiofhbu2dAe+Xd2bejv1+PVJcEC3SRPGy17kb6bme6gD3zty5ft4VpzP0nomUNqfZBRLUYxSZuKlHJaZ6Nuq434rKmXrcN6uy+eEWDorTbjyM22IIYgUmrhg++Qtu/MBR7/rriPhyRltCU14361bcxqyq2Hw+HNG8D3hsqo5TiEiYwxOQcXRgddL+Ci6/y0L1EvqOQc+1V8ycwNs2oNicwNgSn5A+9HpF495Kae039hGtj2Gpt4IbplSYwKFq/sFTq+CekxdD2YVQmGvsjep4bNVL66o2RSZVAW1Bg/G8/sSe3BwgD8IToy9+1NHPPuaVupeukRqNyUDcVvWH8hdb8AkXYY87+546etYDpn91GQnhTEberKbXX4UCmpKNXpXoprLE8nQLGb6TIoHPTyA+RRNQ4erDzMjqF43UVmhOZTtkGaRgIWK7vDAKpLUnuOguuhJUNpYpRggGQsMV8cZnaCumy5OFUf6i6rfN0Ru6a+/Bm7grJiAcnZlU7igaxgI38QaJgCKcqqzIImdcRYNQC74/Ok/1oM=
-        - secure: BK++GwKVPoS0iG8aB7wQ13daTgJR9MifHA+l9xr/tSZ3SUL6nc7kjxLbliRQJCqT9lcOODsd+v2u9PziEzBp0CCh67ftFxJw8riP2+FgdmHTK4yav9QpSwoBJHhV2SgBMGlXiqdUVC7wpgjzzK63V8abvzAhXkthWPl3kYpUI//xGYyuBNXVHEOImHB3F1M5bn90lflFtRfq2iH5FigGesMi2BFfTVeqvbzZVZrAs0E1/NRdO+/cRq0c9aRpNLkh254k1tcKbUvULQq1iLQuHN2Ramn3NgNnx93sbwp1e7ZjmETbjr9cwMIDg5mh25H0Rjf2Nn8cqHbBCWzoMkjZW097HRVDYht2kJZQIbQcaxX38DW6vykUwGWSBAWbtvCUwYwU57s/dIbSYUTQErkYYmhiq52cdOtnxZ2/ULoElCVyR8lTmQuANJrq9YFC9q1ly69YuMWWnFgwxWpK1JCgAJGELgj5EvcghEtNmkEFh5f6pmbKBE7PKQPTovzNKcdRauR/L+MsmhVYukCfNZq57LrruIQIX1GQNw9w3Ck8P4EPtNjdI4umCSy6nZSyTevWgVTmIP9EwXa5Cap32ZU+iDtw+wUBAr3sjROJOYGKlL/ktWsWbjog5hIG0rrb8PbgOfbLRZSEYGL9sYsyXXyW5oI37lB7AqG6D7vOA4TdmTQ=
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-06
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-07
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-08
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-09
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-10
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-11
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-12
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-13
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-14
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-15
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-16
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-17
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-18
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-19
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-20
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-21
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-22
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-23
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-24
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-25
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-26
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-27
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-28
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-29
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-30
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-31
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-32
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-33
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-34
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-35
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-36
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-37
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-38
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-39
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-40
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-41
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-42
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-43
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-44
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-45
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-46
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-47
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-48
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-49
+
+    ## k3s versions:  https://github.com/rancher/k3s/releases
+    - stage: test
+      name: intermittency-test-50

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - await_pebble  # jupyterhub's autohttps communicates with it as the ACME server
 script:
   # Install JupyterHub
-  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.2.10
+  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.2.11
   - await_jupyterhub
   - await_autohttps_tls_cert_acquisition
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - await_pebble  # jupyterhub's autohttps communicates with it as the ACME server
 script:
   # Install JupyterHub
-  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.3.2
+  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.2.10
   - await_jupyterhub
   - await_autohttps_tls_cert_acquisition
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
 script:
   # Install JupyterHub
   - helm install jupyterhub ./jupyterhub --values dev-config.yaml \
-        --set proxy.traefik.image.tag=v2.2.11
+        --set proxy.traefik.image.tag=v2.2.10
   - await_jupyterhub
   - await_autohttps_tls_cert_acquisition
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,7 @@ install:
   - await_pebble  # jupyterhub's autohttps communicates with it as the ACME server
 script:
   # Install JupyterHub
-  - helm install jupyterhub ./jupyterhub --values dev-config.yaml \
-        --set proxy.traefik.image.tag=v2.2.10
+  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.3.2
   - await_jupyterhub
   - await_autohttps_tls_cert_acquisition
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
   - await_pebble  # jupyterhub's autohttps communicates with it as the ACME server
 script:
   # Install JupyterHub
-  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.2.11
+  - helm install jupyterhub ./jupyterhub --values dev-config.yaml --set proxy.traefik.image.tag=v2.3.0
   - await_jupyterhub
   - await_autohttps_tls_cert_acquisition
 


### PR DESCRIPTION
This is a practical test of the intermittency issues between Traefik's docker image v2.3.2, v2.2.11, v2.2.10.

I've already concluded we have an intermittency issue in Traefik v2.3.0 and v2.3.1.

## Status
- [x] Traefik v2.2.10 - 50/50 passed
- [x] Traefik v2.2.11 - 49/50 passed
- [x] Traefik v2.3.0 - 50/50 passed (known to have this issue sometimes)
- [x] Traefik v2.3.1 - 50/50 passed (known to have this issue sometimes)
- [x] Traefik v2.3.2 - 50/50 + 50/50 passed - Bumped to in #1859 