### PR TITLE
Bump OAuthenticator to 0.12.0 from 0.11.0

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -13,7 +13,7 @@ certifi==2020.6.20        # via kubernetes, requests
 certipy==0.1.3            # via jupyterhub
 cffi==1.14.3              # via bcrypt, cryptography
 chardet==3.0.4            # via requests
-cryptography==3.1.1       # via pyjwt, pyopenssl
+cryptography==3.2         # via pyjwt, pyopenssl
 entrypoints==0.3          # via jupyterhub
 escapism==1.0.1           # via jupyterhub-kubespawner
 globus-sdk[jwt]==1.9.1    # via -r requirements.in
@@ -39,7 +39,7 @@ mako==1.1.3               # via alembic
 markupsafe==1.1.1         # via jinja2, mako
 mwoauth==0.3.7            # via -r requirements.in
 nullauthenticator==1.0.0  # via -r requirements.in
-oauthenticator==0.11.0    # via -r requirements.in
+oauthenticator==0.12.0    # via -r requirements.in
 oauthlib==3.1.0           # via jupyterhub, jupyterhub-ltiauthenticator, mwoauth, requests-oauthlib
 onetimepass==1.0.1        # via jupyterhub-nativeauthenticator
 pamela==1.0.0             # via jupyterhub


### PR DESCRIPTION
This should be part of 0.10.0, so we should cut a 0.10.0-beta.2 I guess.
