### PR TITLE
k8s: update Ingress / PriorityClass apiVersions

### DIFF
--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
-apiVersion: networking.k8s.io/v1beta1
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -22,9 +22,18 @@ spec:
       http:
         paths:
           - path: {{ $.Values.hub.baseUrl }}{{ $.Values.ingress.pathSuffix }}
+            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: proxy-public
+                port:
+                  name: http
+            {{- else }}
             backend:
               serviceName: proxy-public
               servicePort: 80
+            {{- end }}
     {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/jupyterhub/templates/scheduling/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/priorityclass.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.scheduling.podPriority.enabled }}
-apiVersion: scheduling.k8s.io/v1beta1
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ .Release.Name }}-default-priority

--- a/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.scheduling.podPriority.enabled }}
 {{- if .Values.scheduling.userPlaceholder.enabled -}}
-apiVersion: scheduling.k8s.io/v1beta1
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ .Release.Name }}-user-placeholder-priority


### PR DESCRIPTION
- k8s: bump Ingress apiVersion to v1 if capability exist (k8s 1.19+)
- k8s: bump PriorityClass apiVersion to v1 (k8s 1.14+ req.)
