### PR TITLE
Fix failure to block insecure metadata server IP

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -487,7 +487,10 @@ set_config_if_not_none(c.Spawner, "default_url", "singleuser.defaultUrl")
 
 cloud_metadata = get_config("singleuser.cloudMetadata", {})
 
-if cloud_metadata.get("block") == True or cloud_metadata.get("enabled") == False:
+if (
+    cloud_metadata.get("blockWithIptables") == True
+    or cloud_metadata.get("enabled") == False
+):
     # Use iptables to block access to cloud metadata by default
     network_tools_image_name = get_config("singleuser.networkTools.image.name")
     network_tools_image_tag = get_config("singleuser.networkTools.image.tag")


### PR DESCRIPTION
#1805 softly deprecated a configuration, but the new configuration didn't work which made the user pods not startup with an initContainer blocking access to the metadata server which is known to be a security concern.