### PR TITLE
refactor: systematically prefer use of with in templates

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -19,15 +19,15 @@ spec:
         hub.jupyter.org/network-access-proxy-api: "true"
         hub.jupyter.org/network-access-proxy-http: "true"
         hub.jupyter.org/network-access-singleuser: "true"
-        {{- if .Values.hub.labels }}
-        {{- .Values.hub.labels | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.hub.labels }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
       annotations:
         # This lets us autorestart when the secret changes!
         checksum/config-map: {{ include (print .Template.BasePath "/hub/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/hub/secret.yaml") . | sha256sum }}
-        {{- if .Values.hub.annotations }}
-        {{- .Values.hub.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.hub.annotations }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.scheduling.podPriority.enabled }}
@@ -43,8 +43,8 @@ spec:
         - name: secret
           secret:
             secretName: {{ include "jupyterhub.hub-secret.fullname" . }}
-        {{- if .Values.hub.extraVolumes }}
-        {{- .Values.hub.extraVolumes | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.hub.extraVolumes }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
         {{- if eq .Values.hub.db.type "sqlite-pvc" }}
         - name: pvc
@@ -59,13 +59,13 @@ spec:
       {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.hub.image) }}
       imagePullSecrets: {{ . }}
       {{- end }}
-      {{- if .Values.hub.initContainers }}
+      {{- with .Values.hub.initContainers }}
       initContainers:
-        {{- .Values.hub.initContainers | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       containers:
-        {{- if .Values.hub.extraContainers }}
-        {{- .Values.hub.extraContainers | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.hub.extraContainers }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
         - name: hub
           image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
@@ -122,14 +122,14 @@ spec:
               name: config
             - mountPath: /etc/jupyterhub/secret/
               name: secret
-            {{- if .Values.hub.extraVolumeMounts }}
-            {{- .Values.hub.extraVolumeMounts | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- with .Values.hub.extraVolumeMounts }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
             {{- end }}
             {{- if eq .Values.hub.db.type "sqlite-pvc" }}
             - mountPath: /srv/jupyterhub
               name: pvc
-              {{- if .Values.hub.db.pvc.subPath }}
-              subPath: {{ .Values.hub.db.pvc.subPath | quote }}
+              {{- with .Values.hub.db.pvc.subPath }}
+              subPath: {{ . | quote }}
               {{- end }}
             {{- end }}
           resources:

--- a/jupyterhub/templates/hub/pvc.yaml
+++ b/jupyterhub/templates/hub/pvc.yaml
@@ -5,14 +5,14 @@ metadata:
   name: {{ include "jupyterhub.hub-pvc.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
-  {{- if .Values.hub.db.pvc.annotations }}
+  {{- with .Values.hub.db.pvc.annotations }}
   annotations:
-    {{- .Values.hub.db.pvc.annotations | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.hub.db.pvc.selector }}
+  {{- with .Values.hub.db.pvc.selector }}
   selector:
-    {{- .Values.hub.db.pvc.selector | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
   {{- end }}
   {{- if typeIs "string" .Values.hub.db.pvc.storageClassName }}
   storageClassName: {{ .Values.hub.db.pvc.storageClassName | quote }}

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -9,11 +9,9 @@ metadata:
   name: {{ include "jupyterhub.ingress.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
-  {{- if .Values.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
   rules:
@@ -35,8 +33,8 @@ spec:
               servicePort: 80
             {{- end }}
     {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- with .Values.ingress.tls }}
   tls:
-    {{- .Values.ingress.tls | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -17,8 +17,8 @@ spec:
       labels:
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-http: "true"
-        {{- if .Values.proxy.traefik.labels }}
-        {{- .Values.proxy.traefik.labels | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.proxy.traefik.labels }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
       annotations:
         # Only force a restart through a change to this checksum when the static

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -20,15 +20,15 @@ spec:
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
         hub.jupyter.org/network-access-singleuser: "true"
-        {{- if .Values.proxy.labels }}
-        {{- .Values.proxy.labels | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.proxy.labels }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
       annotations:
         # This lets us autorestart when the secret changes!
         checksum/hub-secret: {{ include (print $.Template.BasePath "/hub/secret.yaml") . | sha256sum }}
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum }}
-        {{- if .Values.proxy.annotations }}
-        {{- .Values.proxy.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.proxy.annotations }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 60

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -26,12 +26,12 @@ metadata:
   labels:
     {{- $_ := merge (dict "componentSuffix" "-public") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
-    {{- if .Values.proxy.service.labels }}
-    {{- .Values.proxy.service.labels | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- with .Values.proxy.service.labels }}
+    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- if .Values.proxy.service.annotations }}
+  {{- with .Values.proxy.service.annotations }}
   annotations:
-    {{- .Values.proxy.service.annotations | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
+++ b/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
@@ -11,8 +11,8 @@
   operator: Equal
   value: user
   effect: NoSchedule
-{{- if .Values.singleuser.extraTolerations }}
-{{- .Values.singleuser.extraTolerations | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- with .Values.singleuser.extraTolerations }}
+{{- . | toYaml | trimSuffix "\n" | nindent 0 }}
 {{- end }}
 {{- end }}
 
@@ -25,8 +25,8 @@
     operator: In
     values: [user]
 {{- end }}
-{{- if .Values.singleuser.extraNodeAffinity.required }}
-{{- .Values.singleuser.extraNodeAffinity.required | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- with .Values.singleuser.extraNodeAffinity.required }}
+{{- . | toYaml | trimSuffix "\n" | nindent 0 }}
 {{- end }}
 {{- end }}
 
@@ -39,32 +39,32 @@
         operator: In
         values: [user]
 {{- end }}
-{{- if .Values.singleuser.extraNodeAffinity.preferred }}
-{{- .Values.singleuser.extraNodeAffinity.preferred | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- with .Values.singleuser.extraNodeAffinity.preferred }}
+{{- . | toYaml | trimSuffix "\n" | nindent 0 }}
 {{- end }}
 {{- end }}
 
 {{- define "jupyterhub.userPodAffinityRequired" -}}
-{{- if .Values.singleuser.extraPodAffinity.required -}}
-{{ .Values.singleuser.extraPodAffinity.required | toYaml | trimSuffix "\n" }}
+{{- with .Values.singleuser.extraPodAffinity.required -}}
+{{ . | toYaml | trimSuffix "\n" }}
 {{- end }}
 {{- end }}
 
 {{- define "jupyterhub.userPodAffinityPreferred" -}}
-{{- if .Values.singleuser.extraPodAffinity.preferred -}}
-{{ .Values.singleuser.extraPodAffinity.preferred | toYaml | trimSuffix "\n" }}
+{{- with .Values.singleuser.extraPodAffinity.preferred -}}
+{{ . | toYaml | trimSuffix "\n" }}
 {{- end }}
 {{- end }}
 
 {{- define "jupyterhub.userPodAntiAffinityRequired" -}}
-{{- if .Values.singleuser.extraPodAntiAffinity.required -}}
-{{ .Values.singleuser.extraPodAntiAffinity.required | toYaml | trimSuffix "\n" }}
+{{- with .Values.singleuser.extraPodAntiAffinity.required -}}
+{{ . | toYaml | trimSuffix "\n" }}
 {{- end }}
 {{- end }}
 
 {{- define "jupyterhub.userPodAntiAffinityPreferred" -}}
-{{- if .Values.singleuser.extraPodAntiAffinity.preferred -}}
-{{ .Values.singleuser.extraPodAntiAffinity.preferred | toYaml | trimSuffix "\n" }}
+{{- with .Values.singleuser.extraPodAntiAffinity.preferred -}}
+{{ . | toYaml | trimSuffix "\n" }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
This PR transforms statements like this using `if`...

```yaml
        {{- if .Values.hub.annotations }}
        {{- .Values.hub.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
        {{- end }}
```

Into statements like this using `with`...

```yaml
        {{- with .Values.hub.annotations }}
        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
        {{- end }}
```

This is a practice that has become popular and common practice among Helm charts. Currently our chart use a mix of these, but not after this PR where we only use the `with` variation.

### Any actual changes?

No, As can be seen in [the rendered helm template diff](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2003/checks?check_run_id=1737818655), this didn't change anything. The test failure is intermittent k8s 1.20 stuff discussed in #1962.