### PR TITLE
Configurable resource requests for hook-image-awaiter

### DIFF
--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -55,4 +55,6 @@ spec:
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
+          resources:
+            {{- .Values.prePuller.hook.resources | toYaml | trimSuffix "\n" | nindent 12 }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -483,6 +483,10 @@ prePuller:
     podSchedulingWaitDuration: 10
     nodeSelector: {}
     tolerations: []
+    resources:
+      requests:
+        cpu: 0
+        memory: 0
   continuous:
     enabled: true
   pullProfileListImages: true


### PR DESCRIPTION
For any user with a ResourceQuota installed and aggregate limits to all pods combined container requests/limits, we need to allow resources be set to being denied by the Admission webhook that comes with a ResourceQuota resource.

Example of error that can come from not having resources configured on a pod are...

jupyterhub   4m49s       Warning   FailedCreate              job/hook-image-awaiter                 (combined from similar events): Error creating: pods "hook-image-awaiter-6mvsc" is forbidden: failed quota: jupyterhub-resourcequota: must specify limits.cpu,limits.memory,requests.cpu,requests.memory

Thank you @tirumerla for pointing this out!

Closes #1761 (again).
