### PR TITLE
Support node labels with _ instead of / for EKS

### DIFF
--- a/doc/source/administrator/optimization.md
+++ b/doc/source/administrator/optimization.md
@@ -259,18 +259,19 @@ following:
 
 1. Setup a node pool (with autoscaling), a certain label, and a certain taint.
 
-    If you need help on how to do this, please refer to your cloud providers
-    documentation. A node pool may be called a node group.
+    If you need help on how to label and taint your nodes in a node pool (also
+    known as node group), please refer to your cloud providers documentation.
 
-    - The label: `hub.jupyter.org/node-purpose=user`
+    - The label: `hub.jupyter.org/node-purpose=user` or `hub.jupyter.org_node-purpose=user`
 
       **NOTE**: Cloud providers often have their own labels, separate from
-      kubernetes labels, but this label must be a kubernetes label.
+      kubernetes labels, but this label must be a Kubernetes label.
 
-    - The taint: `hub.jupyter.org/dedicated=user:NoSchedule`
+    - The taint: `hub.jupyter.org/dedicated=user:NoSchedule` or `hub.jupyter.org_dedicated=user:NoSchedule`
 
-      **NOTE**: You may need to replace `/` with `_` due cloud provider
-      limitations. Both taints are tolerated by the user pods.
+    Both `/` and `_` are supported by Kubernetes and this Helm chart, but cloud
+    providers may limit you to use `_`, so using `_` is the safer choice if you
+    don't know.
 
 2. Make user pods require to be scheduled on the node pool setup above
 
@@ -281,7 +282,8 @@ following:
     during a rolling update.
 
     The default setting is to make user pods *prefer* to be scheduled on nodes
-    with the `hub.jupyter.org/node-purpose=user` label, but you can also make it
+    with either the `hub.jupyter.org/node-purpose=user` or
+    `hub.jupyter.org_node-purpose=user` label, but you can also make it
     *required* using the configuration below.
 
     ```yaml

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -186,28 +186,29 @@ if get_config('scheduling.podPriority.enabled'):
 # add node-purpose affinity
 match_node_purpose = get_config('scheduling.userPods.nodeAffinity.matchNodePurpose')
 if match_node_purpose:
-    node_selector = dict(
-        matchExpressions=[
-            dict(
-                key="hub.jupyter.org/node-purpose",
-                operator="In",
-                values=["user"],
-            )
-        ],
-    )
-    if match_node_purpose == 'prefer':
-        c.KubeSpawner.node_affinity_preferred.append(
-            dict(
-                weight=100,
-                preference=node_selector,
-            ),
+    for label in ["hub.jupyter.org/node-purpose", "hub.jupyter.org_node-purpose"]:
+        node_selector = dict(
+            matchExpressions=[
+                dict(
+                    key=label,
+                    operator="In",
+                    values=["user"],
+                )
+            ],
         )
-    elif match_node_purpose == 'require':
-        c.KubeSpawner.node_affinity_required.append(node_selector)
-    elif match_node_purpose == 'ignore':
-        pass
-    else:
-        raise ValueError("Unrecognized value for matchNodePurpose: %r" % match_node_purpose)
+        if match_node_purpose == 'prefer':
+            c.KubeSpawner.node_affinity_preferred.append(
+                dict(
+                    weight=100,
+                    preference=node_selector,
+                ),
+            )
+        elif match_node_purpose == 'require':
+            c.KubeSpawner.node_affinity_required.append(node_selector)
+        elif match_node_purpose == 'ignore':
+            pass
+        else:
+            raise ValueError("Unrecognized value for matchNodePurpose: %r" % match_node_purpose)
 
 # add dedicated-node toleration
 for key in (

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1322,9 +1322,10 @@ properties:
                   - require
                 description: |
                   Decide if core pods *ignore*, *prefer* or *require* to
-                  schedule on nodes with this label:
+                  schedule on nodes with one of these labels:
                   ```
                   hub.jupyter.org/node-purpose=core
+                  hub.jupyter.org_node-purpose=core
                   ```
       userPods:
         type: object
@@ -1346,9 +1347,10 @@ properties:
                   - require
                 description: |
                   Decide if user pods *ignore*, *prefer* or *require* to
-                  schedule on nodes with this label:
+                  schedule on nodes with one of these labels:
                   ```
                   hub.jupyter.org/node-purpose=user
+                  hub.jupyter.org_node-purpose=user
                   ```
   ingress:
     type: object

--- a/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
+++ b/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
@@ -24,6 +24,10 @@
   - key: hub.jupyter.org/node-purpose
     operator: In
     values: [user]
+- matchExpressions:
+  - key: hub.jupyter.org_node-purpose
+    operator: In
+    values: [user]
 {{- end }}
 {{- if .Values.singleuser.extraNodeAffinity.required }}
 {{- .Values.singleuser.extraNodeAffinity.required | toYaml | trimSuffix "\n" | nindent 0 }}
@@ -36,6 +40,12 @@
   preference:
     matchExpressions:
       - key: hub.jupyter.org/node-purpose
+        operator: In
+        values: [user]
+- weight: 100
+  preference:
+    matchExpressions:
+      - key: hub.jupyter.org_node-purpose
         operator: In
         values: [user]
 {{- end }}
@@ -144,6 +154,10 @@ affinity:
           - key: hub.jupyter.org/node-purpose
             operator: In
             values: [core]
+        - matchExpressions:
+          - key: hub.jupyter.org_node-purpose
+            operator: In
+            values: [core]
     {{- end }}
     {{- if $prefer }}
     preferredDuringSchedulingIgnoredDuringExecution:
@@ -151,6 +165,12 @@ affinity:
         preference:
           matchExpressions:
             - key: hub.jupyter.org/node-purpose
+              operator: In
+              values: [core]
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: hub.jupyter.org_node-purpose
               operator: In
               values: [core]
     {{- end }}


### PR DESCRIPTION
@yuvipanda it is my understanding that it isn't supported to use `/` in EKS clusters that want autoscaling based on your comment in https://github.com/2i2c-org/pangeo-hubs/commit/955bed4b74cacd09099f82c98915e2801825d078. Is this correct? If so, does this PR make some sense perhaps?

### References:
- [Cluster autoscaler docs for use on AWS](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md)
- [K8s docs on labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) - support one `/` separating a "prefix" and "name", requires name to be max 63 chars.
- [AWS tags restrictions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions) - Say they support `/`, max 128 chars