### PR TITLE
ci: full_namespace_report function improved

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,11 +135,11 @@ jobs:
           # If you have problems with the tests add '--capture=no' to show stdout
           pytest --verbose --maxfail=2 --color=yes ./tests
 
-      - name: Provide info on failures
-        if: failure()
+      - name: Full namespace report
+        if: always()
         run: |
           . ./ci/common
-          full_namespace_report
+          full_namespace_report "deploy/hub" "deploy/proxy"
 
 
   docs_linkcheck:

--- a/ci/common
+++ b/ci/common
@@ -112,54 +112,59 @@ full_namespace_report () {
     # list config (secret,configmap)
     printf "$format" "### \$ kubectl get secret,cm"
     kubectl get secret,cm
-    # list networking (service,ingress)
+    # list networking (service,ingress,networkpolicy)
     printf "$format" "### \$ kubectl get svc,ing,netpol"
     kubectl get svc,ing,netpol
-    # list rbac (sa,role,rolebinding)
+    # list rbac (serviceaccount,role,rolebinding)
     printf "$format" "### \$ kubectl get sa,role,rolebinding"
     kubectl get sa,role,rolebinding
 
-    printf "$format" "## Non-ready pods: description and logs"
     # if any pod has any non-ready -> show its containers' logs
-    kubectl get pods -o json \
-        | jq '
-        .items[]
-        | select(
-            any(.status.containerStatuses[]?; .ready == false)
-        )
-    | .metadata.name' \
-        | xargs --max-args 1 --no-run-if-empty \
-        sh -c '
-            printf "$format_error" "### \$ kubectl describe pod/$0";
-            kubectl describe pod/$0;
-            printf "$format_error" "### \$ kubectl logs --all-containers pod/$0";
-            kubectl logs --all-containers pod/$0 || true;
-    '
+    NON_READY_PODS=$(
+        kubectl get pods -o json \
+            | jq -r '
+                .items[]
+                | select(
+                    any(.status.containerStatuses[]?; .ready == false)
+                )
+                | .metadata.name
+        '
+    )
+    if [ -n "$NON_READY_PODS" ]; then
+        printf "$format_error" "## Non-ready pods detected!"
+        for var in $NON_READY_PODS; do
+            printf "$format_error" "### \$ kubectl describe pod/$var"
+            kubectl describe pod/$var
+            printf "$format_error" "### \$ kubectl logs --all-containers pod/$var"
+            kubectl logs --all-containers pod/$var || true
+        done
+    fi
 
     # if any pods that should be scheduled by the user-scheduler are pending ->
     # show user-scheduler's logs
-    (
+    PENDING_USER_PODS=$(
         kubectl get pods -l "component in (user-placeholder,singleuser-server)" -o json \
             | jq -r '
-            .items[]
-            | select(.status.phase == "Pending")
-            | .metadata.name
+                .items[]
+                | select(.status.phase == "Pending")
+                | .metadata.name
         '
-    ) | xargs --max-args 1 --no-run-if-empty --max-lines \
-        sh -c '
-            printf "$format_error" "### \$ kubectl logs deploy/user-scheduler (pod/$0 was pending)";
-            kubectl logs --all-containers deploy/user-scheduler || true;
-    '
+    )
+    if [ -n "$PENDING_USER_PODS" ]; then
+        printf "$format_error" "## Pending pods detected!"
+        printf "$format_error" "### \$ kubectl logs deploy/user-scheduler"
+        kubectl logs --all-containers deploy/user-scheduler || true
+    fi
 
     # show container logs of all important workloads passed to the function,
     # "deploy/hub" and "deploy/proxy" for example.
     if [ "$#" -gt 0 ]; then
-        printf "$format" "## Important workloads: logs"
+        printf "$format" "## Important workload's logs"
+        for var in "$@"; do
+            printf "$format" "### \$ kubectl logs --all-containers $var"
+            kubectl logs --all-containers $var || true
+        done
     fi
-    for var in "$@"; do
-        printf "$format" "### \$ kubectl logs --all-containers $var"
-        kubectl logs --all-containers $var || true
-    done
 }
 
 install_and_run_chartpress_and_pebble () {

--- a/ci/common
+++ b/ci/common
@@ -104,7 +104,7 @@ full_namespace_report () {
         )
     | .metadata.name' \
         | xargs --max-args 1 --no-run-if-empty \
-        sh -c 'printf "\nPod with non-ready container detected\n - Logs of $0:\n"; kubectl logs --all-containers $0'
+        sh -c 'printf "\nPod with non-ready container detected\n - Logs of $0:\n"; kubectl logs --all-containers $0 || true'
 
     # if any pods that should be scheduled by the user-scheduler are pending ->
     # show user-scheduler's logs
@@ -116,15 +116,15 @@ full_namespace_report () {
             | .metadata.name
         '
     ) | xargs --max-args 1 --no-run-if-empty --max-lines \
-        sh -c 'printf "\nPending user pod detected ($0)\n - Logs of deploy/user-scheduler:\n"; kubectl logs --all-containers deploy/user-scheduler'
+        sh -c 'printf "\nPending user pod detected ($0)\n - Logs of deploy/user-scheduler:\n"; kubectl logs --all-containers deploy/user-scheduler || true'
 
     echo ""
     echo "Just while debugging intermittent issue, lets output the logs of the hub."
-    kubectl logs --all-containers deploy/hub
+    kubectl logs --all-containers deploy/hub || true
 
     echo ""
     echo "Just while debugging intermittent issue, lets output the logs of the proxy pod."
-    kubectl logs --all-containers deploy/proxy
+    kubectl logs --all-containers deploy/proxy || true
 }
 
 install_and_run_chartpress_and_pebble () {

--- a/ci/common
+++ b/ci/common
@@ -88,16 +88,38 @@ setup_kubeval () {
 }
 
 full_namespace_report () {
-    printf "\n---------- FULL NAMESPACE REPORT ----------\n\n"
-    printf "\n---------- kubectl get ----------\n\n"
+    # Purpose:
+    # - To chart agnostically print relevant information of the resources in a
+    #   namespace.
+    #
+    # Arguments:
+    # - Accepts a sequence of arguments such as "deploy/hub" "deploy/proxy". It
+    #   will do `kubectl logs --all-containers <arg>` on them.
+
+    # printf formatting: a bold bold colored topic with a divider.
+    yellow=33
+    red=31
+    divider='--------------------------------------------------------------------------------'
+    # GitHub Workflows resets formatting after \n, so its reapplied.
+    export format="\n\033[${yellow};1m%s\n\033[${yellow};1m${divider}\033[0m\n"
+    export format_error="\n\033[${red};1m%s\n\033[${red};1m${divider}\033[0m\n"
+
+    printf "$format" "# Full namespace report"
+    printf "$format" "## Resource overview"
+    # list workloads (deployment,statefulset,daemonset,pod)
+    printf "$format" "### \$ kubectl get deploy,sts,ds,pod"
+    kubectl get deploy,sts,ds,pod
     # list config (secret,configmap)
+    printf "$format" "### \$ kubectl get secret,cm"
     kubectl get secret,cm
     # list networking (service,ingress)
-    kubectl get svc,ing
-    # list workloads (deployment,statefulset,daemonset,pod)
-    kubectl get deploy,sts,ds,pod
+    printf "$format" "### \$ kubectl get svc,ing,netpol"
+    kubectl get svc,ing,netpol
+    # list rbac (sa,role,rolebinding)
+    printf "$format" "### \$ kubectl get sa,role,rolebinding"
+    kubectl get sa,role,rolebinding
 
-    printf "\n---------- kubectl describe and logs, of non-ready pods ----------\n\n"
+    printf "$format" "## Non-ready pods: description and logs"
     # if any pod has any non-ready -> show its containers' logs
     kubectl get pods -o json \
         | jq '
@@ -107,7 +129,12 @@ full_namespace_report () {
         )
     | .metadata.name' \
         | xargs --max-args 1 --no-run-if-empty \
-        sh -c 'printf "\n----- kubectl describe pod/$0 -----\n\n"; kubectl describe pod/$0; printf "\n----- kubectl logs --all-containers pod/$0 -----\n\n"; kubectl logs --all-containers pod/$0 || true'
+        sh -c '
+            printf "$format_error" "### \$ kubectl describe pod/$0";
+            kubectl describe pod/$0;
+            printf "$format_error" "### \$ kubectl logs --all-containers pod/$0";
+            kubectl logs --all-containers pod/$0 || true;
+    '
 
     # if any pods that should be scheduled by the user-scheduler are pending ->
     # show user-scheduler's logs
@@ -119,14 +146,20 @@ full_namespace_report () {
             | .metadata.name
         '
     ) | xargs --max-args 1 --no-run-if-empty --max-lines \
-        sh -c 'printf "\n---------- Pending user pod detected ($0) ----------\n\n----- kubectl logs deploy/user-scheduler -----\n\n"; kubectl logs --all-containers deploy/user-scheduler || true'
+        sh -c '
+            printf "$format_error" "### \$ kubectl logs deploy/user-scheduler (pod/$0 was pending)";
+            kubectl logs --all-containers deploy/user-scheduler || true;
+    '
 
-    printf "\n---------- kubectl logs of important pods ----------\n\n"
-    printf "\n----- kubectl logs hub -----\n\n"
-    kubectl logs --all-containers deploy/hub || true
-
-    printf "\n----- kubectl logs proxy -----\n\n"
-    kubectl logs --all-containers deploy/proxy || true
+    # show container logs of all important workloads passed to the function,
+    # "deploy/hub" and "deploy/proxy" for example.
+    if [ "$#" -gt 0 ]; then
+        printf "$format" "## Important workloads: logs"
+    fi
+    for var in "$@"; do
+        printf "$format" "### \$ kubectl logs --all-containers $var"
+        kubectl logs --all-containers $var || true
+    done
 }
 
 install_and_run_chartpress_and_pebble () {

--- a/ci/common
+++ b/ci/common
@@ -88,6 +88,8 @@ setup_kubeval () {
 }
 
 full_namespace_report () {
+    printf "\n---------- FULL NAMESPACE REPORT ----------\n\n"
+    printf "\n---------- kubectl get ----------\n\n"
     # list config (secret,configmap)
     kubectl get secret,cm
     # list networking (service,ingress)
@@ -95,6 +97,7 @@ full_namespace_report () {
     # list workloads (deployment,statefulset,daemonset,pod)
     kubectl get deploy,sts,ds,pod
 
+    printf "\n---------- kubectl describe and logs, of non-ready pods ----------\n\n"
     # if any pod has any non-ready -> show its containers' logs
     kubectl get pods -o json \
         | jq '
@@ -104,7 +107,7 @@ full_namespace_report () {
         )
     | .metadata.name' \
         | xargs --max-args 1 --no-run-if-empty \
-        sh -c 'printf "\nPod with non-ready container detected\n - Logs of $0:\n"; kubectl logs --all-containers $0 || true'
+        sh -c 'printf "\n----- kubectl describe pod/$0 -----\n\n"; kubectl describe pod/$0; printf "\n----- kubectl logs --all-containers pod/$0 -----\n\n"; kubectl logs --all-containers pod/$0 || true'
 
     # if any pods that should be scheduled by the user-scheduler are pending ->
     # show user-scheduler's logs
@@ -116,14 +119,13 @@ full_namespace_report () {
             | .metadata.name
         '
     ) | xargs --max-args 1 --no-run-if-empty --max-lines \
-        sh -c 'printf "\nPending user pod detected ($0)\n - Logs of deploy/user-scheduler:\n"; kubectl logs --all-containers deploy/user-scheduler || true'
+        sh -c 'printf "\n---------- Pending user pod detected ($0) ----------\n\n----- kubectl logs deploy/user-scheduler -----\n\n"; kubectl logs --all-containers deploy/user-scheduler || true'
 
-    echo ""
-    echo "Just while debugging intermittent issue, lets output the logs of the hub."
+    printf "\n---------- kubectl logs of important pods ----------\n\n"
+    printf "\n----- kubectl logs hub -----\n\n"
     kubectl logs --all-containers deploy/hub || true
 
-    echo ""
-    echo "Just while debugging intermittent issue, lets output the logs of the proxy pod."
+    printf "\n----- kubectl logs proxy -----\n\n"
     kubectl logs --all-containers deploy/proxy || true
 }
 


### PR DESCRIPTION
The full_namespace_report functioned defined in ci/common prints some useful output about the current k8s namespace using kubectl. This PR updates that function.

1. We now always run it, it only takes 1 second for a local k3s cluster.
2. We provide headers with nice colors, yellow / red depending on if the content to known to be associated with an error or not.
3. I refactored the function a bit, removing xargs as it was hard to only print headers when a condition was met without duplicating a lot of code.

![full-namespace-report](https://user-images.githubusercontent.com/3837114/103140178-f4972a00-46e3-11eb-9d3e-e2e930589161.gif)

