### PR TITLE
CI: fix of intermittent netpol test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,13 +90,10 @@ jobs:
       # kubectl and helm
       #
       # ref: https://github.com/manics/action-k3s-helm/
-      - uses: manics/action-k3s-helm@v0.2.1
+      - uses: manics/action-k3s-helm@dev
         with:
           k3s-version: ${{ matrix.k3s-version }}
-          # FIXME: Let's rely on the latest helm version by omitting this when
-          #        we can bump beyond manics/action-k3s-helm@v0.2.1 that has
-          #        such support.
-          helm-version: v3.4.0
+          helm-version: v3.4.1
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
       # kubectl and helm
       #
       # ref: https://github.com/manics/action-k3s-helm/
-      - uses: manics/action-k3s-helm@dev
+      - uses: manics/action-k3s-helm@main
         with:
           k3s-version: ${{ matrix.k3s-version }}
           helm-version: v3.4.1

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -60,10 +60,12 @@ singleuser:
     # For testing purposes in test_singleuser_netpol
     egress:
       - to:
+        # jupyter.org has multiple IPs associated with it, among them are these
+        # two. We explicitly allow access to one, but leave out the the other.
         - ipBlock:
-            cidr: 104.28.9.110/32       # jupyter.org 1
-        - ipBlock:
-            cidr: 104.28.8.110/32       # jupyter.org 2
+            cidr: 104.28.8.110/32
+        # - ipBlock:
+        #     cidr: 104.28.9.110/32
   extraEnv:
     TEST_ENV_FIELDREF_TO_NAMESPACE:
       valueFrom:

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -225,8 +225,9 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
                 "--",
                 "wget",
                 "--quiet",
-                "--tries=3",
+                "--tries=5",
                 "--timeout=3",
+                "--retry-connrefused",
                 allowed_url,
             ]
         )
@@ -244,8 +245,9 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
                 "--quiet",
                 "--server-response",
                 "-O-",
-                "--tries=3",
+                "--tries=5",
                 "--timeout=3",
+                "--retry-connrefused",
                 blocked_url,
             ]
         )

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -225,15 +225,24 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
                 "--",
                 "wget",
                 "--quiet",
+                "--server-response",
+                "--output-document=/dev/null",
                 "--tries=5",
                 "--timeout=3",
                 "--retry-connrefused",
                 allowed_url,
-            ]
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
-        assert (
-            c.returncode == 0
-        ), f"Network issue: access to '{allowed_url}' was supposed to be allowed"
+        if c.returncode != 0:
+            print(f"Return code: {c.returncode}")
+            print("---")
+            print(c.stdout)
+            raise AssertionError(
+                f"Network issue: access to '{allowed_url}' was supposed to be allowed"
+            )
 
         c = subprocess.run(
             [
@@ -244,16 +253,23 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
                 "wget",
                 "--quiet",
                 "--server-response",
-                "-O-",
+                "--output-document=/dev/null",
                 "--tries=5",
                 "--timeout=3",
                 "--retry-connrefused",
                 blocked_url,
-            ]
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
         )
-        assert (
-            c.returncode > 0
-        ), f"Network issue: access to '{blocked_url}' was supposed to be denied"
+        if c.returncode == 0:
+            print(f"Return code: {c.returncode}")
+            print("---")
+            print(c.stdout)
+            raise AssertionError(
+                f"Network issue: access to '{blocked_url}' was supposed to be denied"
+            )
 
     finally:
         _delete_server(api_request, jupyter_user, request_data["test_timeout"])

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -233,7 +233,7 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
         )
         assert (
             c.returncode == 0
-        ), f"Network issue: access to '{blocked_url}' was supposed to be allowed"
+        ), f"Network issue: access to '{allowed_url}' was supposed to be allowed"
 
         c = subprocess.run(
             [

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -230,17 +230,13 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
         # The IPs we test against are differentiated by the NetworkPolicy shaped
         # by the dev-config.yaml's singleuser.networkPolicy.egress
         # configuration. If these IPs change, you can use `nslookup jupyter.org`
-        # to get new IPs. Note that we have explicitly pinned these IPs and
-        # explicitly pass the Host header in the web-request in order to avoid
-        # test failures following additional IPs are added.
+        # to get new IPs but beware that this response may look different over
+        # time at least on our GitHub Action runners. Note that we have
+        # explicitly pinned these IPs and explicitly pass the Host header in the
+        # web-request in order to avoid test failures following additional IPs
+        # are added.
         allowed_jupyter_org_ip = "104.28.8.110"
         blocked_jupyter_org_ip = "104.28.9.110"
-        assert (
-            allowed_jupyter_org_ip in c.stdout
-        ), f"Did the jupyter.org update its associated IPs to no longer include {allowed_jupyter_org_ip}?"
-        assert (
-            blocked_jupyter_org_ip in c.stdout
-        ), f"Did the jupyter.org update its associated IPs to no longer include {blocked_jupyter_org_ip}?"
 
         cmd_kubectl_exec = ["kubectl", "exec", pod_name, "--"]
         cmd_python_exec = ["python", "-c"]

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -216,22 +216,21 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
         # Must match CIDR in singleuser.networkPolicy.egress.
         allowed_url = "http://jupyter.org"
         blocked_url = "http://mybinder.org"
+        cmd_kubectl_exec_wget = [
+            "kubectl",
+            "exec",
+            pod_name,
+            "--",
+            "wget",
+            "--server-response",
+            "--output-document=/dev/null",
+            "--tries=5",
+            "--timeout=3",
+            "--retry-connrefused",
+        ]
 
         c = subprocess.run(
-            [
-                "kubectl",
-                "exec",
-                pod_name,
-                "--",
-                "wget",
-                "--quiet",
-                "--server-response",
-                "--output-document=/dev/null",
-                "--tries=5",
-                "--timeout=3",
-                "--retry-connrefused",
-                allowed_url,
-            ],
+            cmd_kubectl_exec_wget + [allowed_url],
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -245,20 +244,7 @@ def test_singleuser_netpol(api_request, jupyter_user, request_data):
             )
 
         c = subprocess.run(
-            [
-                "kubectl",
-                "exec",
-                pod_name,
-                "--",
-                "wget",
-                "--quiet",
-                "--server-response",
-                "--output-document=/dev/null",
-                "--tries=5",
-                "--timeout=3",
-                "--retry-connrefused",
-                blocked_url,
-            ],
+            cmd_kubectl_exec_wget + [blocked_url],
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,


### PR DESCRIPTION
This PR fixes a issue in our tests caused by jupyter.org added a new IP address, so when we tried to access jupyter.org which was assumed be sent to one of two ips, it could sometime be sent to another IP.

This PR Closes #1927.

In this PR I also bump helm to 3.4.1 from 3.4.0, and starts using manics/actions-k3s-helm of the latest version so we get a more modern version of Calico for example. These changes only influence the test suite and shouldn't hurt having as part of this PR in my mind, so I'm saving myself the trouble of creating a dedicated PR.