### PR TITLE
ci: accept k8s 1.20 failures until 1.20.3 is out

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -67,6 +67,10 @@ jobs:
         include:
           - k3s-channel: v1.20
             test: install
+            # FIXME: stop accepting failure when 1.20.3 is available for k3s and
+            #        this issue is resolved:
+            #        https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1962
+            accept-failure: true
           - k3s-channel: v1.19
             test: install
           - k3s-channel: v1.18
@@ -205,6 +209,7 @@ jobs:
           await_autohttps_tls_cert_acquisition
 
       - name: Run tests
+        continue-on-error: ${{ matrix.accept-failure == true }}
         run: |
           . ./ci/common
           # If you have problems with the tests add '--capture=no' to show stdout


### PR DESCRIPTION
Workaround the intermittent failures caused by a k8s regression to be fixed in k8s 1.20.3, see #1962 for details about this regression.

While it is allowed to fail, it will emit an "annotation", like a warning, to the GitHub workflow user interface looking like this.

![image](https://user-images.githubusercontent.com/3837114/105346300-b22f1300-5be5-11eb-8169-c8460906bd27.png)
