### PR TITLE
ci: linkcheck rework: avoid duplicated build, add colors, make it fail loud

### DIFF
--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -39,16 +39,9 @@ jobs:
       - name: Install deps
         run: pip install --no-cache-dir -r doc/doc-requirements.txt
 
-      - name: Build and run linkcheck
+      - name: make linkcheck
         run: |
           cd doc
-          echo ---
-          echo Running: make html
-          echo ---
-          make html SPHINXOPTS='--color'
-          echo ---
-          echo Running: make linkcheck -W --keep-going
-          echo ---
           make linkcheck SPHINXOPTS='--color -W --keep-going'
         # Make the job not fail if this step fail. The GitHub UI will due to
         # this signal the job to be green even though it has failures though, so

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -43,10 +43,3 @@ jobs:
         run: |
           cd doc
           make linkcheck SPHINXOPTS='--color -W --keep-going'
-        # Make the job not fail if this step fail. The GitHub UI will due to
-        # this signal the job to be green even though it has failures though, so
-        # manual inspection is needed at the moment. A related ticket to improve
-        # this is open.
-        #
-        # ref: https://github.com/actions/toolkit/issues/399
-        continue-on-error: true

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -27,6 +27,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          # chartpress is used by doc/conf.py, part of doc/doc-requirements.txt,
+          # and requires information about the latest tagged commit, which
+          # requires the git history.
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -42,8 +42,14 @@ jobs:
       - name: Build and run linkcheck
         run: |
           cd doc
-          make html SPHINXOPTS='-W --keep-going --color'
-          make linkcheck SPHINXOPTS='--color'
+          echo ---
+          echo Running: make html
+          echo ---
+          make html SPHINXOPTS='--color'
+          echo ---
+          echo Running: make linkcheck -W --keep-going
+          echo ---
+          make linkcheck SPHINXOPTS='--color -W --keep-going'
         # Make the job not fail if this step fail. The GitHub UI will due to
         # this signal the job to be green even though it has failures though, so
         # manual inspection is needed at the moment. A related ticket to improve

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -42,8 +42,8 @@ jobs:
       - name: Build and run linkcheck
         run: |
           cd doc
-          make html SPHINXOPTS='-W --keep-going'
-          make linkcheck
+          make html SPHINXOPTS='-W --keep-going --color'
+          make linkcheck SPHINXOPTS='--color'
         # Make the job not fail if this step fail. The GitHub UI will due to
         # this signal the job to be green even though it has failures though, so
         # manual inspection is needed at the moment. A related ticket to improve

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -32,7 +32,7 @@ devenv:
 # For local development and CI:
 # - verifies that links are valid
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/linkcheck"
+	$(SPHINXBUILD) -b linkcheck --color $(ALLSPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/linkcheck"
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,14 +10,14 @@ BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+# "make mode" option.
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
 
 # Manually added commands
@@ -27,12 +27,12 @@ help:
 # - builds and rebuilds html on changes to source
 # - starts a livereload enabled webserver and opens up a browser
 devenv:
-	sphinx-autobuild -b html --open-browser --ignore "*/reference.md" $(ALLSPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
+	sphinx-autobuild -b html --open-browser --ignore "*/reference.md" "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS)
 
 # For local development and CI:
 # - verifies that links are valid
 linkcheck:
-	$(SPHINXBUILD) -b linkcheck --color $(ALLSPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/linkcheck"
+	$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)/linkcheck" $(SPHINXOPTS)
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -23,12 +23,12 @@ if errorlevel 9009 (
 	echo.The 'sphinx-build' command was not found. Open and read README.md!
 	exit /b 1
 )
-%SPHINXBUILD% -M %1 "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
+%SPHINXBUILD% -M %1 "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS%
 goto end
 
 
 :help
-%SPHINXBUILD% -M help "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS% %O%
+%SPHINXBUILD% -M help "%SOURCEDIR%" "%BUILDDIR%" %SPHINXOPTS%
 goto end
 
 
@@ -39,12 +39,12 @@ if errorlevel 9009 (
 	echo.The 'sphinx-autobuild' command was not found. Open and read README.md!
 	exit /b 1
 )
-sphinx-autobuild -b html --open-browser --ignore "*/reference.md" %ALLSPHINXOPTS% "%SOURCEDIR%" "%BUILDDIR%/html"
+sphinx-autobuild -b html --open-browser --ignore "*/reference.md" "%SOURCEDIR%" "%BUILDDIR%/html" %SPHINXOPTS%
 goto end
 
 
 :linkcheck
-%SPHINXBUILD% -b linkcheck --color %ALLSPHINXOPTS% "%SOURCEDIR%" "%BUILDDIR%/linkcheck"
+%SPHINXBUILD% -b linkcheck "%SOURCEDIR%" "%BUILDDIR%/linkcheck" %SPHINXOPTS%
 echo.
 echo.Link check complete; look for any errors in the above output 
 echo.or in "%BUILDDIR%/linkcheck/output.txt".

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -44,7 +44,7 @@ goto end
 
 
 :linkcheck
-%SPHINXBUILD% -b linkcheck %ALLSPHINXOPTS% "%SOURCEDIR%" "%BUILDDIR%/linkcheck"
+%SPHINXBUILD% -b linkcheck --color %ALLSPHINXOPTS% "%SOURCEDIR%" "%BUILDDIR%/linkcheck"
 echo.
 echo.Link check complete; look for any errors in the above output 
 echo.or in "%BUILDDIR%/linkcheck/output.txt".


### PR DESCRIPTION
Since we now only run this job on changes to the doc folder, I think it can be acceptable to let it fail loudly for a while.