### PR TITLE
ci: cronjob to scan images for known vulnerabilities

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -1,0 +1,67 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+#
+name: Image scan
+
+on:
+  schedule:
+    # At 00:00 on Monday - https://crontab.guru
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  trivy_image_scan:
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_ref: hub
+          - image_ref: secret-sync
+          - image_ref: network-tools
+          - image_ref: image-awaiter
+          - image_ref: singleuser-sample
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # chartpress requires the full history
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install chartpress
+        run: |
+          pip install chartpress
+
+      # charpress --list-images output lines of name:tag format. We use it with
+      # a search string in matrix.image_ref to find the specific image to scan
+      # in this job.
+      - name: Identify image name:tag
+        id: image
+        run: |
+          IMAGE=$(
+              chartpress --list-images \
+            | grep ${{ matrix.image_ref }}:
+          )
+          IMAGE_NAME=$(echo $IMAGE | sed 's/\(.*\):.*/\1/')
+          IMAGE_TAG=$(echo $IMAGE | sed 's/.*:\(.*\)/\1/')
+          echo "::set-output name=name::$IMAGE_NAME"
+          echo "::set-output name=tag::$IMAGE_TAG"
+          echo "Image identified: $IMAGE_NAME:$IMAGE_TAG"
+
+      # Action reference: https://github.com/aquasecurity/trivy-action
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ steps.image.outputs.name }}:${{ steps.image.outputs.tag }}
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -5,8 +5,8 @@ name: Image scan
 
 on:
   schedule:
-    # At 00:00 on Monday - https://crontab.guru
-    - cron: "0 0 * * 1"
+    # At 00:00 - https://crontab.guru
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -1,7 +1,7 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
 # ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 #
-name: Image scan
+name: Vuln. scan
 
 on:
   schedule:

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -56,17 +56,14 @@ jobs:
               chartpress --list-images \
             | grep ${{ matrix.image_ref }}:
           )
-          IMAGE_NAME=$(echo $IMAGE | sed 's/\(.*\):.*/\1/')
-          IMAGE_TAG=$(echo $IMAGE | sed 's/.*:\(.*\)/\1/')
-          echo "::set-output name=name::$IMAGE_NAME"
-          echo "::set-output name=tag::$IMAGE_TAG"
-          echo "Image identified: $IMAGE_NAME:$IMAGE_TAG"
+          echo "::set-output name=image::$IMAGE"
+          echo "Image identified: $IMAGE"
 
       # Action reference: https://github.com/aquasecurity/trivy-action
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ steps.image.outputs.name }}:${{ steps.image.outputs.tag }}
+          image-ref: ${{ steps.image.outputs.image }}
           format: table
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -1,6 +1,11 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
 # ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 #
+# This workflow use aquasecurity/trivy to scan the images we have published for
+# known vulnerabilities. If there are such that can be patched, we let this
+# workflow fail to signal that unless we make an exception, which we do for the
+# singleuser-sample image only.
+#
 name: Vuln. scan
 
 on:
@@ -26,6 +31,7 @@ jobs:
           - image_ref: network-tools
           - image_ref: image-awaiter
           - image_ref: singleuser-sample
+            accept_trivy_failure: true
 
     steps:
       - uses: actions/checkout@v2
@@ -65,3 +71,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           severity: 'CRITICAL,HIGH'
+        # Make the job not fail if this step fails and we accept_trivy failure.
+        # If we continue-on-error, the GitHub UI signal the job to be green, but
+        # report a warning as an annotation about it.
+        continue-on-error: ${{ matrix.accept_trivy_failure == true }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Zero to JupyterHub with Kubernetes
 
 [![Documentation build status](https://img.shields.io/readthedocs/zero-to-jupyterhub?logo=read-the-docs)](https://zero-to-jupyterhub.readthedocs.io/en/latest/?badge=latest)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jupyterhub/zero-to-jupyterhub-k8s/Test?logo=github)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions)
+[![GitHub Workflow Status - Test](https://img.shields.io/github/workflow/status/jupyterhub/zero-to-jupyterhub-k8s/Test?logo=github&label=tests)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions)
+[![GitHub Workflow Status - Vuln. scan](https://img.shields.io/github/workflow/status/jupyterhub/zero-to-jupyterhub-k8s/Vuln%20scan?logo=github&label=Vuln.%20scan)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions)
 [![Latest stable release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=stable&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.stable&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#jupyterhub)
 [![Latest pre-release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=pre&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.pre&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
 [![Latest development release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=dev&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.latest&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)


### PR DESCRIPTION
In this PR I've created a workflow scheduled to run once daily scanning the images we manage with chartpress for known vulnerabilities using [aquasecurity/trivy](https://github.com/aquasecurity/trivy) by using the [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action).

Closes #1712.

## In this PR also...
- [x] Use GitHub workflow status badges in README.md

## In future PRs...
- [ ] Update Dockerfiles with a comment to trigger rebuilds by the CI system
  - [ ] Let the comment contain a hash of some kind, diffing the latest released vulns with the new vulns.
  - [ ] Update _all_ Dockerfiles to contain such comment
- [x] Automate practice of forcing a rebuild to see if it resolves security concerns and if so, open a PR to trigger the rebuild.
- [ ] Block this workflow from running on forks randomly disturbing anyone having forked this repo
- [ ] Update Dockerfiles to help anyone apply a security patch manually.


## Example workflow run
![image](https://user-images.githubusercontent.com/3837114/101992247-1b9c3780-3cb2-11eb-9ba4-513257af49dd.png)