### PR TITLE
ci: stop using --long as chartpress 1.0.0 makes it not needed

### DIFF
--- a/ci/publish
+++ b/ci/publish
@@ -10,9 +10,6 @@ set -eux
 # branch of jupyterhub/helm-chart. We have installed a private SSH key within
 # the ~/.ssh folder with permissions to push to jupyterhub/helm-chart.
 if [[ $GITHUB_REF != refs/tags/* ]]; then
-    # Using --long, we are ensured to get a build suffix, which ensures we don't
-    # build the same tag twice.
-    #
     # Using --extra-message, we help readers of merged PRs to know what version
     # they need to bump to in order to make use of the PR. This is enabled by a
     # GitHub notificaiton in the PR like "Github Action user pushed a commit to
@@ -29,7 +26,7 @@ if [[ $GITHUB_REF != refs/tags/* ]]; then
     PR_OR_HASH=$(git log -1 --pretty=%h-%B | head -n1 | sed 's/^.*\(#[0-9]*\).*/\1/' | sed 's/^\([0-9a-f]*\)-.*/@\1/')
     LATEST_COMMIT_TITLE=$(git log -1 --pretty=%B | head -n1)
     EXTRA_MESSAGE="${GITHUB_REPOSITORY}${PR_OR_HASH} ${LATEST_COMMIT_TITLE}"
-    chartpress --push --publish-chart --long --extra-message "${EXTRA_MESSAGE}"
+    chartpress --push --publish-chart --extra-message "${EXTRA_MESSAGE}"
 else
     # Setting a tag explicitly enforces a rebuild if this tag had already been
     # built and we wanted to override it.


### PR DESCRIPTION
Chartpress 1.0.0 which we now use doesn't push a chart that is already
published unless we also pass --force-publish-chart, due to that we no
longer need --long when publishing our charts.

See https://github.com/jupyterhub/chartpress/pull/102