### PR TITLE
Require k8s 1.17+ to reduce complexity

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -77,8 +77,6 @@ jobs:
             test: install
           - k3s-channel: v1.17
             test: install
-          - k3s-channel: v1.16
-            test: install
 
           # We run two upgrade tests where we first install an already released
           # Helm chart version and then upgrades to the version we are now

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org
 sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
 icon: https://jupyter.org/assets/hublogo.svg
-kubeVersion: ">=1.14.0-0"
+kubeVersion: ">=1.17.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team


### PR DESCRIPTION
By relying on k8s 1.17+, we can cut away a hard to maintain
user-scheduler implementation for k8s 1.16 and earlier that is different
from the implementation we use for k8s 1.17+. See #1995.

## Action points
- [x] Await merge criteria.
  @yuvipanda suggested holding off until GKE's stable release channel defaults to k8s 1.17, which I think will be in a week or two.
  > 1.16 is still the 'stable' version listed on GKE - https://cloud.google.com/kubernetes-engine/docs/release-notes. I think we shouldn't drop support for it until 1.17 is the stable version.