### PR TITLE
Allow exposing extra ports in traefik deployment

### DIFF
--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -84,6 +84,9 @@ spec:
               containerPort: 8080
             - name: https
               containerPort: 8443
+            {{- with .Values.proxy.traefik.extraPorts }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: traefik-config
               mountPath: /etc/traefik

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -232,6 +232,7 @@ proxy:
     extraDynamicConfig: {}
     nodeSelector: {}
     tolerations: []
+    extraPorts: []
     networkPolicy:
       enabled: true
       ingress: []

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -146,7 +146,7 @@ proxy:
   traefik:
     extraPorts:
     - name: ssh
-      containerPort: 22
+      containerPort: 8022
     labels:
       hub.jupyter.org/test-label: mock
     resources:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -144,6 +144,9 @@ proxy:
       interNamespaceAccessLabels: accept
       allowedIngressPorts: [http, https]
   traefik:
+    extraPorts:
+    - name: ssh
+      containerPort: 22
     labels:
       hub.jupyter.org/test-label: mock
     resources:


### PR DESCRIPTION
Follow-up to #1852. Useful to explicitly expose ports
in deployment too - otherwise you can't use port names like
`ssh` in service definitions. To allow ingress on a port named
`ssh` in traefik right now, you have to know it is listening
on port 8022, and set the following:

```yaml
proxy:
  autohttps:
    networkPolicy:
      allowedIngress: [http, https, 8022]
```

This requires knowledge that `8022` is the ssh port. Instead,
it would be nice to specify `ssh` instead - and that requires
defining that in the deployment. This is true for other places
too - like the service definition.


----

#