### PR TITLE
ci: add another upgrade test and provide a template rendering diff

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -80,7 +80,7 @@ jobs:
         # k3s-version: https://github.com/rancher/k3s/tags
         # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
-          - k3s-channel: latest   # v1.20 as of 2020-12-31
+          - k3s-channel: v1.20
             test: install
           - k3s-channel: v1.19
             test: install
@@ -91,8 +91,23 @@ jobs:
           - k3s-channel: v1.16
             test: install
 
-          - k3s-channel: stable   # v1.19 as of 2020-12-31
+          # We run two upgrade tests where we first install an already released
+          # Helm chart version and then upgrades to the version we are now
+          # testing. We test upgrading from the latest stable version (like
+          # 1.2.3), and one from the latest dev version (like
+          # 1.2.3-n012.h1234abc).
+          #
+          # It can be very useful to see the "Helm diff" step's output from the
+          # latest dev version.
+          #
+          # The upgrade-from input should match the version information from
+          # https://jupyterhub.github.io/helm-chart/info.json
+          - k3s-channel: v1.19
             test: upgrade
+            upgrade-from: stable
+          - k3s-channel: v1.19
+            test: upgrade
+            upgrade-from: dev
 
     steps:
       - uses: actions/checkout@v2
@@ -123,22 +138,26 @@ jobs:
           . ./ci/common
           install_and_run_chartpress_and_pebble
 
-      - name: Install latest released chart
+      - name: "Install ${{ matrix.upgrade-from }} chart"
         if: matrix.test == 'upgrade'
         run: |
           . ./ci/common
-          helm install jupyterhub jupyterhub/jupyterhub --values dev-config.yaml
+          UPGRADE_FROM_VERSION=$(curl -sS https://jupyterhub.github.io/helm-chart/info.json | jq -er '.jupyterhub.${{ matrix.upgrade-from }}')
+
+          echo ""
+          echo "Installing already released jupyterhub version $UPGRADE_FROM_VERSION"
+          helm install jupyterhub jupyterhub/jupyterhub --values dev-config.yaml --version=$UPGRADE_FROM_VERSION
 
           echo ""
           echo "Installing Helm diff plugin while k8s resources are initializing"
           helm plugin install https://github.com/databus23/helm-diff
 
-      - name: Helm diff latest released chart with current
+      - name: "Helm diff ${{ matrix.upgrade-from }} chart with current chart"
         if: matrix.test == 'upgrade'
         run: |
           helm diff upgrade --install jupyterhub ./jupyterhub --values dev-config.yaml
 
-      - name: Await latest released chart
+      - name: "Await ${{ matrix.upgrade-from }} chart"
         if: matrix.test == 'upgrade'
         run: |
           . ./ci/common
@@ -146,7 +165,7 @@ jobs:
           await_autohttps_tls_cert_acquisition
           await_autohttps_tls_cert_save
 
-      - name: Upgrade latest released chart to current
+      - name: "Upgrade ${{ matrix.upgrade-from }} chart to current chart"
         run: |
           . ./ci/common
           helm upgrade --install jupyterhub ./jupyterhub --values dev-config.yaml

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -123,16 +123,30 @@ jobs:
           . ./ci/common
           install_and_run_chartpress_and_pebble
 
-      - name: Install latest JupyterHub version from Helm chart repo
+      - name: Install latest released chart
         if: matrix.test == 'upgrade'
         run: |
           . ./ci/common
           helm install jupyterhub jupyterhub/jupyterhub --values dev-config.yaml
+
+          echo ""
+          echo "Installing Helm diff plugin while k8s resources are initializing"
+          helm plugin install https://github.com/databus23/helm-diff
+
+      - name: Helm diff latest released chart with current
+        if: matrix.test == 'upgrade'
+        run: |
+          helm diff upgrade --install jupyterhub ./jupyterhub --values dev-config.yaml
+
+      - name: Await latest released chart
+        if: matrix.test == 'upgrade'
+        run: |
+          . ./ci/common
           await_jupyterhub
           await_autohttps_tls_cert_acquisition
           await_autohttps_tls_cert_save
 
-      - name: Install JupyterHub dev chart
+      - name: Upgrade latest released chart to current
         run: |
           . ./ci/common
           helm upgrade --install jupyterhub ./jupyterhub --values dev-config.yaml


### PR DESCRIPTION
Working on #1923 it became very relevant to inspect the changes in rendered helm templates. The [helm diff plugin](https://github.com/databus23/helm-diff) can provide a diff compared to an already installed helm chart, so in other words it is only sensible to add as part of the upgrade tests, diffing from the installed version and the version to be installed.

In this PR I add another upgrade tests, so instead of just going from the latest stable release, we try to upgrade also from the latest dev release. By upgrading from the latest dev release we can also smoothly inject a `helm diff` first that provides us with the specific details on what changed in the Helm template rendered output of this PR.

While this is a good start, I'm not sure about what happens if the PR isn't recently rebased. Will it then also show removal of added parts in the helm diff? I guess it comes down to how the checkout action works, does it checkout the exact state of the PR, or the state of the repo after PR would be merged?

