### PR TITLE
CI: publish with helpful commit message

### DIFF
--- a/ci/publish
+++ b/ci/publish
@@ -1,4 +1,9 @@
 #!/bin/bash
+# This script publishes the Helm chart to the JupyterHub Helm chart repo and
+# pushes associated built docker images to Docker hub using chartpress.
+# --------------------------------------------------------------------------
+
+# Exit on error and raise an error for unset environment variables
 set -eu
 
 # Decrypt a private SSH key having its public key registered on GitHub. It will
@@ -7,6 +12,7 @@ set -eu
 openssl aes-256-cbc -K $encrypted_c6b45058ffe8_key -iv $encrypted_c6b45058ffe8_iv -in ci/publish-id_rsa.enc -out ci/id_rsa -d
 chmod 0400 ci/id_rsa
 
+# Configure docker with credentials to let chartpress push images to docker hub.
 docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 
 # Activate logging of bash commands now that the sensitive stuff is done
@@ -18,8 +24,27 @@ export GIT_SSH_COMMAND="ssh -i ${PWD}/ci/id_rsa"
 
 if [ "${TRAVIS_TAG:-}" == "" ]; then
     # Using --long, we are ensured to get a build suffix, which ensures we don't
-    # build the same tag twice.
-    chartpress --push --publish-chart --long
+    # build the same tag twice. Using --extra-message, we help automation like
+    # henchbot to submit update PRs to jupyterhub/mybinder.org-deploy.
+    #
+    # ref: https://github.com/jupyterhub/chartpress#usage ref:
+    # https://github.com/henchbot/mybinder.org-upgrades
+    #
+    # NOTE: By crafting a smart commit message for the publication commit to
+    #       jupyterhub/helm-chart, we can make GitHub help us mention the
+    #       publication commit in the PR or commit. This helps users realize
+    #       what version they need to upgrade to etc in order to be able to
+    #       benefit from the merged PR in a development release.
+    #
+    #       GitHub merge commits contain a PR reference like #123. `sed` looks
+    #       to extract either a PR reference like #123 or fall back to create a
+    #       commit hash reference like @123abcd. Combined with TRAVIS_REPO_SLUG
+    #       we craft a commit message like jupyterhub/binderhub#123 or
+    #       jupyterhub/binderhub@123abcd which will be understood as a reference
+    #       by GitHub.
+    PR_OR_HASH=$(git log -1 --pretty=%B | head -n1 | sed 's/^.*\(#[0-9]*\).*/\1/' | sed 's/^\([0-9a-f]*\)-.*/@\1/')
+    EXTRA_MESSAGE="${TRAVIS_REPO_SLUG}${PR_OR_HASH}"
+    chartpress --push --publish-chart --long --extra-message "${EXTRA_MESSAGE}"
 else
     # Setting a tag explicitly enforces a rebuild if this tag had already been
     # built and we wanted to override it.


### PR DESCRIPTION
This mirrors jupyterhub/binderhub setup. The value from this message is that whenever a PR is merged, chartpress will publish a new dev version with a git push to jupyterhub/helm-chart's gh-pages branch along with the package helm chart. Since this is done with a commit message referencing the PR, GitHub will show a notice of the commit mentioning the PR when viewing the PR. And, this commit will in its title have information about the Helm chart version, which can help anyone look at a merged PR to realize what version they need to upgrade to benefit from this.
