### PR TITLE
ci: vuln scan fix

### DIFF
--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -118,8 +118,7 @@ jobs:
         run: |
           json_to_misc() {
               # Count vulnerabilities
-              VULNERABILITY_COUNT=$(cat tmp/scan_$1.json | jq -r '.[].Vulnerabilities | select(. != null) | length')
-              VULNERABILITY_COUNT=${VULNERABILITY_COUNT:-0}
+              VULNERABILITY_COUNT="$(cat tmp/scan_$1.json | jq -r '[.[].Vulnerabilities | select(type == "array") | add] | select(. != null) | length')"
               echo "VULNERABILITY_COUNT_$1=$VULNERABILITY_COUNT" >> $GITHUB_ENV
 
               # Construct a markdown summary


### PR DESCRIPTION
In the edge case situations when we multiple kinds of vulnerabilities are found, we needed a fix to the `jq` logic.

Test failed due to unrelated intermittent failure of cert acquisition :'( Not again...
