### PR TITLE
pre-commit: chartpress --reset on Chart.yaml/values.yaml changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,14 @@ jobs:
         with:
           python-version: '3.7'
 
-      - uses: pre-commit/action@v2.0.0
-
       - name: Install dependencies
         run: |
           . ci/common
           setup_helm
           KUBEVAL_VERSION=0.15.0 setup_kubeval
-          pip install yamllint
+          pip install chartpress yamllint
+
+      - uses: pre-commit/action@v2.0.0
 
       - name: Lint and validate
         # NOTE: Kubernetes resource validation can only be done against

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,28 @@
+# pre-commit is a tool to automatically do tasks before committing.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
 repos:
+  # Python code formatting
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:
       - id: black
         args: [--target-version=py36]
+
+  # Shell script code formatting
   - repo: https://github.com/lovesegfault/beautysh
     rev: 6.0.1
     hooks:
       - id: beautysh
+
+  # Reset changes by chartpress
+  - repo: local
+    hooks:
+      - id: chartpress
+        name: chartpress --reset
+        files: jupyterhub/Chart.yaml|jupyterhub/values.yaml
+        description: Run `chartpress --reset` to clean up helm charts before committing.
+        entry: chartpress --reset
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
I was skeptical, but now I fully understand that pre-commit really doesn't bother you unless you change the specific liens of codes in the specific file that would be influenced.

For example, assume you have run `chartpress --skip-build`, the Chart.yaml file will have its line `version: 0.10.6-n123.h1234567` set, which should be `0.0.1-set.by.chartpress` by default. But, if you commit another line change in this file, you will be fine! Having `chartpress --reset` run as part of pre-commit won't change a thing and everything will be fine.