### PR TITLE
Require Helm 3 to allow for enhancements

### DIFF
--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -1,16 +1,14 @@
-# Chart.yaml v1 reference: https://v2.helm.sh/docs/developing_charts/#the-chart-yaml-file
 # Chart.yaml v2 reference: https://helm.sh/docs/topics/charts/#the-chartyaml-file
-apiVersion: v1
+apiVersion: v2
 name: jupyterhub
 version: 0.0.1-set.by.chartpress
 appVersion: 1.3.0
 description: Multi-user Jupyter installation
+keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org
-sources:
-  - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
+sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
 icon: https://jupyter.org/assets/hublogo.svg
 kubeVersion: ">=1.14.0-0"
-tillerVersion: ">=2.16.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team


### PR DESCRIPTION
Helm 2 reached end of life in November 2020, so for future releases of
this Helm chart, just like many other Helm charts have opted to do, we
drop support for Helm 2 and allow ourselves to depend on Helm 3. By
updating this Chart.yaml to apiVersion 2 we will require Helm 3.

By relying on Helm 3.1+, we can solve some long standing issues, for
example the need to manually specify proxy.secretToken.