### PR TITLE
dep: bump kube-scheduler from 1.19.2 to 1.19.7

### DIFF
--- a/ci/common
+++ b/ci/common
@@ -18,6 +18,11 @@ await_jupyterhub() {
         if kubectl get deploy/autohttps &> /dev/null; then
             kubectl rollout status --watch --timeout 300s deployment/autohttps
         fi
+    ) \
+        && (
+        if kubectl get deploy/user-scheduler &> /dev/null; then
+            kubectl rollout status --watch --timeout 300s deployment/user-scheduler
+        fi
     )
 }
 

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -79,9 +79,7 @@ prePuller:
 scheduling:
   userScheduler:
     enabled: true
-    # replicas lowered to make it easier to get the relevant logs if a pod get
-    # stuck in pending mode
-    replicas: 1
+    replicas: 2
     logLevel: 10
 
 debug:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -416,8 +416,11 @@ scheduling:
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
+      # IMPORTANT: Bumping the minor version of this binary should go hand in
+      #            hand with an inspection of the user-scheduelrs RBAC resources
+      #            that we have forked.
       name: k8s.gcr.io/kube-scheduler
-      tag: v1.19.2
+      tag: v1.19.7
       pullPolicy: ''
       pullSecrets: []
     nodeSelector: {}


### PR DESCRIPTION
Just a maintenance bump, keeping up to date with kube-scheduler binary version used in the user-scheduler deployment.

The lint failure come from helm being upgraded and warns about deprecated API matters which make `helm lint --strict` fail.