### PR TITLE
Allow extraFiles to be injected to hub / singleuser pods and automatically load config in /usr/local/etc/jupyterhub_config.d

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -51,32 +51,32 @@ hub:
   extraFiles:
     my_config:
       name: my_config.py
-      mountPath: /etc/jupyterhub.d
+      mountDir: /etc/jupyterhub.d
       stringData: |
         with open("/tmp/created-by-extra-files-config.txt", "w") as f:
             f.write("hello world!")
     binaryData.txt: &binaryData
-      mountPath: /tmp/
+      mountDir: /tmp/
       mode: 0666
       binaryData: |
         aGVsbG8gd
         29ybGQhCg==
     binaryData-explicit-name.txt: &binaryData2
       name: binaryData.txt
-      mountPath: /tmp/dir1
+      mountDir: /tmp/dir1
       mode: 0666
       binaryData: aGVsbG8gd29ybGQhCg==
     stringData.txt: &stringData
-      mountPath: /tmp
+      mountDir: /tmp
       mode: 0666
       stringData: hello world!
     stringData-explicit-name.txt: &stringData2
       name: stringData.txt
-      mountPath: /tmp/dir1/
+      mountDir: /tmp/dir1/
       mode: 0666
       stringData: hello world!
     data.yaml: &data
-      mountPath: /etc/test
+      mountDir: /etc/test
       mode: 0444
       data:
         config:

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -48,8 +48,46 @@ hub:
     requests:
       memory: 0
       cpu: 0
+  extraFiles:
+    binaryData.txt: &binaryData
+      mountPath: /tmp/
+      mode: 0666
+      binaryData: aGVsbG8gd29ybGQhCg==
+    binaryData2.txt: &binaryData2
+      mountPath: /tmp/dir1
+      mode: 0666
+      binaryData: aGVsbG8gd29ybGQhCg==
+    stringData.txt: &stringData
+      mountPath: /tmp
+      mode: 0666
+      stringData: hello world!
+    stringData2.txt: &stringData2
+      mountPath: /tmp/dir1/
+      mode: 0666
+      stringData: hello world!
+    data.yaml: &data
+      mountPath: /etc/test
+      mode: 0444
+      data:
+        config:
+          map:
+            number: 123
+            string: "hi"
+          list: [1, 2]
+    data.yml: *data
+    data.json: *data
+    data.toml: *data
 
 singleuser:
+  extraFiles:
+    binaryData.txt: *binaryData
+    binaryData2.txt: *binaryData2
+    stringData.txt: *stringData
+    stringData2.txt: *stringData2
+    data.yaml: *data
+    data.yml: *data
+    data.json: *data
+    data.toml: *data
   storage:
     type: none
   memory:

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -53,7 +53,8 @@ hub:
       mountPath: /tmp/
       mode: 0666
       binaryData: aGVsbG8gd29ybGQhCg==
-    binaryData2.txt: &binaryData2
+    binaryData-explicit-name.txt: &binaryData2
+      name: binaryData.txt
       mountPath: /tmp/dir1
       mode: 0666
       binaryData: aGVsbG8gd29ybGQhCg==
@@ -61,7 +62,8 @@ hub:
       mountPath: /tmp
       mode: 0666
       stringData: hello world!
-    stringData2.txt: &stringData2
+    stringData-explicit-name.txt: &stringData2
+      name: stringData.txt
       mountPath: /tmp/dir1/
       mode: 0666
       stringData: hello world!
@@ -81,9 +83,9 @@ hub:
 singleuser:
   extraFiles:
     binaryData.txt: *binaryData
-    binaryData2.txt: *binaryData2
+    binaryData-explicit-name.txt: *binaryData2
     stringData.txt: *stringData
-    stringData2.txt: *stringData2
+    stringData-explicit-name.txt: *stringData2
     data.yaml: *data
     data.yml: *data
     data.json: *data

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -49,6 +49,12 @@ hub:
       memory: 0
       cpu: 0
   extraFiles:
+    my_config:
+      name: my_config.py
+      mountPath: /etc/jupyterhub.d
+      stringData: |
+        with open("/tmp/created-by-extra-files-config.txt", "w") as f:
+            f.write("hello world!")
     binaryData.txt: &binaryData
       mountPath: /tmp/
       mode: 0666

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -50,7 +50,7 @@ hub:
       cpu: 0
   extraFiles:
     my_config:
-      mountPath: /etc/jupyterhub.d/my_config.py
+      mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/my_config.py
       stringData: |
         with open("/tmp/created-by-extra-files-config.txt", "w") as f:
             f.write("hello world!")

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -50,33 +50,30 @@ hub:
       cpu: 0
   extraFiles:
     my_config:
-      name: my_config.py
-      mountDir: /etc/jupyterhub.d
+      mountPath: /etc/jupyterhub.d/my_config.py
       stringData: |
         with open("/tmp/created-by-extra-files-config.txt", "w") as f:
             f.write("hello world!")
-    binaryData.txt: &binaryData
-      mountDir: /tmp/
+    binaryData1: &binaryData1
+      mountPath: /tmp/binaryData.txt
       mode: 0666
       binaryData: |
         aGVsbG8gd
         29ybGQhCg==
-    binaryData-explicit-name.txt: &binaryData2
-      name: binaryData.txt
-      mountDir: /tmp/dir1
+    binaryData2: &binaryData2
+      mountPath: /tmp/dir1/binaryData.txt
       mode: 0666
       binaryData: aGVsbG8gd29ybGQhCg==
-    stringData.txt: &stringData
-      mountDir: /tmp
+    stringData1: &stringData1
+      mountPath: /tmp/stringData.txt
       mode: 0666
       stringData: hello world!
-    stringData-explicit-name.txt: &stringData2
-      name: stringData.txt
-      mountDir: /tmp/dir1/
+    stringData2: &stringData2
+      mountPath: /tmp/dir1/stringData.txt
       mode: 0666
       stringData: hello world!
-    data.yaml: &data
-      mountDir: /etc/test
+    data-yaml: &data-yaml
+      mountPath: /etc/test/data.yaml
       mode: 0444
       data:
         config:
@@ -84,20 +81,26 @@ hub:
             number: 123
             string: "hi"
           list: [1, 2]
-    data.yml: *data
-    data.json: *data
-    data.toml: *data
+    data-yml: &data-yml
+      <<: *data-yaml
+      mountPath: /etc/test/data.yml
+    data-json: &data-json
+      <<: *data-yaml
+      mountPath: /etc/test/data.json
+    data-toml: &data-toml
+      <<: *data-yaml
+      mountPath: /etc/test/data.toml
 
 singleuser:
   extraFiles:
-    binaryData.txt: *binaryData
-    binaryData-explicit-name.txt: *binaryData2
-    stringData.txt: *stringData
-    stringData-explicit-name.txt: *stringData2
-    data.yaml: *data
-    data.yml: *data
-    data.json: *data
-    data.toml: *data
+    binaryData1: *binaryData1
+    binaryData2: *binaryData2
+    stringData1: *stringData1
+    stringData2: *stringData2
+    data-yaml: *data-yaml
+    data-yml: *data-yml
+    data-json: *data-json
+    data-toml: *data-toml
   storage:
     type: none
   memory:

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -52,7 +52,9 @@ hub:
     binaryData.txt: &binaryData
       mountPath: /tmp/
       mode: 0666
-      binaryData: aGVsbG8gd29ybGQhCg==
+      binaryData: |
+        aGVsbG8gd
+        29ybGQhCg==
     binaryData-explicit-name.txt: &binaryData2
       name: binaryData.txt
       mountPath: /tmp/dir1

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -64,4 +64,4 @@ ARG PIP_TOOLS=
 RUN test -z "$PIP_TOOLS" || pip install --no-cache pip-tools==$PIP_TOOLS
 
 USER ${NB_USER}
-CMD ["jupyterhub", "--config", "/etc/jupyterhub/jupyterhub_config.py"]
+CMD ["jupyterhub", "--config", "/usr/local/etc/jupyterhub/jupyterhub_config.py"]

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -309,7 +309,7 @@ if extra_files:
         file_name = file_details.get("name", file_key)
         volume_mounts.append(
             {
-                "mountPath": file_details["mountPath"].rstrip("/") + "/" + file_name,
+                "mountPath": file_details["mountDir"].rstrip("/") + "/" + file_name,
                 "subPath": file_key,
                 "name": "files",
             }

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -411,7 +411,7 @@ if get_config("debug.enabled", False):
 # load /etc/jupyterhub.d config files
 config_dir = "/etc/jupyterhub.d"
 if os.path.isdir(config_dir):
-    for file_name in os.listdir(config_dir):
+    for file_name in sorted(os.listdir(config_dir)):
         print(f"Loading {config_dir} config: {file_name}")
         with open(f"{config_dir}/{file_name}") as f:
             file_content = f.read()

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -408,6 +408,15 @@ if get_config("debug.enabled", False):
     c.JupyterHub.log_level = "DEBUG"
     c.Spawner.debug = True
 
+# load /etc/jupyterhub.d config files
+config_dir = "/etc/jupyterhub.d"
+if os.path.isdir(config_dir):
+    for file_name in os.listdir(config_dir):
+        print(f"Loading {config_dir} config: {file_name}")
+        with open(f"{config_dir}/{file_name}") as f:
+            file_content = f.read()
+        # compiling makes debugging easier: https://stackoverflow.com/a/437857
+        exec(compile(source=file_content, filename=file_name, mode="exec"))
 
 # load potentially seeded secrets
 c.JupyterHub.proxy_auth_token = get_secret_value("JupyterHub.proxy_auth_token")

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -407,8 +407,8 @@ if get_config("debug.enabled", False):
     c.JupyterHub.log_level = "DEBUG"
     c.Spawner.debug = True
 
-# load /etc/jupyterhub.d config files
-config_dir = "/etc/jupyterhub.d"
+# load /usr/local/etc/jupyterhub/jupyterhub_config.d config files
+config_dir = "/usr/local/etc/jupyterhub/jupyterhub_config.d"
 if os.path.isdir(config_dir):
     for file_name in sorted(os.listdir(config_dir)):
         print(f"Loading {config_dir} config: {file_name}")

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -306,10 +306,9 @@ if extra_files:
 
     volume_mounts = []
     for file_key, file_details in extra_files.items():
-        file_name = file_details.get("name", file_key)
         volume_mounts.append(
             {
-                "mountPath": file_details["mountDir"].rstrip("/") + "/" + file_name,
+                "mountPath": file_details["mountPath"],
                 "subPath": file_key,
                 "name": "files",
             }

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -287,10 +287,13 @@ if extra_files:
         "name": "files",
     }
     items = []
-    for file_name, file_details in extra_files.items():
+    for file_key, file_details in extra_files.items():
+        # Each item is a mapping of a key in the k8s Secret to a path in this
+        # abstract volume, the goal is to enable us to set the mode /
+        # permissions only though so we don't change the mapping.
         item = {
-            "key": file_name,
-            "path": file_name,
+            "key": file_key,
+            "path": file_key,
         }
         if "mode" in file_details:
             item["mode"] = file_details["mode"]
@@ -302,11 +305,12 @@ if extra_files:
     c.KubeSpawner.volumes.append(volume)
 
     volume_mounts = []
-    for file_name, file_details in extra_files.items():
+    for file_key, file_details in extra_files.items():
+        file_name = file_details.get("name", file_key)
         volume_mounts.append(
             {
                 "mountPath": file_details["mountPath"].rstrip("/") + "/" + file_name,
-                "subPath": file_name,
+                "subPath": file_key,
                 "name": "files",
             }
         )

--- a/jupyterhub/files/hub/z2jh.py
+++ b/jupyterhub/files/hub/z2jh.py
@@ -15,7 +15,7 @@ def _load_config():
     """Load the Helm chart configuration used to render the Helm templates of
     the chart from a mounted k8s Secret."""
 
-    path = f"/etc/jupyterhub/secret/values.yaml"
+    path = f"/usr/local/etc/jupyterhub/secret/values.yaml"
     if os.path.exists(path):
         print(f"Loading {path}")
         with open(path) as f:
@@ -28,7 +28,7 @@ def _load_config():
 def _get_config_value(key):
     """Load value from the k8s ConfigMap given a key."""
 
-    path = f"/etc/jupyterhub/config/{key}"
+    path = f"/usr/local/etc/jupyterhub/config/{key}"
     if os.path.exists(path):
         with open(path) as f:
             return f.read()
@@ -40,7 +40,7 @@ def _get_config_value(key):
 def get_secret_value(key):
     """Load value from the k8s Secret given a key."""
 
-    path = f"/etc/jupyterhub/secret/{key}"
+    path = f"/usr/local/etc/jupyterhub/secret/{key}"
     if os.path.exists(path):
         with open(path) as f:
             return f.read()

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -235,10 +235,10 @@ properties:
                 # filename extension that are required to be either .yaml, .yml,
                 # .json, or .toml.
                 #
-                # If your content is YAML, JSON, or TOML, it can be useful to
-                # use data over stringData, because then you can update parts of
-                # the files content from different files as compared to opting
-                # for one or another string.
+                # If your content is YAML, JSON, or TOML, it can make sense to
+                # use data to represent it over stringData as data can be merged
+                # instead of replaced if set partially from separate Helm
+                # configuration files.
                 #
                 # Both stringData and binaryData should be set to a string
                 # representing the content, where binaryData should be the

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -215,8 +215,9 @@ properties:
       extraFiles: &extraFiles
         type: string
         description: |
-          A dictionary with extra files that should be injected into the pod's
-          container on startup.
+          A dictionary with extra files to be injected into the pod's container
+          on startup. This can for example be used to inject: configuration
+          files, custom user interface templates, images, and more.
 
           ```yaml
           hub:
@@ -262,6 +263,8 @@ properties:
                 mode: <file system permissions>
           ```
 
+          **Using --set-file**
+
           To avoid embedding entire files in the Helm chart configuration, you
           can use the `--set-file` flag during `helm upgrade` to set the
           stringData or binaryData field.
@@ -288,6 +291,36 @@ properties:
               --set-file hub.extraFiles.my_image.binaryData=./my_image.png.b64 \
               --set-file hub.extraFiles.my_config.stringData=./my_jupyterhub_config.py
           ```
+
+          **Common uses**
+
+          1. **JupyterHub template customization**
+
+             You can replace the default JupyterHub user interface templates in
+             the hub pod by injecting new ones to
+             `/usr/local/share/jupyterhub/templates`. These can in turn
+             reference custom images injected to
+             `/usr/local/share/jupyterhub/static`.
+
+          1. **JupyterHub standalone file config**
+
+             Instead of embedding JupyterHub python configuration as a string
+             within a YAML file through
+             [`hub.extraConfig`](schema_hub.extraConfig), you can inject a
+             standalone .py file into `/etc/jupyterhub.d` that is automatically
+             loaded.
+
+          1. **Flexible configuration**
+
+             By injecting files, you don't have to embed them in a docker image
+             that you have to rebuild.
+
+             If your configuration file is a YAML/JSON/TOML file, you can also
+             use `data` instead of `stringData` which allow you to set various
+             configuration in separate Helm config files. This can be useful to
+             help dependent charts override only some configuration part of the
+             file, or to allow for the configuration be set through multiple
+             Helm configuration files.
       baseUrl:
         type: string
         description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -272,9 +272,14 @@ properties:
           ```yaml
           hub:
             extraFiles:
+              # Explicitly set the name to avoid having the file key include a .
+              # as it can hamper our ability to use --set-file.
               my_image:
                 name: my_image.png
                 mountPath: /usr/local/share/jupyterhub/static/
+
+              # Files in /etc/jupyterhub.d are automatically loaded just like
+              # hub.extraConfig entries.
               my_config:
                 name: my_jupyterhub_config.py
                 mountPath: /etc/jupyterhub.d

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -264,6 +264,32 @@ properties:
                       - 1
                       - 2
           ```
+
+          To avoid embedding entire files in the Helm chart configuration, you
+          can use the `--set-file` flag during `helm upgrade` to set the
+          stringData or binaryData field.
+
+          ```yaml
+          hub:
+            extraFiles:
+              my_image:
+                name: my_image.png
+                mountPath: /usr/local/share/jupyterhub/static/
+              my_config:
+                name: my_jupyterhub_config.py
+                mountPath: /etc/jupyterhub.d
+          ```
+
+          ```bash
+          # --set-file expects a text based file, so you need to base64 encode
+          # it manually first. Note that -w0 ensures no line breaks are
+          # introduced.
+          base64 -w0 my_image.png > my_image.png.b64
+
+          helm upgrade <...> \
+              --set-file hub.extraFiles.my_image.binaryData=./my_image.png.b64
+              --set-file hub.extraFiles.my_config.stringData=./my_jupyterhub_config.py
+          ```
       baseUrl:
         type: string
         description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -275,11 +275,11 @@ properties:
               my_image:
                 mountPath: /usr/local/share/jupyterhub/static/my_image.png
 
-              # Files in /etc/jupyterhub.d are automatically loaded in
-              # alphabetical order of the final file name when JupyterHub
-              # starts.
+              # Files in /usr/local/etc/jupyterhub/jupyterhub_config.d are
+              # automatically loaded in alphabetical order of the final file
+              # name when JupyterHub starts.
               my_config:
-                mountPath: /etc/jupyterhub.d/my_jupyterhub_config.py
+                mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/my_jupyterhub_config.py
           ```
 
           ```bash
@@ -307,8 +307,9 @@ properties:
              Instead of embedding JupyterHub python configuration as a string
              within a YAML file through
              [`hub.extraConfig`](schema_hub.extraConfig), you can inject a
-             standalone .py file into `/etc/jupyterhub.d` that is automatically
-             loaded.
+             standalone .py file into
+             `/usr/local/etc/jupyterhub/jupyterhub_config.d` that is
+             automatically loaded.
 
           1. **Flexible configuration**
 
@@ -371,10 +372,10 @@ properties:
 
           ```{warning}
           By replacing the entire configuration file, which is mounted to
-          `/etc/jupyterhub/jupyterhub_config.py` by the Helm chart, instead of
-          appending to it with `hub.extraConfig`, you expose your deployment for
-          issues stemming from getting out of sync with the Helm chart's config
-          file.
+          `/usr/local/etc/jupyterhub/jupyterhub_config.py` by the Helm chart,
+          instead of appending to it with `hub.extraConfig`, you expose your
+          deployment for issues stemming from getting out of sync with the Helm
+          chart's config file.
 
           These kind of issues will be significantly harder to debug and
           diagnose, and can due to this could cause a lot of time expenditure
@@ -396,7 +397,7 @@ properties:
             args:
               - "jupyterhub"
               - "--config"
-              - "/etc/jupyterhub/jupyterhub_config.py"
+              - "/usr/local/etc/jupyterhub/jupyterhub_config.py"
               - "--debug"
               - "--upgrade-db"
           ```

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -221,26 +221,14 @@ properties:
           ```yaml
           hub:
             extraFiles:
-              <implicit file name>:
-                # name is an optional way to override the implicit file name
-                # that must be unique.
-                name: <explicit file name>
-
-                # mode is by default 0644 and you can optionally override it
-                # either by octal notation (example: 0400) or decimal notation
-                # (example: 256).
-                mode: <file system permissions>
-
-                # mountDir is required and must be the directory you want to
-                # mount the file.
-                mountDir: <directory path>
+              # The file key is just a reference that doesn't influence the
+              # actual file name.
+              <file key>:
+                # mountPath is required and must be the absolute file path.
+                mountPath: <full file path>
 
                 # Choose one out of the three ways to represent the actual file
                 # content: data, stringData, or binaryData.
-                #
-                # Both stringData and binaryData should be set to a string
-                # representing the content, where binaryData should be the
-                # base64 encoding of the actual file content.
                 #
                 # data should be set to a mapping (dictionary). It will in the
                 # end be rendered to either YAML, JSON, or TOML based on the
@@ -252,9 +240,10 @@ properties:
                 # the files content from different files as compared to opting
                 # for one or another string.
                 #
-                binaryData: aGVsbG8gd29ybGQhCg==
-                stringData: |
-                  hello world!
+                # Both stringData and binaryData should be set to a string
+                # representing the content, where binaryData should be the
+                # base64 encoding of the actual file content.
+                #
                 data:
                   config:
                     map:
@@ -263,6 +252,14 @@ properties:
                     list:
                       - 1
                       - 2
+                stringData: |
+                  hello world!
+                binaryData: aGVsbG8gd29ybGQhCg==
+
+                # mode is by default 0644 and you can optionally override it
+                # either by octal notation (example: 0400) or decimal notation
+                # (example: 256).
+                mode: <file system permissions>
           ```
 
           To avoid embedding entire files in the Helm chart configuration, you
@@ -272,18 +269,14 @@ properties:
           ```yaml
           hub:
             extraFiles:
-              # Explicitly set the name to avoid having the file key include a .
-              # as it can hamper our ability to use --set-file.
               my_image:
-                name: my_image.png
-                mountDir: /usr/local/share/jupyterhub/static/
+                mountPath: /usr/local/share/jupyterhub/static/my_image.png
 
               # Files in /etc/jupyterhub.d are automatically loaded in
               # alphabetical order of the final file name when JupyterHub
               # starts.
               my_config:
-                name: my_jupyterhub_config.py
-                mountDir: /etc/jupyterhub.d
+                mountPath: /etc/jupyterhub.d/my_jupyterhub_config.py
           ```
 
           ```bash

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -321,6 +321,25 @@ properties:
              help dependent charts override only some configuration part of the
              file, or to allow for the configuration be set through multiple
              Helm configuration files.
+
+          **Limitations**
+
+          1. File size
+
+             The files in `hub.extraFiles` and `singleuser.extraFiles` are
+             respectively stored in their own k8s Secret resource. As k8s
+             Secret's are limited, typically to 1MB, you will be limited to a
+             total file size of less than 1MB as there is also base64 encoding
+             that takes place reducing available capacity to 75%.
+
+          2. File updates
+
+             The files that are mounted are only set during container startup.
+             This is [because we use
+             `subPath`](https://kubernetes.io/docs/concepts/storage/volumes/#secret)
+             as is required to avoid replacing the content of the entire
+             directory we mount in.
+
       baseUrl:
         type: string
         description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -212,6 +212,58 @@ properties:
           the `--values` or `-f` flag. During merging, lists are replaced while
           dictionaries are updated.
           ```
+      extraFiles: &extraFiles
+        type: string
+        description: |
+          A dictionary with extra files that should be injected into the pod's
+          container.
+
+          ```yaml
+          hub:
+            extraFiles:
+              <implicit file name>:
+                # name is an optional way to override the implicit file name
+                # that must be unique.
+                name: <explicit file name>
+
+                # mode is by default 0644 and you can optionally override it
+                # either by octal notation (example: 0400) or decimal notation
+                # (example: 256).
+                mode: <file system permissions>
+
+                # mountPath is required and must be the directory you want to
+                # mount the file.
+                mountPath: <directory path>
+
+                # Choose one out of the three ways to represent the actual file
+                # content: data, stringData, or binaryData.
+                #
+                # Both stringData and binaryData should be set to a string
+                # representing the content, where binaryData should be the
+                # base64 encoding of the actual file content.
+                #
+                # data should be set to a mapping (dictionary). It will in the
+                # end be rendered to either YAML, JSON, or TOML based on the
+                # filename extension that are required to be either .yaml, .yml,
+                # .json, or .toml.
+                #
+                # If your content is YAML, JSON, or TOML, it can be useful to
+                # use data over stringData, because then you can update parts of
+                # the files content from different files as compared to opting
+                # for one or another string.
+                #
+                binaryData: aGVsbG8gd29ybGQhCg==
+                stringData: |
+                  hello world!
+                data:
+                  config:
+                    map:
+                      number: 123
+                      string: "hi"
+                    list:
+                      - 1
+                      - 2
+          ```
       baseUrl:
         type: string
         description: |
@@ -1154,6 +1206,7 @@ properties:
         description: |
           Deprecated and no longer does anything. Use the user-scheduler instead
           in order to accomplish a good packing of the user pods.
+      extraFiles: *extraFiles
       extraEnv:
         type: object
         description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -279,7 +279,7 @@ properties:
                 mountPath: /usr/local/share/jupyterhub/static/
 
               # Files in /etc/jupyterhub.d are automatically loaded just like
-              # hub.extraConfig entries.
+              # hub.extraConfig entries, sorted based on their name.
               my_config:
                 name: my_jupyterhub_config.py
                 mountPath: /etc/jupyterhub.d

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -231,9 +231,9 @@ properties:
                 # (example: 256).
                 mode: <file system permissions>
 
-                # mountPath is required and must be the directory you want to
+                # mountDir is required and must be the directory you want to
                 # mount the file.
-                mountPath: <directory path>
+                mountDir: <directory path>
 
                 # Choose one out of the three ways to represent the actual file
                 # content: data, stringData, or binaryData.
@@ -276,13 +276,13 @@ properties:
               # as it can hamper our ability to use --set-file.
               my_image:
                 name: my_image.png
-                mountPath: /usr/local/share/jupyterhub/static/
+                mountDir: /usr/local/share/jupyterhub/static/
 
               # Files in /etc/jupyterhub.d are automatically loaded just like
               # hub.extraConfig entries, sorted based on their name.
               my_config:
                 name: my_jupyterhub_config.py
-                mountPath: /etc/jupyterhub.d
+                mountDir: /etc/jupyterhub.d
           ```
 
           ```bash

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -278,8 +278,9 @@ properties:
                 name: my_image.png
                 mountDir: /usr/local/share/jupyterhub/static/
 
-              # Files in /etc/jupyterhub.d are automatically loaded just like
-              # hub.extraConfig entries, sorted based on their name.
+              # Files in /etc/jupyterhub.d are automatically loaded in
+              # alphabetical order of the final file name when JupyterHub
+              # starts.
               my_config:
                 name: my_jupyterhub_config.py
                 mountDir: /etc/jupyterhub.d
@@ -291,7 +292,7 @@ properties:
           base64 my_image.png > my_image.png.b64
 
           helm upgrade <...> \
-              --set-file hub.extraFiles.my_image.binaryData=./my_image.png.b64
+              --set-file hub.extraFiles.my_image.binaryData=./my_image.png.b64 \
               --set-file hub.extraFiles.my_config.stringData=./my_jupyterhub_config.py
           ```
       baseUrl:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -282,9 +282,8 @@ properties:
 
           ```bash
           # --set-file expects a text based file, so you need to base64 encode
-          # it manually first. Note that -w0 ensures no line breaks are
-          # introduced.
-          base64 -w0 my_image.png > my_image.png.b64
+          # it manually first.
+          base64 my_image.png > my_image.png.b64
 
           helm upgrade <...> \
               --set-file hub.extraFiles.my_image.binaryData=./my_image.png.b64

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -216,7 +216,7 @@ properties:
         type: string
         description: |
           A dictionary with extra files that should be injected into the pod's
-          container.
+          container on startup.
 
           ```yaml
           hub:

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -350,7 +350,7 @@ true
 {{- define "jupyterhub.extraFiles.stringData.withNewLineSuffix" -}}
     {{- range $file_key, $file_details := . }}
         {{- include "jupyterhub.extraFiles.validate-file" (list $file_key $file_details) }}
-        {{- $file_name := $file_details.name | default $file_key }}
+        {{- $file_name := $file_details.mountPath | base }}
         {{- if $file_details.stringData }}
             {{- $file_key | quote }}: |
               {{- $file_details.stringData | trimSuffix "\n" | nindent 2 }}{{ println }}
@@ -364,7 +364,7 @@ true
               {{- else if eq (ext $file_name) ".toml" }}
               {{- $file_details.data | toToml | trimSuffix "\n" | nindent 2 }}{{ println }}
               {{- else }}
-              {{- print "\n\nextraFiles entries with 'data' (" $file_name ") needs to have a filename extension of .yaml, .yml, .json, or .toml!" | fail }}
+              {{- print "\n\nextraFiles entries with 'data' (" $file_key " > " $file_details.mountPath ") needs to have a filename extension of .yaml, .yml, .json, or .toml!" | fail }}
               {{- end }}
         {{- end }}
     {{- end }}
@@ -376,6 +376,13 @@ true
 {{- define "jupyterhub.extraFiles.validate-file" -}}
     {{- $file_key := index . 0 }}
     {{- $file_details := index . 1 }}
+
+    {{- /* Use of mountPath. */}}
+    {{- if not ($file_details.mountPath) }}
+        {{- print "\n\nextraFiles entries (" $file_key ") must contain the field 'mountPath'." | fail }}
+    {{- end }}
+
+    {{- /* Use one of stringData, binaryData, data. */}}
     {{- $field_count := 0 }}
     {{- if $file_details.data }}
         {{- $field_count = add1 $field_count }}
@@ -387,6 +394,6 @@ true
         {{- $field_count = add1 $field_count }}
     {{- end }}
     {{- if ne $field_count 1 }}
-        {{- print "\n\nextraFiles entries (" $file_key ") must only contain one of the fields: data, stringData, and binaryData." | fail }}
+        {{- print "\n\nextraFiles entries (" $file_key ") must only contain one of the fields: 'data', 'stringData', and 'binaryData'." | fail }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -331,9 +331,9 @@ true
     binaryData entries.
 */}}
 {{- define "jupyterhub.extraFiles.data.withNewLineSuffix" -}}
-    {{- range $file_name, $file_details := . }}
+    {{- range $file_key, $file_details := . }}
         {{- if $file_details.binaryData }}
-            {{- $file_name | quote }}: {{ $file_details.binaryData | trimSuffix "\n" | quote }}{{ println }}
+            {{- $file_key | quote }}: {{ $file_details.binaryData | trimSuffix "\n" | quote }}{{ println }}
         {{- end }}
     {{- end }}
 {{- end }}
@@ -347,13 +347,14 @@ true
     with either data or stringData entries.
 */}}
 {{- define "jupyterhub.extraFiles.stringData.withNewLineSuffix" -}}
-    {{- range $file_name, $file_details := . }}
+    {{- range $file_key, $file_details := . }}
+        {{- $file_name := $file_details.name | default $file_key }}
         {{- if $file_details.stringData }}
-            {{- $file_name | quote }}: |
+            {{- $file_key | quote }}: |
               {{- $file_details.stringData | trimSuffix "\n" | nindent 2 }}{{ println }}
         {{- end }}
         {{- if $file_details.data }}
-            {{- $file_name | quote }}: |
+            {{- $file_key | quote }}: |
               {{- if or (eq (ext $file_name) ".yaml") (eq (ext $file_name) ".yml") }}
               {{- $file_details.data | toYaml | trimSuffix "\n" | nindent 2 }}{{ println }}
               {{- else if eq (ext $file_name) ".json" }}

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -334,7 +334,7 @@ true
     {{- range $file_key, $file_details := . }}
         {{- include "jupyterhub.extraFiles.validate-file" (list $file_key $file_details) }}
         {{- if $file_details.binaryData }}
-            {{- $file_key | quote }}: {{ $file_details.binaryData | trimSuffix "\n" | quote }}{{ println }}
+            {{- $file_key | quote }}: {{ $file_details.binaryData | nospace | quote }}{{ println }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -324,3 +324,48 @@ limits:
 true
 {{- end }}
 {{- end }}
+
+{{- /*
+  jupyterhub.extraFiles.data:
+    Renders content for a k8s Secret's data field, coming from extraFiles with
+    binaryData entries.
+*/}}
+{{- define "jupyterhub.extraFiles.data.withNewLineSuffix" -}}
+    {{- range $file_name, $file_details := . }}
+        {{- if $file_details.binaryData }}
+            {{- $file_name | quote }}: {{ $file_details.binaryData | trimSuffix "\n" | quote }}{{ println }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- define "jupyterhub.extraFiles.data" -}}
+    {{- include "jupyterhub.extraFiles.data.withNewLineSuffix" . | trimSuffix "\n" }}
+{{- end }}
+
+{{- /*
+  jupyterhub.extraFiles.stringData:
+    Renders content for a k8s Secret's stringData field, coming from extraFiles
+    with either data or stringData entries.
+*/}}
+{{- define "jupyterhub.extraFiles.stringData.withNewLineSuffix" -}}
+    {{- range $file_name, $file_details := . }}
+        {{- if $file_details.stringData }}
+            {{- $file_name | quote }}: |
+              {{- $file_details.stringData | trimSuffix "\n" | nindent 2 }}{{ println }}
+        {{- end }}
+        {{- if $file_details.data }}
+            {{- $file_name | quote }}: |
+              {{- if or (eq (ext $file_name) ".yaml") (eq (ext $file_name) ".yml") }}
+              {{- $file_details.data | toYaml | trimSuffix "\n" | nindent 2 }}{{ println }}
+              {{- else if eq (ext $file_name) ".json" }}
+              {{- $file_details.data | toJson | trimSuffix "\n" | nindent 2 }}{{ println }}
+              {{- else if eq (ext $file_name) ".toml" }}
+              {{- $file_details.data | toToml | trimSuffix "\n" | nindent 2 }}{{ println }}
+              {{- else }}
+              {{- print "\n\nextraFiles entries with 'data' (" $file_name ") needs to have a filename extension of .yaml, .yml, .json, or .toml!" | fail }}
+              {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- define "jupyterhub.extraFiles.stringData" -}}
+    {{- include "jupyterhub.extraFiles.stringData.withNewLineSuffix" . | trimSuffix "\n" }}
+{{- end }}

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -332,6 +332,7 @@ true
 */}}
 {{- define "jupyterhub.extraFiles.data.withNewLineSuffix" -}}
     {{- range $file_key, $file_details := . }}
+        {{- include "jupyterhub.extraFiles.validate-file" (list $file_key $file_details) }}
         {{- if $file_details.binaryData }}
             {{- $file_key | quote }}: {{ $file_details.binaryData | trimSuffix "\n" | quote }}{{ println }}
         {{- end }}
@@ -348,6 +349,7 @@ true
 */}}
 {{- define "jupyterhub.extraFiles.stringData.withNewLineSuffix" -}}
     {{- range $file_key, $file_details := . }}
+        {{- include "jupyterhub.extraFiles.validate-file" (list $file_key $file_details) }}
         {{- $file_name := $file_details.name | default $file_key }}
         {{- if $file_details.stringData }}
             {{- $file_key | quote }}: |
@@ -369,4 +371,22 @@ true
 {{- end }}
 {{- define "jupyterhub.extraFiles.stringData" -}}
     {{- include "jupyterhub.extraFiles.stringData.withNewLineSuffix" . | trimSuffix "\n" }}
+{{- end }}
+
+{{- define "jupyterhub.extraFiles.validate-file" -}}
+    {{- $file_key := index . 0 }}
+    {{- $file_details := index . 1 }}
+    {{- $field_count := 0 }}
+    {{- if $file_details.data }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if $file_details.stringData }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if $file_details.binaryData }}
+        {{- $field_count = add1 $field_count }}
+    {{- end }}
+    {{- if ne $field_count 1 }}
+        {{- print "\n\nextraFiles entries (" $file_key ") must only contain one of the fields: data, stringData, and binaryData." | fail }}
+    {{- end }}
 {{- end }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             {{- else }}
             - jupyterhub
             - --config
-            - /etc/jupyterhub/jupyterhub_config.py
+            - /usr/local/etc/jupyterhub/jupyterhub_config.py
             {{- if .Values.debug.enabled }}
             - --debug
             {{- end }}
@@ -136,15 +136,15 @@ spec:
             {{- end }}
             {{- end }}
           volumeMounts:
-            - mountPath: /etc/jupyterhub/jupyterhub_config.py
+            - mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.py
               subPath: jupyterhub_config.py
               name: config
-            - mountPath: /etc/jupyterhub/z2jh.py
+            - mountPath: /usr/local/etc/jupyterhub/z2jh.py
               subPath: z2jh.py
               name: config
-            - mountPath: /etc/jupyterhub/config/
+            - mountPath: /usr/local/etc/jupyterhub/config/
               name: config
-            - mountPath: /etc/jupyterhub/secret/
+            - mountPath: /usr/local/etc/jupyterhub/secret/
               name: secret
             {{- range $file_key, $file_details := .Values.hub.extraFiles }}
             - mountPath: {{ $file_details.mountPath }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -147,8 +147,7 @@ spec:
             - mountPath: /etc/jupyterhub/secret/
               name: secret
             {{- range $file_key, $file_details := .Values.hub.extraFiles }}
-            {{- $file_name := $file_details.name | default $file_key }}
-            - mountPath: {{ $file_details.mountDir | trimSuffix "/" }}/{{ $file_name }}
+            - mountPath: {{ $file_details.mountPath }}
               subPath: {{ $file_key | quote }}
               name: files
             {{- end }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -59,9 +59,9 @@ spec:
           secret:
             secretName: {{ include "jupyterhub.hub-secret.fullname" . }}
             items:
-              {{- range $file_name, $file_details := .Values.hub.extraFiles }}
-              - key: {{ $file_name | quote }}
-                path: {{ $file_name | quote }}
+              {{- range $file_key, $file_details := .Values.hub.extraFiles }}
+              - key: {{ $file_key | quote }}
+                path: {{ $file_key | quote }}
                 {{- with $file_details.mode }}
                 mode: {{ . }}
                 {{- end }}
@@ -146,9 +146,10 @@ spec:
               name: config
             - mountPath: /etc/jupyterhub/secret/
               name: secret
-            {{- range $file_name, $file_details := .Values.hub.extraFiles }}
+            {{- range $file_key, $file_details := .Values.hub.extraFiles }}
+            {{- $file_name := $file_details.name | default $file_key }}
             - mountPath: {{ $file_details.mountPath | trimSuffix "/" }}/{{ $file_name }}
-              subPath: {{ $file_name | quote }}
+              subPath: {{ $file_key | quote }}
               name: files
             {{- end }}
             {{- with .Values.hub.extraVolumeMounts }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -148,7 +148,7 @@ spec:
               name: secret
             {{- range $file_key, $file_details := .Values.hub.extraFiles }}
             {{- $file_name := $file_details.name | default $file_key }}
-            - mountPath: {{ $file_details.mountPath | trimSuffix "/" }}/{{ $file_name }}
+            - mountPath: {{ $file_details.mountDir | trimSuffix "/" }}/{{ $file_name }}
               subPath: {{ $file_key | quote }}
               name: files
             {{- end }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -54,6 +54,19 @@ spec:
         - name: secret
           secret:
             secretName: {{ include "jupyterhub.hub-secret.fullname" . }}
+        {{- if .Values.hub.extraFiles }}
+        - name: files
+          secret:
+            secretName: {{ include "jupyterhub.hub-secret.fullname" . }}
+            items:
+              {{- range $file_name, $file_details := .Values.hub.extraFiles }}
+              - key: {{ $file_name | quote }}
+                path: {{ $file_name | quote }}
+                {{- with $file_details.mode }}
+                mode: {{ . }}
+                {{- end }}
+              {{- end }}
+        {{- end }}
         {{- with .Values.hub.extraVolumes }}
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
@@ -133,6 +146,11 @@ spec:
               name: config
             - mountPath: /etc/jupyterhub/secret/
               name: secret
+            {{- range $file_name, $file_details := .Values.hub.extraFiles }}
+            - mountPath: {{ $file_details.mountPath | trimSuffix "/" }}/{{ $file_name }}
+              subPath: {{ $file_name | quote }}
+              name: files
+            {{- end }}
             {{- with .Values.hub.extraVolumeMounts }}
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
             {{- end }}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -41,4 +41,13 @@ data:
   JupyterHub.proxy_auth_token: {{ include "jupyterhub.config.JupyterHub.proxy_auth_token" . | required "This should not happen: blank output from 'jupyterhub.config.JupyterHub.proxy_auth_token' template" | b64enc | quote }}
   JupyterHub.cookie_secret: {{ include "jupyterhub.config.JupyterHub.cookie_secret" . | required "This should not happen: blank output from 'jupyterhub.config.JupyterHub.cookie_secret' template" | b64enc | quote }}
   CryptKeeper.keys: {{ include "jupyterhub.config.CryptKeeper.keys" . | required "This should not happen: blank output from 'jupyterhub.config.CryptKeeper.keys' template" | b64enc | quote }}
+
+  {{- with include "jupyterhub.extraFiles.data" .Values.hub.extraFiles }}
+  {{- . | nindent 2 }}
+  {{- end }}
+
+{{- with include "jupyterhub.extraFiles.stringData" .Values.hub.extraFiles }}
+stringData:
+  {{- . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/jupyterhub/templates/singleuser/secret.yaml
+++ b/jupyterhub/templates/singleuser/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.singleuser.extraFiles }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ include "jupyterhub.singleuser.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+type: Opaque
+{{- with include "jupyterhub.extraFiles.data" .Values.singleuser.extraFiles }}
+data:
+  {{- . | nindent 2 }}
+{{- end }}
+{{- with include "jupyterhub.extraFiles.stringData" .Values.singleuser.extraFiles }}
+stringData:
+  {{- . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -73,6 +73,7 @@ hub:
   args: []
   extraConfig: {}
   extraConfigMap: {}
+  extraFiles: {}
   extraEnv: {}
   extraContainers: []
   extraVolumes: []
@@ -340,6 +341,7 @@ singleuser:
   extraAnnotations: {}
   extraLabels:
     hub.jupyter.org/network-access-hub: "true"
+  extraFiles: {}
   extraEnv: {}
   lifecycleHooks: {}
   initContainers: []

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -153,6 +153,27 @@ def test_hub_mounted_extra_files():
     ), f"The hub.extraFiles configuration doesn't seem to have been honored!"
 
 
+def test_hub_etc_jupyterhub_d_folder():
+    """
+    Tests that the extra jupyterhub config file put into /etc/jupyterhub.d by
+    the hub.extraFiles configuration was loaded.
+    """
+    c = subprocess.run(
+        [
+            "kubectl",
+            "exec",
+            "deploy/hub",
+            "--",
+            "sh",
+            "-c",
+            "cat /tmp/created-by-extra-files-config.txt | grep -- 'hello world' || exit 1",
+        ]
+    )
+    assert (
+        c.returncode == 0
+    ), f"The hub.extraFiles configuration should have mounted a config file to /etc/jupyterhub.d which should have been loaded to write a dummy file for us!"
+
+
 def test_hub_api_request_user_spawn(
     api_request, jupyter_user, request_data, pebble_acme_ca_cert
 ):

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -191,6 +191,31 @@ def test_hub_api_request_user_spawn(
         assert (
             c.returncode == 0
         ), f"singleuser.extraEnv didn't lead to a mounted environment variable!"
+
+        # check user pod's extra files
+        c = subprocess.run(
+            [
+                "kubectl",
+                "exec",
+                pod_name,
+                "--",
+                "sh",
+                "-c",
+                """
+                ls -l /tmp/binaryData.txt | grep -- -rw-rw-rw- || exit 1
+                ls -l /tmp/dir1/binaryData.txt | grep -- -rw-rw-rw- || exit 2
+                ls -l /tmp/stringData.txt | grep -- -rw-rw-rw- || exit 3
+                ls -l /tmp/dir1/stringData.txt | grep -- -rw-rw-rw- || exit 4
+                ls -l /etc/test/data.yaml | grep -- -r--r--r-- || exit 5
+                ls -l /etc/test/data.yml | grep -- -r--r--r-- || exit 6
+                ls -l /etc/test/data.json | grep -- -r--r--r-- || exit 7
+                ls -l /etc/test/data.toml | grep -- -r--r--r-- || exit 8
+                """,
+            ]
+        )
+        assert (
+            c.returncode == 0
+        ), f"The singleuser.extraFiles configuration doesn't seem to have been honored!"
     finally:
         _delete_server(api_request, jupyter_user, request_data["test_timeout"])
 

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -13,6 +13,19 @@ import yaml
 here = os.path.dirname(os.path.abspath(__file__))
 chart_yaml = os.path.join(here, os.pardir, "jupyterhub", "Chart.yaml")
 
+extra_files_test = """
+    ls -l /tmp/binaryData.txt | grep -- -rw-rw-rw- || exit 1
+    ls -l /tmp/dir1/binaryData.txt | grep -- -rw-rw-rw- || exit 2
+    ls -l /tmp/stringData.txt | grep -- -rw-rw-rw- || exit 3
+    ls -l /tmp/dir1/stringData.txt | grep -- -rw-rw-rw- || exit 4
+    ls -l /etc/test/data.yaml | grep -- -r--r--r-- || exit 5
+    ls -l /etc/test/data.yml | grep -- -r--r--r-- || exit 6
+    ls -l /etc/test/data.json | grep -- -r--r--r-- || exit 7
+    ls -l /etc/test/data.toml | grep -- -r--r--r-- || exit 8
+    cat /tmp/binaryData.txt | grep -- "hello world" || exit 9
+    cat /tmp/stringData.txt | grep -- "hello world" || exit 10
+"""
+
 with open(chart_yaml) as f:
     chart = yaml.safe_load(f)
     jupyterhub_version = chart["appVersion"]
@@ -132,16 +145,7 @@ def test_hub_mounted_extra_files():
             "--",
             "sh",
             "-c",
-            """
-            ls -l /tmp/binaryData.txt | grep -- -rw-rw-rw- || exit 1
-            ls -l /tmp/dir1/binaryData.txt | grep -- -rw-rw-rw- || exit 2
-            ls -l /tmp/stringData.txt | grep -- -rw-rw-rw- || exit 3
-            ls -l /tmp/dir1/stringData.txt | grep -- -rw-rw-rw- || exit 4
-            ls -l /etc/test/data.yaml | grep -- -r--r--r-- || exit 5
-            ls -l /etc/test/data.yml | grep -- -r--r--r-- || exit 6
-            ls -l /etc/test/data.json | grep -- -r--r--r-- || exit 7
-            ls -l /etc/test/data.toml | grep -- -r--r--r-- || exit 8
-            """,
+            extra_files_test,
         ]
     )
     assert (
@@ -201,16 +205,7 @@ def test_hub_api_request_user_spawn(
                 "--",
                 "sh",
                 "-c",
-                """
-                ls -l /tmp/binaryData.txt | grep -- -rw-rw-rw- || exit 1
-                ls -l /tmp/dir1/binaryData.txt | grep -- -rw-rw-rw- || exit 2
-                ls -l /tmp/stringData.txt | grep -- -rw-rw-rw- || exit 3
-                ls -l /tmp/dir1/stringData.txt | grep -- -rw-rw-rw- || exit 4
-                ls -l /etc/test/data.yaml | grep -- -r--r--r-- || exit 5
-                ls -l /etc/test/data.yml | grep -- -r--r--r-- || exit 6
-                ls -l /etc/test/data.json | grep -- -r--r--r-- || exit 7
-                ls -l /etc/test/data.toml | grep -- -r--r--r-- || exit 8
-                """,
+                extra_files_test,
             ]
         )
         assert (

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -155,8 +155,9 @@ def test_hub_mounted_extra_files():
 
 def test_hub_etc_jupyterhub_d_folder():
     """
-    Tests that the extra jupyterhub config file put into /etc/jupyterhub.d by
-    the hub.extraFiles configuration was loaded.
+    Tests that the extra jupyterhub config file put into
+    /usr/local/etc/jupyterhub/jupyterhub_config.d by the hub.extraFiles
+    configuration was loaded.
     """
     c = subprocess.run(
         [
@@ -171,7 +172,7 @@ def test_hub_etc_jupyterhub_d_folder():
     )
     assert (
         c.returncode == 0
-    ), f"The hub.extraFiles configuration should have mounted a config file to /etc/jupyterhub.d which should have been loaded to write a dummy file for us!"
+    ), f"The hub.extraFiles configuration should have mounted a config file to /usr/local/etc/jupyterhub/jupyterhub_config.d which should have been loaded to write a dummy file for us!"
 
 
 def test_hub_api_request_user_spawn(

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -9,36 +9,47 @@ imagePullSecrets: [a, b]
 
 hub:
   extraFiles:
-    binaryData.txt:
-      mountDir: /tmp/
+    my_config:
+      mountPath: /etc/jupyterhub.d/my_config.py
+      stringData: |
+        with open("/tmp/created-by-extra-files-config.txt", "w") as f:
+            f.write("hello world!")
+    binaryData1: &binaryData1
+      mountPath: /tmp/binaryData.txt
       mode: 0666
-      binaryData: aGVsbG8gd29ybGQhCg== # "hello world!" base64 encoded
-    binaryData-explicit-name.txt:
-      name: binaryData.txt
-      mountDir: /tmp/dir1
+      binaryData: |
+        aGVsbG8gd
+        29ybGQhCg==
+    binaryData2: &binaryData2
+      mountPath: /tmp/dir1/binaryData.txt
       mode: 0666
-      binaryData: aGVsbG8gd29ybGQhCg== # "hello world!" base64 encoded
-    stringData.txt:
-      mountDir: /tmp
+      binaryData: aGVsbG8gd29ybGQhCg==
+    stringData1: &stringData1
+      mountPath: /tmp/stringData.txt
       mode: 0666
       stringData: hello world!
-    stringData-explicit-name.txt:
-      name: stringData.txt
-      mountDir: /tmp/dir1/
+    stringData2: &stringData2
+      mountPath: /tmp/dir1/stringData.txt
       mode: 0666
       stringData: hello world!
-    data.yaml: &data
-      mountDir: /tmp
-      mode: 0666
+    data-yaml: &data-yaml
+      mountPath: /etc/test/data.yaml
+      mode: 0444
       data:
         config:
           map:
             number: 123
             string: "hi"
           list: [1, 2]
-    data.yml: *data
-    data.json: *data
-    data.toml: *data
+    data-yml: &data-yml
+      <<: *data-yaml
+      mountPath: /etc/test/data.yml
+    data-json: &data-json
+      <<: *data-yaml
+      mountPath: /etc/test/data.json
+    data-toml: &data-toml
+      <<: *data-yaml
+      mountPath: /etc/test/data.toml
   service:
     type: ClusterIP
     ports:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -13,7 +13,8 @@ hub:
       mountPath: /tmp/
       mode: 0666
       binaryData: aGVsbG8gd29ybGQhCg== # "hello world!" base64 encoded
-    binaryData2.txt:
+    binaryData-explicit-name.txt:
+      name: binaryData.txt
       mountPath: /tmp/dir1
       mode: 0666
       binaryData: aGVsbG8gd29ybGQhCg== # "hello world!" base64 encoded
@@ -21,7 +22,8 @@ hub:
       mountPath: /tmp
       mode: 0666
       stringData: hello world!
-    stringData2.txt:
+    stringData-explicit-name.txt:
+      name: stringData.txt
       mountPath: /tmp/dir1/
       mode: 0666
       stringData: hello world!

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -10,25 +10,25 @@ imagePullSecrets: [a, b]
 hub:
   extraFiles:
     binaryData.txt:
-      mountPath: /tmp/
+      mountDir: /tmp/
       mode: 0666
       binaryData: aGVsbG8gd29ybGQhCg== # "hello world!" base64 encoded
     binaryData-explicit-name.txt:
       name: binaryData.txt
-      mountPath: /tmp/dir1
+      mountDir: /tmp/dir1
       mode: 0666
       binaryData: aGVsbG8gd29ybGQhCg== # "hello world!" base64 encoded
     stringData.txt:
-      mountPath: /tmp
+      mountDir: /tmp
       mode: 0666
       stringData: hello world!
     stringData-explicit-name.txt:
       name: stringData.txt
-      mountPath: /tmp/dir1/
+      mountDir: /tmp/dir1/
       mode: 0666
       stringData: hello world!
     data.yaml: &data
-      mountPath: /tmp
+      mountDir: /tmp
       mode: 0666
       data:
         config:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -10,7 +10,7 @@ imagePullSecrets: [a, b]
 hub:
   extraFiles:
     my_config:
-      mountPath: /etc/jupyterhub.d/my_config.py
+      mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/my_config.py
       stringData: |
         with open("/tmp/created-by-extra-files-config.txt", "w") as f:
             f.write("hello world!")

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -8,6 +8,35 @@ imagePullSecret:
 imagePullSecrets: [a, b]
 
 hub:
+  extraFiles:
+    binaryData.txt:
+      mountPath: /tmp/
+      mode: 0666
+      binaryData: aGVsbG8gd29ybGQhCg== # "hello world!" base64 encoded
+    binaryData2.txt:
+      mountPath: /tmp/dir1
+      mode: 0666
+      binaryData: aGVsbG8gd29ybGQhCg== # "hello world!" base64 encoded
+    stringData.txt:
+      mountPath: /tmp
+      mode: 0666
+      stringData: hello world!
+    stringData2.txt:
+      mountPath: /tmp/dir1/
+      mode: 0666
+      stringData: hello world!
+    data.yaml: &data
+      mountPath: /tmp
+      mode: 0666
+      data:
+        config:
+          map:
+            number: 123
+            string: "hi"
+          list: [1, 2]
+    data.yml: *data
+    data.json: *data
+    data.toml: *data
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
# Summary

- Added `hub.extraFiles` and `singleuser.extraFiles` allowing the chart users to inject files to the pods in specific locations with specific permissions (644, 400, etc).
- Added automatic loading of jupyterhub config files in `/etc/jupyterhub.d`.
- Closes #1990.

## Motivation
Injecting files to the hub / singleuser pods have a wide range of applications:

- To manage an external jupyterhub config file instead of embedding it to `hub.extraConfig` that. Related: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1987, https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1580.
- To mount configuration files to the user environments, such as `jupyter_notebook_config.json`, `gitconfig`, etc. Related: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1691
- To mount templates for jupyterhub for easier customization of its user interface. Related: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1266.

## Usage documentation
See the [documentation preview](https://zero-to-jupyterhub--2006.org.readthedocs.build/en/2006/resources/reference.html#hub-extrafiles), or if its already merged the [latest documentation](https://z2jh.jupyter.org/en/latest/resources/reference.html#hub-extrafiles).