### PR TITLE
feat: add port to user-scheduler pod

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,7 +1,0 @@
-# Artifact Hub repository metadata file
-# repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
-owners: # (optional, used to claim repository ownership)
-  - name: Erik Sundell
-    email: erik@sundellopensource.se
-  - name: Simon Li
-    email: orpheus+devel@gmail.com

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -75,15 +75,18 @@ spec:
           volumeMounts:
             - mountPath: /etc/user-scheduler
               name: config
+          ports:
+            - name: http
+              containerPort: 10251
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 10251
+              port: http
             initialDelaySeconds: 15
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 10251
+              port: http
           resources:
             {{- .Values.scheduling.userScheduler.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- with .Values.scheduling.userScheduler.containerSecurityContext }}


### PR DESCRIPTION
add an explicit port to the user-scheduler pod and use it for the probes