### PR TITLE
Enable hub livenessProbe by default and relax hub/proxy probes

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -111,7 +111,7 @@ hub:
   livenessProbe:
     # The livenessProbe's aim to give JupyterHub sufficient time to startup but
     # be able to restart if it becomes unresponsive for ~5 min.
-    enabled: false
+    enabled: true
     initialDelaySeconds: 300
     periodSeconds: 10
     failureThreshold: 30


### PR DESCRIPTION
This PR closes #1936 and stems from a deliberations in #1732 that I suggest we close when we have added a startupProbe as suggested in an action point in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1732#issuecomment-705277165.

The actual changes are:
1. Enable hub's livenessProbe by default.
2. Make hub's livenessProbe start after 5 minutes (from 3), and trigger a pod restart after >5 minutes without any response (from >30s).
3. Make hub's readinessProbe very relaxed so it won't fail before the hub's livenessProbe or generally at all, because it would not serve a purpose to have a non-ready hub pod as it doesn't support being run in parallel with another pod.
4. Make proxy's readinessProbe be very relaxed for the same reasons at the hub pod.

