### PR TITLE
Followup fixes to seed secrets PR (#1993)

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -189,6 +189,9 @@ jobs:
           export STRING_REPLACER_A=${{ steps.local-chart.outputs.version }}
           export STRING_REPLACER_B=$UPGRADE_FROM_VERSION
 
+          echo "NOTE: Helm diff upgrade won't trigger lookup functions, so it"
+          echo "      will look like we seed new passwords all the time."
+          echo
           echo "NOTE: For the helm diff only, we have replaced the new chart"
           echo "      version with the old chart version to reduce clutter."
           echo

--- a/jupyterhub/templates/hub/_helpers-passwords.tpl
+++ b/jupyterhub/templates/hub/_helpers-passwords.tpl
@@ -36,7 +36,7 @@
         {{- if hasKey $k8s_state.data "JupyterHub.proxy_auth_token" }}
             {{- index $k8s_state.data "JupyterHub.proxy_auth_token" | b64dec }}
         {{- else }}
-            {{- include "jupyterhub.randHex" 64 }}
+            {{- randAlphaNum 64 }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/hub/_helpers-passwords.tpl
+++ b/jupyterhub/templates/hub/_helpers-passwords.tpl
@@ -37,7 +37,7 @@
         {{- .Values.proxy.secretToken }}
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default dict }}
-        {{- if and $k8s_state (hasKey $k8s_state "JupyterHub.proxy_auth_token") }}
+        {{- if hasKey $k8s_state "JupyterHub.proxy_auth_token" }}
             {{- index $k8s_state "JupyterHub.proxy_auth_token" }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}
@@ -50,7 +50,7 @@
         {{- .Values.hub.cookieSecret }}
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default dict }}
-        {{- if and $k8s_state (hasKey $k8s_state "JupyterHub.cookie_secret") }}
+        {{- if hasKey $k8s_state "JupyterHub.cookie_secret" }}
             {{- index $k8s_state "JupyterHub.cookie_secret" }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}
@@ -63,7 +63,7 @@
         {{- .Values.hub.config.CryptKeeper.keys | join ";" }}
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default dict }}
-        {{- if and $k8s_state (hasKey $k8s_state "CryptKeeper.keys") }}
+        {{- if hasKey $k8s_state "CryptKeeper.keys" }}
             {{- index $k8s_state "CryptKeeper.keys" }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}

--- a/jupyterhub/templates/hub/_helpers-passwords.tpl
+++ b/jupyterhub/templates/hub/_helpers-passwords.tpl
@@ -36,9 +36,9 @@
     {{- if .Values.proxy.secretToken }}
         {{- .Values.proxy.secretToken }}
     {{- else }}
-        {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default dict }}
-        {{- if hasKey $k8s_state "JupyterHub.proxy_auth_token" }}
-            {{- index $k8s_state "JupyterHub.proxy_auth_token" }}
+        {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default (dict "data" (dict)) }}
+        {{- if hasKey $k8s_state.data "JupyterHub.proxy_auth_token" }}
+            {{- index $k8s_state.data "JupyterHub.proxy_auth_token" }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}
         {{- end }}
@@ -49,9 +49,9 @@
     {{- if .Values.hub.cookieSecret }}
         {{- .Values.hub.cookieSecret }}
     {{- else }}
-        {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default dict }}
-        {{- if hasKey $k8s_state "JupyterHub.cookie_secret" }}
-            {{- index $k8s_state "JupyterHub.cookie_secret" }}
+        {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default (dict "data" (dict)) }}
+        {{- if hasKey $k8s_state.data "JupyterHub.cookie_secret" }}
+            {{- index $k8s_state.data "JupyterHub.cookie_secret" }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}
         {{- end }}
@@ -62,9 +62,9 @@
     {{- if .Values.hub.config.CryptKeeper }}
         {{- .Values.hub.config.CryptKeeper.keys | join ";" }}
     {{- else }}
-        {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default dict }}
-        {{- if hasKey $k8s_state "CryptKeeper.keys" }}
-            {{- index $k8s_state "CryptKeeper.keys" }}
+        {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default (dict "data" (dict)) }}
+        {{- if hasKey $k8s_state.data "CryptKeeper.keys" }}
+            {{- index $k8s_state.data "CryptKeeper.keys" }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}
         {{- end }}

--- a/jupyterhub/templates/hub/_helpers-passwords.tpl
+++ b/jupyterhub/templates/hub/_helpers-passwords.tpl
@@ -5,6 +5,9 @@
     proxy.secretToken       / hub.config.JupyterHub.proxy_auth_token
     hub.cookieSecret        / hub.config.JupyterHub.cookie_secret
     auth.state.cryptoKey    / hub.config.CryptKeeper.keys
+
+    Note that lookup logic returns falsy value when run with
+    `helm diff upgrade`, so it is a bit troublesome to test.
 */}}
 
 {{/*

--- a/jupyterhub/templates/hub/_helpers-passwords.tpl
+++ b/jupyterhub/templates/hub/_helpers-passwords.tpl
@@ -10,21 +10,26 @@
 {{/*
     Returns given number of random Hex characters.
 
-    In practice, it generates up to 100 randAlphaNum strings
+    In practice, it generates up to 25 randAlphaNum strings
     that are filtered from non-hex characters and augmented
-    to the resulting string that is finally trimmed down.
+    to the resulting string that is finally trimmed down. We
+    do it multiple times as on average we filter out 4/15 of
+    the characters.
 */}}
 {{- define "jupyterhub.randHex" -}}
     {{- $result := "" }}
-    {{- range $i := until 100 }}
-        {{- if lt (len $result) . }}
-            {{- $rand_list := randAlphaNum . | splitList "" -}}
-            {{- $reduced_list := without $rand_list "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z" "A" "B" "C" "D" "E" "F" "G" "H" "I" "J" "K" "L" "M" "N" "O" "P" "Q" "R" "S" "T" "U" "V" "W" "X" "Y" "Z" }}
-            {{- $rand_string := join "" $reduced_list }}
-            {{- $result = print $result $rand_string -}}
+    {{- $context := . }}
+    {{- range $i := until 26 }}{{- /* 1-25 */}}
+        {{- if lt (len $result) $context }}
+            {{- $rand_anum_string := randAlphaNum $context }}
+            {{- $rand_anum_list := $rand_anum_string | splitList "" }}
+            {{- $rand_hex_list := without $rand_anum_list "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z" "A" "B" "C" "D" "E" "F" "G" "H" "I" "J" "K" "L" "M" "N" "O" "P" "Q" "R" "S" "T" "U" "V" "W" "X" "Y" "Z" }}
+            {{- $rand_hex_string := join "" $rand_hex_list }}
+            {{- $result = print $result $rand_hex_string }}
         {{- end }}
     {{- end }}
-    {{- $result | trunc . }}
+    {{- /* We shuffle the generated hex numbers for good measure */}}
+    {{- $result | trunc $context | shuffle }}
 {{- end }}
 
 {{- define "jupyterhub.config.JupyterHub.proxy_auth_token" -}}

--- a/jupyterhub/templates/hub/_helpers-passwords.tpl
+++ b/jupyterhub/templates/hub/_helpers-passwords.tpl
@@ -38,7 +38,7 @@
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default (dict "data" (dict)) }}
         {{- if hasKey $k8s_state.data "JupyterHub.proxy_auth_token" }}
-            {{- index $k8s_state.data "JupyterHub.proxy_auth_token" }}
+            {{- index $k8s_state.data "JupyterHub.proxy_auth_token" | b64dec }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}
         {{- end }}
@@ -51,7 +51,7 @@
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default (dict "data" (dict)) }}
         {{- if hasKey $k8s_state.data "JupyterHub.cookie_secret" }}
-            {{- index $k8s_state.data "JupyterHub.cookie_secret" }}
+            {{- index $k8s_state.data "JupyterHub.cookie_secret" | b64dec }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}
         {{- end }}
@@ -64,7 +64,7 @@
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub-secret.fullname" .) | default (dict "data" (dict)) }}
         {{- if hasKey $k8s_state.data "CryptKeeper.keys" }}
-            {{- index $k8s_state.data "CryptKeeper.keys" }}
+            {{- index $k8s_state.data "CryptKeeper.keys" | b64dec }}
         {{- else }}
             {{- include "jupyterhub.randHex" 64 }}
         {{- end }}

--- a/jupyterhub/templates/hub/_helpers-passwords.tpl
+++ b/jupyterhub/templates/hub/_helpers-passwords.tpl
@@ -13,26 +13,19 @@
 {{/*
     Returns given number of random Hex characters.
 
-    In practice, it generates up to 25 randAlphaNum strings
-    that are filtered from non-hex characters and augmented
-    to the resulting string that is finally trimmed down. We
-    do it multiple times as on average we filter out 4/15 of
-    the characters.
+    - randNumeric 4 | atoi generates a random number in [0, 10^4)
+      This is a range range evenly divisble by 16, but even if off by one,
+      that last partial interval offsetting randomness is only 1 part in 625.
+    - mod N 16 maps to the range 0-15
+    - printf "%x" represents a single number 0-15 as a single hex character
 */}}
 {{- define "jupyterhub.randHex" -}}
     {{- $result := "" }}
-    {{- $context := . }}
-    {{- range $i := until 26 }}{{- /* 1-25 */}}
-        {{- if lt (len $result) $context }}
-            {{- $rand_anum_string := randAlphaNum $context }}
-            {{- $rand_anum_list := $rand_anum_string | splitList "" }}
-            {{- $rand_hex_list := without $rand_anum_list "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z" "A" "B" "C" "D" "E" "F" "G" "H" "I" "J" "K" "L" "M" "N" "O" "P" "Q" "R" "S" "T" "U" "V" "W" "X" "Y" "Z" }}
-            {{- $rand_hex_string := join "" $rand_hex_list }}
-            {{- $result = print $result $rand_hex_string }}
-        {{- end }}
+    {{- range $i := until . }}
+        {{- $rand_hex_char := mod (randNumeric 4 | atoi) 16 | printf "%x" }}
+        {{- $result = print $result $rand_hex_char }}
     {{- end }}
-    {{- /* We shuffle the generated hex numbers for good measure */}}
-    {{- $result | trunc $context | shuffle }}
+    {{- $result }}
 {{- end }}
 
 {{- define "jupyterhub.config.JupyterHub.proxy_auth_token" -}}


### PR DESCRIPTION
I'm debugging an issue with the seed secrets PR which seemingly misbehaves a bit.

## Action points
- [x] The randHex function gives never gives me a leading hex character with a-f, only 0-9. Whyyyyyyyyyyyyyy?
  Unless my algorithm is implemented wrong, it should mean that randAlphaNum first a-f letter is always showing up after its first 0-9 digit for some reason.
  Answer: it turns out `randAlphaNum 1` in helm/sprig always starts with a number. See 9f0889c.
- [x] `helm diff` in the CI system under the upgrade dev job make it seem like passwords were generated both during the installation of the latest dev release and the local chart upgrade instead of re-using the existing value from the k8s Secret. Why?
  Answer: The logic failed as I forgot to inspect the `data` value. See f243d3c
- [x] We also need to normalize the fetched value to a non-base64 encoded string. a6d8e32