### PR TITLE
ci: let dependabot update jupyterhub, replace JUPYTERHUB_VERSION with PIP_OVERRIDES

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,3 +1,13 @@
+# This is the configuration for chartpress, a CLI for Helm chart management.
+#
+# chartpress is used to:
+# - Build images
+# - Update Chart.yaml (version) and values.yaml (image tags)
+# - Package and publish Helm charts to a GitHub based Helm chart repository
+#
+# For more information, see the projects README.md file:
+# https://github.com/jupyterhub/chartpress
+#
 charts:
   - name: jupyterhub
     imagePrefix: jupyterhub/k8s-

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -10,19 +10,41 @@
 #
 charts:
   - name: jupyterhub
+    # Dev: imagePrefix can be useful to override if you want to trial something
+    #      locally developed in a remote k8s cluster.
     imagePrefix: jupyterhub/k8s-
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart
 
     images:
-      secret-sync:
-        valuesPath: proxy.secretSync.image
+      # hub, the container where JupyterHub, KubeSpawner, and the configured
+      # Authenticator are running.
       hub:
         valuesPath: hub.image
+        # Dev: buildArgs can help you try the Helm chart against unreleased
+        #      versions of JupyterHub or KubeSpawner.
+        # buildArgs:
+        #   PIP_OVERRIDES: "jupyterhub==1.3.0 git+https://github.com/your-username-here/kubespawner.git"
+
+      # secret-sync, a sidecar container running in the autohttps pod to next to
+      # Traefik meant to sync a TLS certificate with a k8s Secret.
+      secret-sync:
+        valuesPath: proxy.secretSync.image
+
+      # network-tools, an initContainer with iptables installed starting on user
+      # pods to block access to the so called "cloud metadata server" for
+      # security reasons.
       network-tools:
         valuesPath: singleuser.networkTools.image
+
+      # image-awaiter, the only container inside the image-awaiter-job Pod
+      # starting as part of `helm upgrade` in order to check that images have
+      # been pulled by the hook-image-puller before helm starts doing additional
+      # changes as part of the upgrade.
       image-awaiter:
         valuesPath: prePuller.hook.image
+
+      # singleuser-sample, a primitive user container to start with.
       singleuser-sample:
         valuesPath: singleuser.image

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -10,14 +10,9 @@ charts:
         valuesPath: proxy.secretSync.image
       hub:
         valuesPath: hub.image
-        buildArgs:
-          # NOTE: Also bump the Chart.yaml's appVersion if this is bumped
-          JUPYTERHUB_VERSION: 1.2.2
       network-tools:
         valuesPath: singleuser.networkTools.image
       image-awaiter:
         valuesPath: prePuller.hook.image
       singleuser-sample:
         valuesPath: singleuser.image
-        buildArgs:
-          JUPYTERHUB_VERSION: 1.2.2

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -34,21 +34,20 @@ RUN adduser --disabled-password \
     --force-badname \
     ${NB_USER}
 
-RUN python3 -m pip install --upgrade --no-cache setuptools pip
 COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --upgrade --no-cache-dir \
+        setuptools \
+        pip
+RUN PYCURL_SSL_LIBRARY=openssl \
+    pip install --no-cache-dir \
+        -r /tmp/requirements.txt
 
-# NOTE: This is a default and will be overridden by chartpress and the
-#       dependencies script using the chartpress.yaml configuration's buildArgs
-ARG JUPYTERHUB_VERSION=1.2.2
-
-RUN PYCURL_SSL_LIBRARY=openssl pip3 install --no-cache-dir \
-         -r /tmp/requirements.txt \
- && pip3 install --no-cache-dir \
-         $(bash -c 'if [[ $JUPYTERHUB_VERSION == "git"* ]]; then \
-            echo ${JUPYTERHUB_VERSION}; \
-          else \
-            echo jupyterhub==${JUPYTERHUB_VERSION}; \
-          fi')
+# Support overriding a package or two through passed docker --build-args.
+# ARG PIP_OVERRIDES="jupyterhub==1.3.0 git+https://github.com/consideratio/kubespawner.git"
+ARG PIP_OVERRIDES=
+RUN if [[ -n "$PIP_OVERRIDES" ]]; then \
+        pip install --no-cache-dir $PIP_OVERRIDES; \
+    fi
 
 WORKDIR /srv/jupyterhub
 

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
       curl \
       dnsutils \
       && \
-    apt-get purge && apt-get clean
+    rm -rf /var/lib/apt/lists/*
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -1,12 +1,11 @@
-# This file can automatically be used to update requirements.txt with pinned
-# versions by running:
+# This file is automatically maintained by Dependabot, as configured in
+# .github/dependabot.yaml. It can also be updated by...
 #
 #    ./dependencies freeze --upgrade
 #
 
-# JupyterHub is pinned in chartpress.yaml, but need to be pinned here as well to
-# so our generated requirements.txt get proper comments set on it.
-jupyterhub==1.2.2
+# JupyterHub itself
+jupyterhub
 
 ## Authenticators
 jupyterhub-dummyauthenticator

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -8,10 +8,6 @@ FROM jupyter/base-notebook:45bfe5a474fa
 # The jupyter/docker-stacks images contains jupyterhub, jupyterlab and the
 # jupyterlab-hub extension already.
 
-## NOTE: This is a default and be overridden by chartpress using the
-##       chartpress.yaml configuration
-ARG JUPYTERHUB_VERSION=1.2.2
-
 # Example install of git and nbgitpuller.
 # NOTE: git is already available in the jupyter/minimal-notebook image.
 USER root
@@ -22,13 +18,17 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 USER $NB_USER
 
-RUN python -m pip install nbgitpuller \
-    $(bash -c 'if [[ $JUPYTERHUB_VERSION == "git"* ]]; then \
-       echo ${JUPYTERHUB_VERSION}; \
-     else \
-       echo jupyterhub==${JUPYTERHUB_VERSION}; \
-     fi') && \
-    jupyter serverextension enable --py nbgitpuller --sys-prefix
+RUN python -m pip install --no-cache-dir \
+        nbgitpuller
+
+# Support overriding a package or two through passed docker --build-args.
+# ARG PIP_OVERRIDES="jupyterhub==1.3.0"
+ARG PIP_OVERRIDES=
+RUN if [[ -n "$PIP_OVERRIDES" ]]; then \
+        pip install --no-cache-dir $PIP_OVERRIDES; \
+    fi
+
+RUN jupyter serverextension enable --py nbgitpuller --sys-prefix
 
 # Uncomment the line below to make nbgitpuller default to start up in JupyterLab
 #ENV NBGITPULLER_APP=lab


### PR DESCRIPTION
I wanted to make dependabot also manage the jupyterhub version. To make that happen, I had to stop pinning it explicitly here and there.

Associated with this in the PR, is a removal of the JUPYTERHUB_VERSION --build-args. I added PIP_OVERRIDES instead as it would be more generally helpful.

## Action points
- [x] Improve inline docs of chartpress.yaml so that users understand how to learn more etc if they inspect it.
- [x] Help users make use of the new PIP_OVERRIDES argument by commenting in chartpress.yaml