### PR TITLE
fix: set tolerations to predefined labels on core pods

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -34,7 +34,18 @@ spec:
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
       nodeSelector: {{ toJson .Values.hub.nodeSelector }}
-      tolerations: {{ toJson .Values.hub.tolerations }}
+      tolerations:
+        - key: hub.jupyter.org/dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        - key: hub.jupyter.org_dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        {{- with .Values.hub.tolerations }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       volumes:
         - name: config

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -32,8 +32,19 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
       {{- end }}
-      tolerations: {{ toJson .Values.prePuller.hook.tolerations }}
       nodeSelector: {{ toJson .Values.prePuller.hook.nodeSelector }}
+      tolerations:
+        - key: hub.jupyter.org/dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        - key: hub.jupyter.org_dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        {{- with .Values.prePuller.hook.tolerations }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.prePuller.hook.image) }}
       imagePullSecrets: {{ . }}
       {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -34,7 +34,18 @@ spec:
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
       nodeSelector: {{ toJson .Values.proxy.traefik.nodeSelector }}
-      tolerations: {{ toJson .Values.proxy.traefik.tolerations }}
+      tolerations:
+        - key: hub.jupyter.org/dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        - key: hub.jupyter.org_dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        {{- with .Values.proxy.traefik.tolerations }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       volumes:
         - name: certificates

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -36,7 +36,18 @@ spec:
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
       nodeSelector: {{ toJson .Values.proxy.chp.nodeSelector }}
-      tolerations: {{ toJson .Values.proxy.chp.tolerations }}
+      tolerations:
+        - key: hub.jupyter.org/dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        - key: hub.jupyter.org_dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        {{- with .Values.proxy.chp.tolerations }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       {{- if $manualHTTPS }}
       volumes:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -24,7 +24,18 @@ spec:
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
       nodeSelector: {{ toJson .Values.scheduling.userScheduler.nodeSelector }}
-      tolerations: {{ toJson .Values.scheduling.userScheduler.tolerations }}
+      tolerations:
+        - key: hub.jupyter.org/dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        - key: hub.jupyter.org_dedicated
+          operator: Equal
+          value: core
+          effect: NoSchedule
+        {{- with .Values.scheduling.userScheduler.tolerations }}
+        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       {{- include "jupyterhub.coreAffinity" . | nindent 6 }}
       volumes:
         - name: config


### PR DESCRIPTION
Closes #1486 by adding a default toleration to our core pods to a specific taint [according to our current documentation](https://zero-to-jupyterhub.readthedocs.io/en/stable/resources/reference.html#hub-tolerations). This is done according to strategy described in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1486#issuecomment-648993410.

@minrk I recall trimming away this feature (but apparently missed that part in the docs) while adding the user equivalent tolerations because the complexity of the implementation I went for. Since then we have added configurable tolerations for all our core pods on request by users, this is to me something that indicates the value of having a default toleration.

What do you think about this implementation? I lean towards thinking its a good addition as users have requested configurable tolerations.