### PR TITLE
Remove globus_sdk and update various Docker images

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -36,8 +36,8 @@ RUN adduser --disabled-password \
 RUN python3 -m pip install --upgrade --no-cache setuptools pip
 COPY requirements.txt /tmp/requirements.txt
 
-## NOTE: This is a default and be overridden by chartpress using the
-##       chartpress.yaml configuration
+# NOTE: This is a default and will be overridden by chartpress and the
+#       dependencies script using the chartpress.yaml configuration's buildArgs
 ARG JUPYTERHUB_VERSION=1.1.*
 
 RUN PYCURL_SSL_LIBRARY=openssl pip3 install --no-cache-dir \

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -4,7 +4,9 @@
 #    ./dependencies freeze --upgrade
 #
 
-# JupyterHub's version is defined in chartpress.yaml
+# JupyterHub is pinned in chartpress.yaml, but need to be pinned here as well to
+# so our generated requirements.txt get proper comments set on it.
+jupyterhub==1.2.0b1
 
 ## Authenticators
 jupyterhub-dummyauthenticator
@@ -19,6 +21,7 @@ oauthenticator
 
 # Authenticator optional dependencies
 mwoauth
+pyjwt
 
 ## Kubernetes spawner
 jupyterhub-kubespawner

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -19,7 +19,6 @@ oauthenticator
 
 # Authenticator optional dependencies
 mwoauth
-globus_sdk[jwt]
 
 ## Kubernetes spawner
 jupyterhub-kubespawner

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -13,10 +13,9 @@ certifi==2020.6.20        # via kubernetes, requests
 certipy==0.1.3            # via jupyterhub
 cffi==1.14.3              # via bcrypt, cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2         # via pyjwt, pyopenssl
+cryptography==3.2         # via pyopenssl
 entrypoints==0.3          # via jupyterhub
 escapism==1.0.1           # via jupyterhub-kubespawner
-globus-sdk[jwt]==1.9.1    # via -r requirements.in
 google-auth==1.22.1       # via kubernetes
 idna==2.10                # via requests
 ipython-genutils==0.2.0   # via traitlets
@@ -32,7 +31,7 @@ jupyterhub-ldapauthenticator==1.3.2  # via -r requirements.in
 jupyterhub-ltiauthenticator==0.4.0  # via -r requirements.in
 jupyterhub-nativeauthenticator==0.0.5  # via -r requirements.in
 jupyterhub-tmpauthenticator==0.6  # via -r requirements.in
-jupyterhub==1.2.0b1       # via jupyterhub-firstuseauthenticator, jupyterhub-kubespawner, jupyterhub-ldapauthenticator, jupyterhub-ltiauthenticator, jupyterhub-nativeauthenticator, nullauthenticator, oauthenticator
+jupyterhub==1.2.0b1       # via -r requirements.in, jupyterhub-firstuseauthenticator, jupyterhub-kubespawner, jupyterhub-ldapauthenticator, jupyterhub-ltiauthenticator, jupyterhub-nativeauthenticator, nullauthenticator, oauthenticator
 kubernetes==12.0.0        # via jupyterhub-kubespawner
 ldap3==2.8.1              # via jupyterhub-ldapauthenticator
 mako==1.1.3               # via alembic
@@ -50,7 +49,7 @@ pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via ldap3, pyasn1-modules, rsa
 pycparser==2.20           # via cffi
 pycurl==7.43.0.6          # via -r requirements.in
-pyjwt[crypto]==1.7.1      # via globus-sdk, mwoauth
+pyjwt==1.7.1              # via -r requirements.in, mwoauth
 pymysql==0.10.1           # via -r requirements.in
 pyopenssl==19.1.0         # via certipy
 pyrsistent==0.17.3        # via jsonschema
@@ -60,11 +59,11 @@ python-json-logger==2.0.1  # via jupyter-telemetry
 python-slugify==4.0.1     # via jupyterhub-kubespawner
 pyyaml==5.3.1             # via jupyterhub-kubespawner, kubernetes
 requests-oauthlib==1.3.0  # via kubernetes, mwoauth
-requests==2.24.0          # via globus-sdk, jupyterhub, kubernetes, mwoauth, requests-oauthlib
+requests==2.24.0          # via jupyterhub, kubernetes, mwoauth, requests-oauthlib
 rsa==4.6                  # via google-auth
 ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via jupyter-telemetry
-six==1.15.0               # via bcrypt, cryptography, globus-sdk, google-auth, jsonschema, kubernetes, mwoauth, onetimepass, pyopenssl, python-dateutil, websocket-client
+six==1.15.0               # via bcrypt, cryptography, google-auth, jsonschema, kubernetes, mwoauth, onetimepass, pyopenssl, python-dateutil, websocket-client
 sqlalchemy==1.3.20        # via alembic, jupyterhub
 statsd==3.3.0             # via -r requirements.in
 text-unidecode==1.3       # via python-slugify

--- a/images/network-tools/Dockerfile
+++ b/images/network-tools/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.6
+FROM alpine:3
 
 RUN apk add --no-cache iptables

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:a07573d685a4
+FROM jupyter/base-notebook:45bfe5a474fa
 # Built from... https://hub.docker.com/r/jupyter/base-notebook/
 #               https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile
 # Built from... Ubuntu 18.04

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -422,7 +422,7 @@ scheduling:
       allowPrivilegeEscalation: false
     image:
       name: k8s.gcr.io/kube-scheduler
-      tag: v1.19.1
+      tag: v1.19.2
       pullPolicy: ''
       pullSecrets: []
     nodeSelector: {}


### PR DESCRIPTION
This PR bumps some core images to avoid known vulnerabilities and just keep up to date in general.

`globus_sdk[jwt]` as a dependency could be removed because it was no longer needed for the GlobusOAuthenticator any more, but the azure authenticator still require PyJWT so we still install that.

I choose to keep pinning the docker-stacks/base-notebook version to avoid risking issues introduced without us understanding why.
