### PR TITLE
DOCS: Adding note on limit to guarantee ratio

### DIFF
--- a/doc/source/jupyterhub/customizing/user-resources.rst
+++ b/doc/source/jupyterhub/customizing/user-resources.rst
@@ -20,6 +20,7 @@ resource requirements as well as beginning users with more basic resource
 needs. The ability to customize the Hub's resources to satisfy both user
 groups improves the user experience for all Hub users.
 
+.. _memory-cpu-limits:
 
 Set user memory and CPU guarantees / limits
 *******************************************


### PR DESCRIPTION
This adds a short guide to explain the "limit to guarantee ratio" for memory and CPU. It's a tricky subject that we've found a lot of hub admnistrators run into, but it's also a bit of an art-form without a single strict answer. So this tries to add some explanation of the problem and its nuance in the hopes that administrators will be able to more effectively provision their resources.

WDYT @yuvipanda , who was the one to originally explain this to me.