### PR TITLE
docs: fix edit button, so it doesn't go to a 404 page

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -149,7 +149,7 @@ html_context = {
     "github_user": "jupyterhub",
     "github_repo": "zero-to-jupyterhub-k8s",
     "github_version": "master",
-    "doc_path":"doc",
+    "doc_path":"doc/source",
 }
 
 html_favicon = '_static/images/logo/favicon.ico'


### PR DESCRIPTION
The edit on github button didn't work before, because it referenced /doc instead of /doc/source
