### PR TITLE
Disable PDBs for hub/proxy, add PDB for autohttps, and relocate config proxy.pdb to proxy.chp.pdb

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -562,10 +562,24 @@ properties:
             type: object
             description: |
               Kubernetes annotations to apply to the hub service.
-      pdb:
+      pdb: &pdb-spec
         type: object
         description: |
-          Set the Pod Disruption Budget for the hub pod.
+          Configure a PodDisruptionBudget for this Deployment.
+
+          These are disabled by default for our deployments that doesn't support
+          being run in parallel with multiple replicas. Only the user-scheduler
+          currently support being run in parallel with multiple replicas. If
+          they are enabled for a Deployment with only one replica, they will
+          block `kubectl drain` of a node for example.
+
+          Note that if you aim to block scaling down a node with the
+          hub/proxy/autohttps pod that would cause disruptions of the
+          deployment, then you should instead annotate the pod's of the
+          Deployment [as described
+          here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node).
+
+              "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
 
           See [the Kubernetes
           documentation](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/)
@@ -574,11 +588,13 @@ properties:
           enabled:
             type: boolean
             description: |
-              Whether PodDisruptionBudget is enabled for the hub pod.
+              Decides if a PodDisruptionBudget is created targeting the
+              Deployment's pods.
           minAvailable:
             type: integer
             description: |
-              Minimum number of pods to be available during the voluntary disruptions.
+              The minimum number of pods required to be available during
+              voluntary disruptions.
       existingSecret:
         type:
           - string
@@ -702,6 +718,7 @@ properties:
 
               For more information, see the [Kubernetes EnvVar
               specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
+          pdb: *pdb-spec
           nodeSelector: *nodeSelector-spec
           tolerations: *tolerations-spec
       secretToken:
@@ -886,23 +903,6 @@ properties:
               hosts:
                 - <your-domain-name>
               ```   
-      pdb:
-        type: object
-        description: |
-          Set the Pod Disruption Budget for the proxy pod.
-
-          See [the Kubernetes
-          documentation](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/)
-          for more details about disruptions.
-        properties:
-          enabled:
-            type: boolean
-            description: |
-              Whether PodDisruptionBudget is enabled for the proxy pod.
-          minAvailable:
-            type: integer
-            description: |
-              Minimum number of pods to be available during the voluntary disruptions.
       traefik:
         type: object
         description: |
@@ -952,6 +952,7 @@ properties:
 
               For more information, see the [Kubernetes EnvVar
               specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
+          pdb: *pdb-spec
           nodeSelector: *nodeSelector-spec
           tolerations: *tolerations-spec
     required:
@@ -1195,23 +1196,7 @@ properties:
               You can have multiple schedulers to share the workload or improve
               availability on node failure.
           image: *image-spec
-          pdb:
-            type: object
-            description: |
-              Set the Pod Disruption Budget for the user scheduler.
-
-              See [the Kubernetes
-              documentation](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/)
-              for more details about disruptions.
-            properties:
-              enabled:
-                type: boolean
-                description: |
-                  Whether PodDisruptionBudget is enabled for the user scheduler.
-              minAvailable:
-                type: integer
-                description: |
-                  Minimum number of pods to be available during the voluntary disruptions.
+          pdb: *pdb-spec
           nodeSelector: *nodeSelector-spec
           tolerations: *tolerations-spec
       podPriority:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -567,15 +567,15 @@ properties:
         description: |
           Configure a PodDisruptionBudget for this Deployment.
 
-          These are disabled by default for our deployments that doesn't support
+          These are disabled by default for our deployments that don't support
           being run in parallel with multiple replicas. Only the user-scheduler
-          currently support being run in parallel with multiple replicas. If
+          currently supports being run in parallel with multiple replicas. If
           they are enabled for a Deployment with only one replica, they will
           block `kubectl drain` of a node for example.
 
           Note that if you aim to block scaling down a node with the
           hub/proxy/autohttps pod that would cause disruptions of the
-          deployment, then you should instead annotate the pod's of the
+          deployment, then you should instead annotate the pods of the
           Deployment [as described
           here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node).
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -79,3 +79,8 @@ directly instead.
 {{ "HARD DEPRECATION: singleuser.imagePullSecret has renamed to imagePullSecret" | fail }}
 {{- end }}
 {{- end }}
+
+
+{{- if hasKey .Values.proxy "pdb" }}
+{{ "HARD DEPRECATION: proxy.pdb has renamed to proxy.chp.pdb" | fail }}
+{{- end }}

--- a/jupyterhub/templates/proxy/autohttps/pdb.yaml
+++ b/jupyterhub/templates/proxy/autohttps/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.proxy.traefik.pdb.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: proxy
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.proxy.traefik.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "jupyterhub.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.proxy.pdb.enabled -}}
+{{- if .Values.proxy.chp.pdb.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.proxy.pdb.minAvailable }}
+  minAvailable: {{ .Values.proxy.chp.pdb.minAvailable }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -242,6 +242,9 @@ proxy:
                 cidr: 0.0.0.0/0
       interNamespaceAccessLabels: ignore
       allowedIngressPorts: [http, https]
+    pdb:
+      enabled: false
+      minAvailable: 1
   secretSync:
     containerSecurityContext:
       runAsUser: 65534  # nobody user

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -205,6 +205,9 @@ proxy:
                 cidr: 0.0.0.0/0
       interNamespaceAccessLabels: ignore
       allowedIngressPorts: [http, https]
+    pdb:
+      enabled: true
+      minAvailable: 1
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
   traefik:
@@ -257,9 +260,6 @@ proxy:
       pullSecrets: []
     resources: {}
   labels: {}
-  pdb:
-    enabled: true
-    minAvailable: 1
   https:
     enabled: false
     type: letsencrypt

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -84,7 +84,7 @@ hub:
     allowPrivilegeEscalation: false
   services: {}
   pdb:
-    enabled: true
+    enabled: false
     minAvailable: 1
   networkPolicy:
     enabled: true
@@ -206,7 +206,7 @@ proxy:
       interNamespaceAccessLabels: ignore
       allowedIngressPorts: [http, https]
     pdb:
-      enabled: true
+      enabled: false
       minAvailable: 1
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -143,6 +143,8 @@ proxy:
                 cidr: 0.0.0.0/0
       interNamespaceAccessLabels: accept
       allowedIngressPorts: [http, https]
+    pdb:
+      enabled: true
   traefik:
     extraPorts:
     - name: ssh
@@ -191,8 +193,6 @@ proxy:
     mock-proxy-label: mock
   nodeSelector:
     mock-proxy-node-selector: mock
-  pdb:
-    enabled: true
   https:
     enabled: true
     type: letsencrypt

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -177,6 +177,8 @@ proxy:
                 cidr: 0.0.0.0/0
       interNamespaceAccessLabels: accept
       allowedIngressPorts: [http, https]
+    pdb:
+      enabled: true
   secretSync:
     resources:
       requests:


### PR DESCRIPTION
This PR follows #1937 and discussion in #1934. I suggest we continue the discussion about _what to do_ in #1934 unless it is about the lines of codes changed.

I've opened https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1951 to represent the wish for better documentation about HA so that the we are more explicit with assumptions.

## PR summary

- [x] Disabling hub/proxy PDB by default.
  This is done to close #1934, and motivated by them being non-HA applications. For more in-depth discussion, see #1934.
- [x] Added autohttps PDB, also disabled by default.
  This is done for completeness as it would generally make sense to enable PDBs for proxy/hub/autohttps all at once if either was enabled.
- [x] Renamed pdb configuration proxy.pdb to to proxy.chp.pdb.
  This was done to make the configuration more cohesive and easy to understand now that we have one for the proxy pod and the autohttps pod. This is in alignment of how we have mapped the other configuration. It will make it easier in the future if we replace the configurable-http-proxy with another implementation also that may merit from other defaults. The old name is deprecated with a `fail` to help users quickly spot the change and transition.

## Motivation for the new default

1. Most other Helm chart defaults to having PDBs disabled by default
   making our chart's behavior unexpected.

2. The idea of using a PDB is tightly coupled with applications that
   support high availability, in other words, to run in parallel to
   another. But, the hub/proxy/autohttps pod doesn't support it. As an
   indication of this, see the k8s docs on "configure-pdb" which has a
   "Before you begin" section that sais "You are the owner of an
   application running on a Kubernetes cluster that requires high
   availability.

   ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/

3. When evictions take place, such as when a node is drained, the PDBs
   will be respected, and since we have `minAvailable: 1` and cannot
   create another one, a manual pod deletion is required.

   It is my perception that the act of draining a node should come with
   intent and consideration typically. If it comes as part of an
   automated k8s upgrade of nodes, it should at least be scheduled at a
   acceptable time window etc. So, it wouldn't be helpful to add the
   need to run `kubect delete pod` alongside this.

4. If the wish is to avoid making the cluster autoscaler relocate a pod
   part of a deployment, then it is more direct and sensible to use the
   `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"`
   annotation.

   ref: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node