### PR TITLE
CI: make upgrades more robust and skip 1m precautionary sleep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           . ./ci/common
           # If you have problems with the tests add '--capture=no' to show stdout
-          pytest --verbose --exitfirst ./tests || (full_namespace_report && exit 1)
+          pytest --verbose --exitfirst --color=yes ./tests || (full_namespace_report && exit 1)
 
 
   docs_linkcheck:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,13 @@ jobs:
         run: |
           . ./ci/common
           # If you have problems with the tests add '--capture=no' to show stdout
-          pytest --verbose --exitfirst --color=yes ./tests || (full_namespace_report && exit 1)
+          pytest --verbose --exitfirst --color=yes ./tests
+
+      - name: Provide info on failures
+        if: failure()
+        run: |
+          . ./ci/common
+          full_namespace_report
 
 
   docs_linkcheck:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,7 @@ jobs:
           helm install jupyterhub jupyterhub/jupyterhub --values dev-config.yaml
           await_jupyterhub
           await_autohttps_tls_cert_acquisition
+          await_autohttps_tls_cert_save
 
       - name: Install JupyterHub dev chart
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,12 +127,6 @@ jobs:
           await_jupyterhub
           await_autohttps_tls_cert_acquisition
 
-      - name: Wait 1 minute for everything to be ready
-        # TODO: find out exactly which resources are slow and wait for thoses
-        # So far errors have included:
-        # - some pods not being ready
-        # - network policies not being ready
-        run: sleep 1m
       - name: Run tests
         run: |
           . ./ci/common

--- a/ci/common
+++ b/ci/common
@@ -42,7 +42,7 @@ await_jupyterhub() {
 
 await_autohttps_tls_cert_acquisition() {
     i=0; while [ $i -ne 60 ]; do
-        kubectl logs deploy/pebble -c pebble | grep "Issued certificate" \
+        kubectl logs deploy/autohttps -c traefik | grep "Adding certificate" \
         && acquired_cert=true && break \
         || acquired_cert=false && sleep 0.5 && i=$((i + 1))
     done
@@ -60,6 +60,25 @@ await_autohttps_tls_cert_acquisition() {
     # a precausion as pebble logs is a bad indicator of the readiness state of
     # Traefik's readiness to use the cert for TLS termination.
     sleep 1
+}
+
+await_autohttps_tls_cert_save() {
+    i=0; while [ $i -ne 60 ]; do
+        kubectl logs deploy/autohttps -c secret-sync | grep "Created secret" \
+        && saved_cert=true && break \
+        || saved_cert=false && sleep 0.5 && i=$((i + 1))
+    done
+    if [ "$saved_cert" != "true" ]; then
+        echo "Certificate acquisition failed!"
+        kubectl get service,networkpolicy,configmap,pod
+        kubectl describe pod -l app.kubernetes.io/name=pebble
+        kubectl logs deploy/pebble --all-containers # --prefix
+        kubectl describe pod -l app.kubernetes.io/name=pebble-coredns
+        kubectl logs deploy/pebble-coredns --all-containers # --prefix
+        kubectl describe pod -l component=autohttps
+        kubectl logs deploy/autohttps --all-containers # --prefix
+        exit 1
+    fi
 }
 
 setup_kubeval () {
@@ -106,10 +125,6 @@ full_namespace_report () {
     echo ""
     echo "Just while debugging intermittent issue, lets output the logs of the proxy pod."
     kubectl logs --all-containers deploy/proxy
-
-    echo ""
-    echo "Just while debugging intermittent issue, lets output the logs of the autohttps pod."
-    kubectl logs --all-containers deploy/autohttps
 }
 
 install_and_run_chartpress_and_pebble () {

--- a/ci/publish
+++ b/ci/publish
@@ -40,4 +40,4 @@ fi
 
 # Let us log the changes chartpress did, it should include replacements for
 # fields in values.yaml, such as what tag for various images we are using.
-git --no-pager diff
+git --no-pager diff --color


### PR DESCRIPTION
@manics I had 34/34 success `install jobs` but had `1/2` failures on `upgrade` jobs when I removed the 1 minute delay and I think I understand at least some parts of the issues. [Here](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1904/checks?check_run_id=1377782878) is a failure example of an `upgrade` job.

## Issues
### Autohttps pod's readiness
The autohttps pod doesn't have a readiness probe, it was removed as it is required to be Ready to receive responses for the ACME challenge, but from the perspective of users, this isn't sufficient as a criteria.

### await_autohttps_tls_cert_acquisition during upgrades
We currently await with `await_autohttps_tls_cert_acquisition` which inspects the logs for the text `Issued certificate`, but is this something that will show up if there isn't a need for issuing a certificate because there already exists one? I don't think so.

### Autohttps pod's secret-sync container is too slow for upgrades
When we first install and then upgrade the Helm chart, the autohttp's pod is supposed to stash away its certificate but it may not have time to do so before we upgrade to the next version. Due to this, we may end up re-acquiring a certificate when we shouldn't.

### Rolling updates
When we make rolling updates of the autohttps pod, and the previous pod hasn't saved the cert into a secret, it won't get loaded by the new pod as it should. Then, it may end up trying to acquire a new cert, but traffic will potentially be redirected to the old pod in a ready but terminating state.

## Fixes
- [x] Let's make `await_autohttps_tls_cert_acquisition` spot when the autohttps pod loads a certificate, no matter if it acquires it fresh from the ACME server or from a cache on disk from a mounted k8s Secret created by secret-sync.
  We previously inspected the logs of pebble rather than autohttps. If autohttps debug logs are enabled, we can make use of the statement `Added certificate` to spot when it successfully adds a certificate.
- [x] Let's make `await_autohttps_tls_cert_save` await the secret-sync's saving of the cert for now
- [ ] Let's make make secret-sync work smarter and not rely on a interval to update

## Outcome

10/10 upgrade script attempts worked! I'll cleanup my debugging commits and merge this.

![image](https://user-images.githubusercontent.com/3837114/98630738-1ac35f00-231c-11eb-91d4-dee5b67f6ea6.png)
