### PR TITLE
hub image: kubernetes 12.0.1, nativeauth 0.0.6, tornado 6.1

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -6,17 +6,17 @@
 #
 alembic==1.4.3            # via jupyterhub
 async-generator==1.10     # via jupyterhub, jupyterhub-kubespawner
-attrs==20.2.0             # via jsonschema
+attrs==20.3.0             # via jsonschema
 bcrypt==3.2.0             # via jupyterhub-firstuseauthenticator, jupyterhub-nativeauthenticator
 cachetools==4.1.1         # via google-auth
-certifi==2020.6.20        # via kubernetes, requests
+certifi==2020.11.8        # via kubernetes, requests
 certipy==0.1.3            # via jupyterhub
 cffi==1.14.3              # via bcrypt, cryptography
 chardet==3.0.4            # via requests
-cryptography==3.2         # via pyopenssl
+cryptography==3.2.1       # via pyopenssl
 entrypoints==0.3          # via jupyterhub
 escapism==1.0.1           # via jupyterhub-kubespawner
-google-auth==1.22.1       # via kubernetes
+google-auth==1.23.0       # via kubernetes
 idna==2.10                # via requests
 ipython-genutils==0.2.0   # via traitlets
 jinja2==2.11.2            # via jupyterhub, jupyterhub-kubespawner
@@ -29,10 +29,10 @@ jupyterhub-idle-culler==1.0  # via -r requirements.in
 jupyterhub-kubespawner==0.14.1  # via -r requirements.in
 jupyterhub-ldapauthenticator==1.3.2  # via -r requirements.in
 jupyterhub-ltiauthenticator==0.4.0  # via -r requirements.in
-jupyterhub-nativeauthenticator==0.0.5  # via -r requirements.in
+jupyterhub-nativeauthenticator==0.0.6  # via -r requirements.in
 jupyterhub-tmpauthenticator==0.6  # via -r requirements.in
 jupyterhub==1.2.1         # via -r requirements.in, jupyterhub-firstuseauthenticator, jupyterhub-kubespawner, jupyterhub-ldapauthenticator, jupyterhub-ltiauthenticator, jupyterhub-nativeauthenticator, nullauthenticator, oauthenticator
-kubernetes==12.0.0        # via jupyterhub-kubespawner
+kubernetes==12.0.1        # via jupyterhub-kubespawner
 ldap3==2.8.1              # via jupyterhub-ldapauthenticator
 mako==1.1.3               # via alembic
 markupsafe==1.1.1         # via jinja2, mako
@@ -59,7 +59,7 @@ python-json-logger==2.0.1  # via jupyter-telemetry
 python-slugify==4.0.1     # via jupyterhub-kubespawner
 pyyaml==5.3.1             # via jupyterhub-kubespawner, kubernetes
 requests-oauthlib==1.3.0  # via kubernetes, mwoauth
-requests==2.24.0          # via jupyterhub, kubernetes, mwoauth, requests-oauthlib
+requests==2.25.0          # via jupyterhub, kubernetes, mwoauth, requests-oauthlib
 rsa==4.6                  # via google-auth
 ruamel.yaml.clib==0.2.2   # via ruamel.yaml
 ruamel.yaml==0.16.12      # via jupyter-telemetry
@@ -67,9 +67,9 @@ six==1.15.0               # via bcrypt, cryptography, google-auth, jsonschema, k
 sqlalchemy==1.3.20        # via alembic, jupyterhub
 statsd==3.3.0             # via -r requirements.in
 text-unidecode==1.3       # via python-slugify
-tornado==6.0.4            # via jupyterhub, jupyterhub-idle-culler, jupyterhub-ldapauthenticator
+tornado==6.1              # via jupyterhub, jupyterhub-idle-culler, jupyterhub-ldapauthenticator
 traitlets==5.0.5          # via jupyter-telemetry, jupyterhub, jupyterhub-ldapauthenticator
-urllib3==1.25.11          # via jupyterhub-kubespawner, kubernetes, requests
+urllib3==1.26.2           # via jupyterhub-kubespawner, kubernetes, requests
 websocket-client==0.57.0  # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This PR bumps some dependencies in the hub image. There was a bugfix that could cause the kubernetes/python-client library to crash in kubespawner which would make the hub pod crash if the k8s server had some unrelated issues I think.
