### PR TITLE
fix: fix of ingress regression and improved testing

### DIFF
--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
       http:
         paths:
           - path: {{ $.Values.hub.baseUrl }}{{ $.Values.ingress.pathSuffix }}
-            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: Prefix
             backend:
               service:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -406,8 +406,14 @@ ingress:
   enabled: true
   annotations:
     mock: mock
-  hosts: []
-  tls: []
+  hosts:
+    - mocked1.domain.name
+    - mocked2.domain.name
+  tls:
+    - secretName: jupyterhub-tls
+      hosts:
+        - mocked1.domain.name
+        - mocked2.domain.name
 
 
 cull:
@@ -416,7 +422,7 @@ cull:
   timeout: 3600
   every: 600
   concurrency: 10
-  maxAge: 3600*8
+  maxAge: 28800
 
 
 debug:


### PR DESCRIPTION
Our linting example didn't cover the ingress Helm template properly and a basic syntax error sneaked past in #1983.

I'll release 0.11.1 with this bugfix.