### PR TITLE
Bump KubeSpawner to 0.14.1 to fix a bug in 0.14.0 about image_pull_secrets

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -27,7 +27,7 @@ jupyterhub-dummyauthenticator==0.3.1  # via -r requirements.in
 jupyterhub-firstuseauthenticator==0.14.1  # via -r requirements.in
 jupyterhub-hmacauthenticator==0.1  # via -r requirements.in
 jupyterhub-idle-culler==1.0  # via -r requirements.in
-jupyterhub-kubespawner==0.14.0  # via -r requirements.in
+jupyterhub-kubespawner==0.14.1  # via -r requirements.in
 jupyterhub-ldapauthenticator==1.3.2  # via -r requirements.in
 jupyterhub-ltiauthenticator==0.4.0  # via -r requirements.in
 jupyterhub-nativeauthenticator==0.0.5  # via -r requirements.in
@@ -70,7 +70,7 @@ statsd==3.3.0             # via -r requirements.in
 text-unidecode==1.3       # via python-slugify
 tornado==6.0.4            # via jupyterhub, jupyterhub-idle-culler, jupyterhub-ldapauthenticator
 traitlets==5.0.5          # via jupyter-telemetry, jupyterhub, jupyterhub-ldapauthenticator
-urllib3==1.25.10          # via jupyterhub-kubespawner, kubernetes, requests
+urllib3==1.25.11          # via jupyterhub-kubespawner, kubernetes, requests
 websocket-client==0.57.0  # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This PR fixes a recently introduced bug influencing the configuration of singleuser.imagePullSecrets.

Thank you @johnhoman :heart: