### PR TITLE
ci: replace kubeval with helm template --validate

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -123,14 +123,32 @@ jobs:
         with:
           python-version: '3.8'
 
+      # Install a local ACME server to fill the role of Let's Encrypt (LE). We
+      # do this as the HTTP challenge sent out by an ACME server must be able to
+      # reach the ACME client in our autohttps pod.
+      - name: Install local ACME server
+        run: |
+          helm install pebble --repo https://jupyterhub.github.io/helm-chart/ pebble --values dev-config-pebble.yaml
+
+      # Build our images if needed and update values.yaml with the tags
       - name: Install and run chartpress
         run: |
-          . ./ci/common
-          install_and_run_chartpress_and_pebble
+          pip3 install --no-cache-dir -r dev-requirements.txt
+          chartpress
 
+      # Validate rendered helm templates against the k8s api-server with the
+      # dedicated lint-and-validate-values.yaml config.
       - name: "Helm template --validate (with lint and validate config)"
         run: |
           helm template --validate jupyterhub ./jupyterhub --values tools/templates/lint-and-validate-values.yaml
+
+      # It is only needed at this point forward as this is when we install
+      # jupyterhub and the autohttps pod is about to start, so for CI
+      # performance we delayed this until now and did other things in between.
+      - name: Await local ACME server
+        run: |
+          . ./ci/common
+          await_pebble
 
       - name: "Install ${{ matrix.upgrade-from }} chart"
         if: matrix.test == 'upgrade'
@@ -140,7 +158,7 @@ jobs:
 
           echo ""
           echo "Installing already released jupyterhub version $UPGRADE_FROM_VERSION"
-          helm install jupyterhub jupyterhub/jupyterhub --values dev-config.yaml --version=$UPGRADE_FROM_VERSION
+          helm install jupyterhub --repo https://jupyterhub.github.io/helm-chart/ jupyterhub --values dev-config.yaml --version=$UPGRADE_FROM_VERSION
 
           echo ""
           echo "Installing Helm diff plugin while k8s resources are initializing"

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -112,7 +112,6 @@ jobs:
       - uses: jupyterhub/action-k3s-helm@v1
         with:
           k3s-channel: ${{ matrix.k3s-channel }}
-          helm-version: v3.4.2
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: true

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -41,30 +41,18 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |
           . ci/common
           setup_helm
-          KUBEVAL_VERSION=0.15.0 setup_kubeval
           pip install chartpress yamllint
 
       - uses: pre-commit/action@v2.0.0
 
       - name: Lint and validate
-        # NOTE: Kubernetes resource validation can only be done against
-        #       Kubernetes versions with schemas available in:
-        #       https://github.com/instrumenta/kubernetes-json-schema
-        #
-        # NOTE: The "helm template" command will evaluate
-        #       .Capabilities.APIVersion.Has in templates based on a Kubernetes
-        #       version associated with the helm binary's version. Since we
-        #       render the templates with a specific helm version, we end up
-        #       rendering templates using a mocked k8s version unrelated to the
-        #       Kubernetes version we want to validate against. This issue has
-        #       made us not validate against versions lower than 1.14.
-        run: tools/templates/lint-and-validate.py --kubernetes-versions 1.14.0,1.18.0
+        run: tools/templates/lint-and-validate.py
 
 
   test:
@@ -140,6 +128,10 @@ jobs:
           . ./ci/common
           install_and_run_chartpress_and_pebble
 
+      - name: "Helm template --validate (with lint and validate config)"
+        run: |
+          helm template --validate jupyterhub ./jupyterhub --values tools/templates/lint-and-validate-values.yaml
+
       - name: "Install ${{ matrix.upgrade-from }} chart"
         if: matrix.test == 'upgrade'
         run: |
@@ -167,7 +159,7 @@ jobs:
           await_autohttps_tls_cert_acquisition
           await_autohttps_tls_cert_save
 
-      - name: "Upgrade ${{ matrix.upgrade-from }} chart to current chart"
+      - name: "Install or upgrade to current chart"
         run: |
           . ./ci/common
           helm upgrade --install jupyterhub ./jupyterhub --values dev-config.yaml

--- a/ci/common
+++ b/ci/common
@@ -67,12 +67,6 @@ await_autohttps_tls_cert_save() {
     fi
 }
 
-setup_kubeval () {
-    echo "setup kubeval ${KUBEVAL_VERSION}"
-    curl -sfL https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz | tar xz kubeval
-    sudo mv kubeval /usr/local/bin/
-}
-
 install_and_run_chartpress_and_pebble () {
     helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
     helm repo update

--- a/ci/common
+++ b/ci/common
@@ -66,14 +66,3 @@ await_autohttps_tls_cert_save() {
         exit 1
     fi
 }
-
-install_and_run_chartpress_and_pebble () {
-    helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
-    helm repo update
-    # Install a local ACME server
-    helm install pebble jupyterhub/pebble --values dev-config-pebble.yaml
-    # Build our images if needed and update values.yaml with the tags
-    pip3 install --no-cache-dir -r dev-requirements.txt
-    chartpress
-    await_pebble  # jupyterhub's autohttps communicates with it as the ACME server
-}

--- a/doc/source/jupyterhub/customizing/extending-jupyterhub.md
+++ b/doc/source/jupyterhub/customizing/extending-jupyterhub.md
@@ -20,7 +20,7 @@ The general method to modify your Kubernetes deployment is to:
    NAMESPACE=jhub
    
    helm upgrade --cleanup-on-fail \
-             $RELEASE jupyterhub/jupyterhub \
+     $RELEASE jupyterhub/jupyterhub \
      --namespace $NAMESPACE \
      --version=0.10.6 \
      --values config.yaml

--- a/tools/templates/lint-and-validate.py
+++ b/tools/templates/lint-and-validate.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """
 Lints and validates the chart's template files and their rendered output without
-any cluster interaction. For this script to function, you must install yamllint
-and kubeval.
+any cluster interaction. For this script to function, you must install yamllint.
 
 USAGE:
 
@@ -13,13 +12,6 @@ DEPENDENCIES:
 yamllint: https://github.com/adrienverge/yamllint
 
   pip install yamllint
-
-kubeval: https://github.com/instrumenta/kubeval
-
-  LATEST=$(curl --silent "https://api.github.com/repos/instrumenta/kubeval/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-  wget https://github.com/instrumenta/kubeval/releases/download/$LATEST/kubeval-linux-amd64.tar.gz
-  tar xf kubeval-linux-amd64.tar.gz
-  sudo mv kubeval /usr/local/bin
 """
 
 import os
@@ -47,8 +39,8 @@ def check_call(cmd, **kwargs):
         sys.exit(e.returncode)
 
 
-def lint(yamllint_config, values, kubernetes_versions, output_dir, debug):
-    """Calls `helm lint`, `helm template`, `yamllint` and `kubeval`."""
+def lint(yamllint_config, values, output_dir, debug):
+    """Calls `helm lint`, `helm template`, and `yamllint`."""
 
     print("### Clearing output directory")
     check_call(
@@ -67,7 +59,7 @@ def lint(yamllint_config, values, kubernetes_versions, output_dir, debug):
     )
 
     print("### Linting started")
-    print("### 1/4 - helm lint: lint helm templates")
+    print("### 1/3 - helm lint: lint helm templates")
     helm_lint_cmd = [
         "helm",
         "lint",
@@ -80,7 +72,7 @@ def lint(yamllint_config, values, kubernetes_versions, output_dir, debug):
         helm_lint_cmd.append("--debug")
     check_call(helm_lint_cmd)
 
-    print("### 2/4 - helm template: generate kubernetes resources")
+    print("### 2/3 - helm template: generate kubernetes resources")
     helm_template_cmd = [
         "helm",
         "template",
@@ -94,22 +86,8 @@ def lint(yamllint_config, values, kubernetes_versions, output_dir, debug):
         helm_template_cmd.append("--debug")
     check_call(helm_template_cmd)
 
-    print("### 3/4 - yamllint: yaml lint generated kubernetes resources")
+    print("### 3/3 - yamllint: yaml lint generated kubernetes resources")
     check_call(["yamllint", "-c", yamllint_config, output_dir])
-
-    print("### 4/4 - kubeval: validate generated kubernetes resources")
-    for kubernetes_version in kubernetes_versions.split(","):
-        print("#### kubernetes_version ", kubernetes_version)
-        for filename in glob.iglob(output_dir + "/**/*.yaml", recursive=True):
-            check_call(
-                [
-                    "kubeval",
-                    filename,
-                    "--kubernetes-version",
-                    kubernetes_version,
-                    "--strict",
-                ]
-            )
 
     print()
     print(
@@ -130,11 +108,6 @@ if __name__ == "__main__":
         help="Specify Helm values in a YAML file (can specify multiple)",
     )
     argparser.add_argument(
-        "--kubernetes-versions",
-        default="1.15.0",
-        help='List of Kubernetes versions to validate against separated by ","',
-    )
-    argparser.add_argument(
         "--output-dir",
         default="rendered-templates",
         help="Output directory for the rendered templates. Warning: content in this will be wiped.",
@@ -150,7 +123,6 @@ if __name__ == "__main__":
     lint(
         args.yamllint_config,
         args.values,
-        args.kubernetes_versions,
         args.output_dir,
         args.debug,
     )


### PR DESCRIPTION
Without `helm template --validate`, I could not properly test #1983. And, with it added, it is redundant to have the kubeval steps in our CI system. For local development, `helm template --validate` can be used as well even though it now requires a k8s cluster which it didn't before, but I think it's too much maintenance to retain it just for that.

---

kubeval and the json schemas is a project with too little maintainers,
so now we can't validate against k8s 1.19 or 1.20. Thankfully, we have
helm template --validate now that allow us to use a k8s api-server to
validate that our rendered templates are valid k8s resources.

By running a helm template --validate step with the
lint-and-validate-values.yaml we can ensure that they are valid.

This transition also solves a problem we have had with how `helm template` rendered templates with conditionals such as...

```yaml
{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
apiVersion: networking.k8s.io/v1
{{- else }}
apiVersion: networking.k8s.io/v1beta1
{{- end }}
```

---

I squeezed in some smaller ci changes in this PR to save time.