### PR TITLE
Dependency: bump proxy pods image of CHP to 4.2.2 for bugfixes and docker image dependency updates

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -176,7 +176,7 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: jupyterhub/configurable-http-proxy
-      tag: 4.2.1
+      tag: 4.2.2
       pullPolicy: ''
       pullSecrets: []
     extraCommandLineFlags: []


### PR DESCRIPTION
This PR just bumps the CHP images, which has some bugfixes, for example regarding the implementation of the --custom-header flag, but also just makes the Docker image be more updated.
