### PR TITLE
ci: use extracted github action for namespace report

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -178,8 +178,9 @@ jobs:
           # If you have problems with the tests add '--capture=no' to show stdout
           pytest --verbose --maxfail=2 --color=yes ./tests
 
-      - name: Full namespace report
+      # ref: https://github.com/jupyterhub/action-k8s-namespace-report
+      - name: Kubernetes namespace report
+        uses: jupyterhub/action-k8s-namespace-report@v1
         if: always()
-        run: |
-          . ./ci/common
-          full_namespace_report "deploy/hub" "deploy/proxy"
+        with:
+          important-workloads: deploy/hub deploy/proxy

--- a/ci/common
+++ b/ci/common
@@ -8,15 +8,7 @@ setup_helm () {
 
 await_pebble() {
     kubectl rollout status --watch --timeout 300s deployment/pebble \
-        && kubectl rollout status --watch --timeout 300s deployment/pebble-coredns \
-        || {
-        echo "Startup of Pebble failed!"
-        kubectl describe pod -l app.kubernetes.io/name=pebble
-        kubectl logs deploy/pebble --all-containers # --prefix
-        kubectl describe pod -l app.kubernetes.io/name=pebble-coredns
-        kubectl logs deploy/pebble-coredns --all-containers # --prefix
-        exit 1
-    }
+        && kubectl rollout status --watch --timeout 300s deployment/pebble-coredns
 }
 
 await_jupyterhub() {
@@ -24,20 +16,9 @@ await_jupyterhub() {
         && kubectl rollout status --watch --timeout 300s deployment/hub \
         && (
         if kubectl get deploy/autohttps &> /dev/null; then
-            kubectl rollout status --watch --timeout 300s deployment/autohttps || exit 1
+            kubectl rollout status --watch --timeout 300s deployment/autohttps
         fi
-    )\
-        || {
-        echo "Startup of JupyterHub failed!"
-        kubectl get all
-        kubectl describe pod -l component=hub
-        kubectl logs deploy/hub --all-containers # --prefix
-        kubectl describe pod -l component=proxy
-        kubectl logs deploy/proxy --all-containers # --prefix
-        kubectl describe pod -l component=autohttps || true
-        kubectl logs deploy/autohttps --all-containers || true # --prefix || true
-        exit 1
-    }
+    )
 }
 
 await_autohttps_tls_cert_acquisition() {
@@ -85,128 +66,6 @@ setup_kubeval () {
     echo "setup kubeval ${KUBEVAL_VERSION}"
     curl -sfL https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz | tar xz kubeval
     sudo mv kubeval /usr/local/bin/
-}
-
-full_namespace_report () {
-    # Purpose:
-    # - To chart agnostically print relevant information of the resources in a
-    #   namespace.
-    #
-    # Arguments:
-    # - Accepts a sequence of arguments such as "deploy/hub" "deploy/proxy". It
-    #   will do `kubectl logs --all-containers <arg>` on them.
-    #
-    # Relevant references:
-    # - ContainerStatus ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#containerstatus-v1-core
-
-    # printf formatting: a bold bold colored topic with a divider.
-    yellow=33
-    red=31
-    divider='--------------------------------------------------------------------------------'
-    # GitHub Workflows resets formatting after \n, so its reapplied.
-    export format="\n\033[${yellow};1m%s\n\033[${yellow};1m${divider}\033[0m\n"
-    export format_error="\n\033[${red};1m%s\n\033[${red};1m${divider}\033[0m\n"
-
-    printf "$format" "# Full namespace report"
-    printf "$format" "## Resource overview"
-    # list workloads (deployment,statefulset,daemonset,pod)
-    printf "$format" "### \$ kubectl get deploy,sts,ds,pod"
-    kubectl get deploy,sts,ds,pod
-    # list config (secret,configmap)
-    printf "$format" "### \$ kubectl get secret,cm"
-    kubectl get secret,cm
-    # list networking (service,ingress,networkpolicy)
-    printf "$format" "### \$ kubectl get svc,ing,netpol"
-    kubectl get svc,ing,netpol
-    # list rbac (serviceaccount,role,rolebinding)
-    printf "$format" "### \$ kubectl get sa,role,rolebinding"
-    kubectl get sa,role,rolebinding
-
-    # Check if any container of any pod has a non ready status
-    PODS_WITH_NON_READY_CONTAINER=$(
-        kubectl get pods -o json \
-            | jq -r '
-                .items[]
-                | select(
-                    any(.status.initContainerStatuses[]?; .ready == false)
-                    or
-                    any(.status.containerStatuses[]?; .ready == false)
-                )
-                | .metadata.name
-        '
-    )
-    if [ -n "$PODS_WITH_NON_READY_CONTAINER" ]; then
-        printf "$format_error" "## Pods with non-ready container(s) detected!"
-        echo "$PODS_WITH_NON_READY_CONTAINER" | xargs --max-args=1 echo -
-
-        for var in $PODS_WITH_NON_READY_CONTAINER; do
-            printf "$format_error" "### \$ kubectl describe pod/$var"
-            kubectl describe pod/$var
-            printf "$format_error" "### \$ kubectl logs --all-containers pod/$var"
-            kubectl logs --all-containers pod/$var || echo  # a newline on failure for consistency with non-failure
-        done
-
-    fi
-
-    # Check if any container of any pod has a restartCount > 0. Then, we inspect
-    # their logs with --previous. We also add --follow and --ignore-errors in
-    # order to ensure we get the information from all containers, and combined
-    # with --previous it will exit and not get stuck.
-    #
-    # ref: https://github.com/kubernetes/kubernetes/issues/97530
-    PODS_WITH_RESTARTED_CONTAINERS=$(
-        kubectl get pods -o json \
-            | jq -r '
-                .items[]
-                | select(
-                    any(.status.initContainerStatuses[]?; .restartCount > 0)
-                    or
-                    any(.status.containerStatuses[]?; .restartCount > 0)
-                )
-                | .metadata.name
-        '
-    )
-    if [ -n "$PODS_WITH_RESTARTED_CONTAINERS" ]; then
-        printf "$format_error" "## Pods with restarted containers detected!"
-        echo "$PODS_WITH_RESTARTED_CONTAINERS" | xargs --max-args=1 echo -
-
-        for var in $PODS_WITH_RESTARTED_CONTAINERS; do
-            printf "$format_error" "### \$ kubectl describe pod/$var"
-            kubectl describe pod/$var
-            printf "$format_error" "### \$ kubectl logs --previous --all-containers --follow --ignore-errors pod/$var"
-            kubectl logs --previous --all-containers --follow --ignore-errors pod/$var
-        done
-    fi
-
-    # if any pods that should be scheduled by the user-scheduler are pending ->
-    # show user-scheduler's logs
-    PENDING_USER_PODS=$(
-        kubectl get pods -l "component in (user-placeholder,singleuser-server)" -o json \
-            | jq -r '
-                .items[]
-                | select(.status.phase == "Pending")
-                | .metadata.name
-        '
-    )
-    if [ -n "$PENDING_USER_PODS" ]; then
-        printf "$format_error" "## Pending pods detected!"
-        echo "$PENDING_USER_PODS" | xargs --max-args=1 echo -
-
-        printf "$format_error" "### \$ kubectl logs --all-containers deploy/user-scheduler"
-        kubectl logs --all-containers deploy/user-scheduler || echo  # a newline on failure for consistency with non-failure
-    fi
-
-    # show container logs of all important workloads passed to the function,
-    # "deploy/hub" and "deploy/proxy" for example.
-    if [ "$#" -gt 0 ]; then
-        printf "$format" "## Important workload's logs"
-        echo "$@" | xargs --max-args=1 echo -
-
-        for var in "$@"; do
-            printf "$format" "### \$ kubectl logs --all-containers $var"
-            kubectl logs --all-containers $var || echo  # a newline on failure for consistency with non-failure
-        done
-    fi
 }
 
 install_and_run_chartpress_and_pebble () {


### PR DESCRIPTION
I extracted the namespace report logic to a dedicated action to be reused in binderhub/mybinder.org-deploy/daskhub etc. So, now I'm trying it out here in z2jh.

https://github.com/jupyterhub/action-k8s-namespace-report
