### PR TITLE
cleanup: remove mistakenly added artifactshub.io config file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,7 +1,0 @@
-# Artifact Hub repository metadata file
-# repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
-owners: # (optional, used to claim repository ownership)
-  - name: Erik Sundell
-    email: erik@sundellopensource.se
-  - name: Simon Li
-    email: orpheus+devel@gmail.com


### PR DESCRIPTION
This reverts #1820 which was a mistake, it should really been added to the jupyterhub/helm-chart repo's gh-pages branch. I did this in https://github.com/jupyterhub/helm-chart/pull/114.

It would be good if a few jupyterhub team members created an account on artifactshub.io to avoid single points of failures. Ping me and I'll invite you to the JupyterHub org i created on artifactshub.