### PR TITLE
Pin Traefik to v2.3.2 for cert acquisition stability

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -200,7 +200,10 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: traefik
-      tag: v2.3.0 # ref: https://hub.docker.com/_/traefik?tab=tags
+      # tag for Traefik should be thoroughly tested before bumping, because it
+      # has been prone to have intermittency issues in the past. See for example
+      # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1857.
+      tag: v2.3.2 # ref: https://hub.docker.com/_/traefik?tab=tags
       pullPolicy: ''
       pullSecrets: []
     hsts:


### PR DESCRIPTION
Traefik v2.3.1 and v2.3.0 has behaved unreliably, but Traefik v2.3.2 at least managed to reliably work 50/50 times tested.

Assumed to close #1853 