### PR TITLE
Update Travis CI badge following .org -> com migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zero to JupyterHub with Kubernetes
 
 [![Documentation build status](https://img.shields.io/readthedocs/zero-to-jupyterhub?logo=read-the-docs)](https://zero-to-jupyterhub.readthedocs.io/en/latest/?badge=latest)
-[![TravisCI build status](https://img.shields.io/travis/jupyterhub/zero-to-jupyterhub-k8s/master?logo=travis)](https://travis-ci.org/jupyterhub/zero-to-jupyterhub-k8s)
+[![TravisCI build status](https://img.shields.io/travis/com/jupyterhub/zero-to-jupyterhub-k8s/master?logo=travis)](https://travis-ci.com/jupyterhub/zero-to-jupyterhub-k8s)
 [![Latest stable release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=stable&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.stable&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#jupyterhub)
 [![Latest pre-release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=pre&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.pre&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
 [![Latest development release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=dev&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.latest&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)


### PR DESCRIPTION
See https://github.com/jupyterhub/team-compass/issues/348 for the JupyterHub org's migration.