### PR TITLE
Helm template linting - remove extra space

### DIFF
--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -4,7 +4,7 @@
 {{- $manualHTTPSwithsecret := and $enabled (eq .Values.proxy.https.type "secret") -}}
 {{- $offloadHTTPS := and $enabled (eq .Values.proxy.https.type "offload") -}}
 {{- $valid := or $autoHTTPS (or $manualHTTPS (or $manualHTTPSwithsecret $offloadHTTPS)) -}}
-{{- $HTTPS := and $enabled $valid  -}}
+{{- $HTTPS := and $enabled $valid -}}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
This extra space is breaking the lexing of old version of Rancher that I'm stuck with.  It's related to this issue: https://go-review.googlesource.com/c/go/+/168457