### PR TITLE
ci: configure dependabot for singleuser-sample

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,7 +8,6 @@ updates:
       interval: daily
       time: "05:00"
       timezone: "Etc/UTC"
-    open-pull-requests-limit: 4
     versioning-strategy: lockfile-only
     labels:
       - maintenance

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,8 +4,10 @@ updates:
   # Maintain Python dependencies for the jupyterhub/k8s-hub image
   - package-ecosystem: pip
     directory: "/images/hub"
-    schedule:
+    schedule: &schedule
       interval: daily
+      time: "05:00"
+      timezone: "Etc/UTC"
     open-pull-requests-limit: 4
     versioning-strategy: lockfile-only
     labels:
@@ -15,8 +17,7 @@ updates:
   # Maintain dependencies in our GitHub Workflows
   - package-ecosystem: "github-actions"
     directory: "/"  # This should be / rather than .github/workflows
-    schedule:
-      interval: daily
+    schedule: *schedule
     labels:
       - maintenance
       - dependencies

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,15 @@ updates:
       - maintenance
       - dependencies
 
+  # Maintain Python dependencies for the jupyterhub/k8s-singleuser-sample image
+  - package-ecosystem: pip
+    directory: "/images/singleuser-sample"
+    schedule: *schedule
+    versioning-strategy: lockfile-only
+    labels:
+      - maintenance
+      - dependencies
+
   # Maintain dependencies in our GitHub Workflows
   - package-ecosystem: "github-actions"
     directory: "/"  # This should be / rather than .github/workflows

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -18,8 +18,9 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 USER $NB_USER
 
+COPY requirements.txt /tmp/requirements.txt
 RUN python -m pip install --no-cache-dir \
-        nbgitpuller
+    -r /tmp/requirements.txt
 
 # Support overriding a package or two through passed docker --build-args.
 # ARG PIP_OVERRIDES="jupyterhub==1.3.0"

--- a/images/singleuser-sample/requirements.txt
+++ b/images/singleuser-sample/requirements.txt
@@ -1,0 +1,5 @@
+# This file is automatically maintained by Dependabot, as configured in
+# .github/dependabot.yaml.
+
+jupyterhub==1.2.2
+nbgitpuller==0.9.0


### PR DESCRIPTION
Helps us update jupyterhub's version in this image as well, which should mirror the hub image version even though its often not important.
