### PR TITLE
Allow adding extra labels to the traefik pod

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -789,6 +789,13 @@ properties:
         description: |
           Configure the traefik proxy used to terminate TLS when 'autohttps' is enabled
         properties:
+          labels:
+            type: object
+            description: |
+              Extra labels to add to the traefik pod.
+
+              See the [Kubernetes docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+              to learn more about labels.
           extraEnv:
             type: object
             description: |

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-http: "true"
+        {{- if .Values.proxy.traefik.labels }}
+        {{- .Values.proxy.traefik.labels | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       annotations:
         # Only force a restart through a change to this checksum when the static
         # configuration is changed, as the dynamic can be updated after start.

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -128,6 +128,8 @@ proxy:
         value: "mock-taint-to-tolerates-value"
         effect: "NoExecute"
   traefik:
+    labels:
+      hub.jupyter.org/test-label: mock
     resources:
       requests:
         cpu: 200m


### PR DESCRIPTION
Allows admins to configure the traefik pod, particularly
to support network policies of *other* charts deployed
in the same namespace
