### PR TITLE
Fixes link to authentication guide from user-management.md

### DIFF
--- a/doc/source/jupyterhub/customizing/user-management.md
+++ b/doc/source/jupyterhub/customizing/user-management.md
@@ -74,4 +74,4 @@ auth:
 ## Authenticating Users
 
 For information on authenticating users in JupyterHub, see
-[the Authentication guide](../administrator/authentication).
+[the Authentication guide](../../administrator/authentication).


### PR DESCRIPTION
The target path was apparently moved. This updates the link down here.