### PR TITLE
ci: Test against k8s 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,16 +68,18 @@ jobs:
         #
         # k3s-version: https://github.com/rancher/k3s/tags
         include:
-          - k3s-version: v1.19.3+k3s2
+          - k3s-version: v1.20.0+k3s2
             test: install
-          - k3s-version: v1.18.10+k3s2
+          - k3s-version: v1.19.5+k3s1
             test: install
-          - k3s-version: v1.17.13+k3s2
+          - k3s-version: v1.18.13+k3s1
+            test: install
+          - k3s-version: v1.17.15+k3s1
             test: install
           - k3s-version: v1.16.15+k3s1
             test: install
 
-          - k3s-version: v1.19.3+k3s1
+          - k3s-version: v1.19.5+k3s1
             test: upgrade
 
     steps:
@@ -93,7 +95,7 @@ jobs:
       - uses: jupyterhub/action-k3s-helm@main
         with:
           k3s-version: ${{ matrix.k3s-version }}
-          helm-version: v3.4.1
+          helm-version: v3.4.2
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: true


### PR DESCRIPTION
Just adds testing against k8s 1.20 which is now supported by k3s, not so long after k8s 1.20 was made available.

---

It has not been fully published yet it seems, probably around by tomorrow at least.