### PR TITLE
ci: accept helm lint --strict failure, but ensure GitHub UI warns

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -54,6 +54,10 @@ jobs:
       - name: Lint and validate
         run: tools/templates/lint-and-validate.py
 
+      - name: Lint and validate (--strict, accept failure)
+        run: tools/templates/lint-and-validate.py --strict
+        continue-on-error: true
+
 
   test:
     runs-on: ubuntu-20.04

--- a/tools/templates/lint-and-validate.py
+++ b/tools/templates/lint-and-validate.py
@@ -39,7 +39,7 @@ def check_call(cmd, **kwargs):
         sys.exit(e.returncode)
 
 
-def lint(yamllint_config, values, output_dir, debug):
+def lint(yamllint_config, values, output_dir, strict, debug):
     """Calls `helm lint`, `helm template`, and `yamllint`."""
 
     print("### Clearing output directory")
@@ -63,11 +63,12 @@ def lint(yamllint_config, values, output_dir, debug):
     helm_lint_cmd = [
         "helm",
         "lint",
-        "--strict",
         "../../jupyterhub",
         "--values",
         values,
     ]
+    if strict:
+        helm_lint_cmd.append("--strict")
     if debug:
         helm_lint_cmd.append("--debug")
     check_call(helm_lint_cmd)
@@ -103,6 +104,11 @@ if __name__ == "__main__":
         help="Run helm lint and helm template with the --debug flag",
     )
     argparser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Run helm lint with the --strict flag",
+    )
+    argparser.add_argument(
         "--values",
         default="lint-and-validate-values.yaml",
         help="Specify Helm values in a YAML file (can specify multiple)",
@@ -124,5 +130,6 @@ if __name__ == "__main__":
         args.yamllint_config,
         args.values,
         args.output_dir,
+        args.strict,
         args.debug,
     )


### PR DESCRIPTION
Helm lint emits warnings about deprecated versions, but since we have some logic like below, we will end up failing non no matter what until we remove support for k8s 1.18 etc at this point. Due to that, I went and allowed that check to fail but made sure it will emit a warning for us still (A GitHub Workflow run annotation).

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/8b315ce66fd3faa1e8b707299c202d0d15449546/jupyterhub/templates/ingress.yaml#L2-L6