### PR TITLE
bump oauthenticator to 0.12.2

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -38,7 +38,7 @@ mako==1.1.3               # via alembic
 markupsafe==1.1.1         # via jinja2, mako
 mwoauth==0.3.7            # via -r requirements.in
 nullauthenticator==1.0.0  # via -r requirements.in
-oauthenticator==0.12.1    # via -r requirements.in
+oauthenticator==0.12.2    # via -r requirements.in
 oauthlib==3.1.0           # via jupyterhub, jupyterhub-ltiauthenticator, mwoauth, requests-oauthlib
 onetimepass==1.0.1        # via jupyterhub-nativeauthenticator
 pamela==1.0.0             # via jupyterhub


### PR DESCRIPTION
fixes issue with deprecated Authenticator config being ignored instead of preserved

closes #1914 (which was also fixed in release 0.10.6)