### PR TITLE
Require helm v2.16.0 explicitly and minor CI updates

### DIFF
--- a/ci/publish
+++ b/ci/publish
@@ -11,26 +11,23 @@ set -eux
 # the ~/.ssh folder with permissions to push to jupyterhub/helm-chart.
 if [[ $GITHUB_REF != refs/tags/* ]]; then
     # Using --long, we are ensured to get a build suffix, which ensures we don't
-    # build the same tag twice. Using --extra-message, we help automation like
-    # henchbot to submit update PRs to jupyterhub/mybinder.org-deploy.
+    # build the same tag twice.
+    #
+    # Using --extra-message, we help readers of merged PRs to know what version
+    # they need to bump to in order to make use of the PR. This is enabled by a
+    # GitHub notificaiton in the PR like "Github Action user pushed a commit to
+    # jupyterhub/helm-chart that referenced this pull request..."
     #
     # ref: https://github.com/jupyterhub/chartpress#usage
-    # ref: https://github.com/henchbot/mybinder.org-upgrades
     #
-    # NOTE: By crafting a smart commit message for the publication commit to
-    #       jupyterhub/helm-chart, we can make GitHub help us mention the
-    #       publication commit in the PR or commit. This helps users realize
-    #       what version they need to upgrade to etc in order to be able to
-    #       benefit from the merged PR in a development release.
-    #
-    #       GitHub merge commits contain a PR reference like #123. `sed` looks
+    # NOTE: GitHub merge commits contain a PR reference like #123. `sed` looks
     #       to extract either a PR reference like #123 or fall back to create a
-    #       commit hash reference like @123abcd. Combined with TRAVIS_REPO_SLUG
-    #       we craft a commit message like jupyterhub/binderhub#123 or
-    #       jupyterhub/binderhub@123abcd which will be understood as a reference
-    #       by GitHub.
+    #       commit hash reference like @123abcd. Combined with GITHUB_REPOSITORY
+    #       we craft a commit message like jupyterhub/zero-to-jupyterhub-k8s#123
+    #       or jupyterhub/zero-to-jupyterhub-k8s@123abcd which will be
+    #       understood as a reference by GitHub.
     PR_OR_HASH=$(git log -1 --pretty=%h-%B | head -n1 | sed 's/^.*\(#[0-9]*\).*/\1/' | sed 's/^\([0-9a-f]*\)-.*/@\1/')
-    EXTRA_MESSAGE="${GITHUB_REPOSITORY}${PR_OR_HASH}"
+    EXTRA_MESSAGE="${GITHUB_REPOSITORY}${PR_OR_HASH} ${LATEST_COMMIT_TITLE}"
     chartpress --push --publish-chart --long --extra-message "${EXTRA_MESSAGE}"
 else
     # Setting a tag explicitly enforces a rebuild if this tag had already been

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -9,8 +9,8 @@ home: https://z2jh.jupyter.org
 sources:
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
 icon: https://jupyter.org/assets/hublogo.svg
-kubeVersion: '>=1.11.0-0'
-tillerVersion: '>=2.11.0-0'
+kubeVersion: '>=1.14.0-0'
+tillerVersion: '>=2.16.0-0'
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team

--- a/tools/templates/lint-and-validate.py
+++ b/tools/templates/lint-and-validate.py
@@ -59,7 +59,7 @@ def lint(yamllint_config, values, kubernetes_versions, output_dir, debug):
     print("### Linting started")
     print("### 1/4 - helm lint: lint helm templates")
     helm_lint_cmd = [
-        'helm', 'lint', '../../jupyterhub',
+        'helm', 'lint', '--strict', '../../jupyterhub',
         '--values', values,
     ]
     if debug:


### PR DESCRIPTION
I made use of a helm template function (list `concat`) made available in helm v2.16 but not helm v2.15, due to that we need to explicitly require helm v2.16+

Besides that, I also add some small changes to the CI, such as strict linting of helm and passing a commit message when chartpress pushes a new helm chart package commit to our git based helm-chart repo.