### PR TITLE
Add app.kubernetes.io/instance label

### DIFF
--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -147,6 +147,7 @@ heritage: {{ .heritageLabel | default .Release.Service }}
     Provides labels: component, app, release, (chart and heritage).
 */}}
 {{- define "jupyterhub.labels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
 component: {{ include "jupyterhub.componentLabel" . }}
 {{ include "jupyterhub.commonLabels" . }}
 {{- end }}


### PR DESCRIPTION
This PR adds an `app.kubernetes.io/instance: {{ .Release.Name }}` label to JupyterHub objects via the `jupyter.labels` field in `_helpers.tpl`.

This label is a Helm idiom per [their documentation](https://helm.sh/docs/chart_best_practices/labels/#standard-labels) and is [uniformly adopted](https://github.com/helm/charts/search?q=app.kubernetes.io%2Finstance).