### PR TITLE
Add use_lookup_dn_username parameter for LDAP

### DIFF
--- a/doc/source/administrator/authentication.rst
+++ b/doc/source/administrator/authentication.rst
@@ -295,7 +295,9 @@ Authenticating with LDAP
 
 JupyterHub supports LDAP and Active Directory authentication.
 Read the `ldapauthenticator <https://github.com/jupyterhub/ldapauthenticator>`_
-documentation for a full explanation of the available parameters.
+documentation for a full explanation of the available parameters. The full mapping
+between parameters set in `values.yaml` and ldapauthenticator parameter names can be 
+found in `jupyterhub_config.py <https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/jupyterhub/files/hub/jupyterhub_config.py#L35>`_. 
 
 Example LDAP Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/administrator/authentication.rst
+++ b/doc/source/administrator/authentication.rst
@@ -296,8 +296,8 @@ Authenticating with LDAP
 JupyterHub supports LDAP and Active Directory authentication.
 Read the `ldapauthenticator <https://github.com/jupyterhub/ldapauthenticator>`_
 documentation for a full explanation of the available parameters. The full mapping
-between parameters set in `values.yaml` and ldapauthenticator parameter names can be 
-found in `jupyterhub_config.py <https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/jupyterhub/files/hub/jupyterhub_config.py#L35>`_. 
+between parameters set in ``values.yaml`` and ``ldapauthenticator`` parameter names can be 
+found in `jupyterhub_config.py <https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/jupyterhub/files/hub/jupyterhub_config.py#L353>`_. 
 
 Example LDAP Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -347,6 +347,7 @@ elif auth_type == 'ldap':
     set_config_if_not_none(c.LDAPAuthenticator, 'valid_username_regex', 'auth.ldap.dn.user.validRegex')
     set_config_if_not_none(c.LDAPAuthenticator, 'user_search_base', 'auth.ldap.dn.user.searchBase')
     set_config_if_not_none(c.LDAPAuthenticator, 'user_attribute', 'auth.ldap.dn.user.attribute')
+    set_config_if_not_none(c.LDAPAuthenticator, 'use_lookup_dn_username', 'auth.ldap.dn.user.useLookupName')
 elif auth_type == 'custom':
     # full_class_name looks like "myauthenticator.MyAuthenticator".
     # To create a docker image with this class availabe, you can just have the


### PR DESCRIPTION
Enable the parameter to be set in values.yaml. Also add a refernce to
the code that does the mapping, so it is easier for user to figure out
correspondence between ldapauthenticator params and params in
values.yaml.