### PR TITLE
ci: help dependabot only trigger one set of tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ name: Test
 on:
   pull_request:
   push:
+    branches-ignore:
+      - "dependabot/**"
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
When dependabot opens a branch for its PR it also directly creates, it leads to the triggering of two separate test executions in parallel: one for the push event to a branch, and one for the PR. This change makes us ignore pushes to the `dependabot/**` branches.
