### PR TITLE
ci: dependabot, add notes to config, fix singleuser-sample config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,15 @@
 # dependabot.yml reference: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
 #
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/zero-to-jupyterhub-k8s/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+# - versioning-strategy: lockfile-only must not be used if you only have a plain
+#   requirements.txt like we do in images/singleuser-sample.
+# - We explicitly set the "maintenance" label to help our changelog generator
+#   tool github-activity to categorize PRs.
+#
+
 version: 2
 updates:
   # Maintain Python dependencies for the jupyterhub/k8s-hub image
@@ -21,7 +31,6 @@ updates:
       interval: daily
       time: "05:00"
       timezone: "Etc/UTC"
-    versioning-strategy: lockfile-only
     labels:
       - maintenance
       - dependencies


### PR DESCRIPTION
With just a requirements.txt file, I should not have `versioning-strategy: lockfile-only` as I added for singleuser-sample.
