### PR TITLE
Allow ingress.hosts to be omitted for a more generic rule

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -152,7 +152,7 @@ jobs:
       - name: Await local ACME server
         uses: jupyterhub/action-k8s-await-workloads@v1
         with:
-          timeout: 90
+          timeout: 150
           max-restarts: 0
 
       - name: "(Upgrade) Install ${{ matrix.upgrade-from }} chart"
@@ -211,7 +211,7 @@ jobs:
         if: matrix.test == 'upgrade'
         uses: jupyterhub/action-k8s-await-workloads@v1
         with:
-          timeout: 90
+          timeout: 150
           max-restarts: 0
 
       - name: "(Upgrade) Await ${{ matrix.upgrade-from }} chart cert acquisition"
@@ -228,7 +228,7 @@ jobs:
       - name: "Await local chart"
         uses: jupyterhub/action-k8s-await-workloads@v1
         with:
-          timeout: 90
+          timeout: 150
           max-restarts: 0
 
       - name: Await local chart cert acquisition

--- a/doc/source/administrator/advanced.md
+++ b/doc/source/administrator/advanced.md
@@ -14,34 +14,33 @@ installations.
 
 ## Ingress
 
-If you are using a Kubernetes Cluster that does not provide public IPs for
-services directly, you need to use a [Kubernetes Ingress
+The Helm chart can be configured to create a [Kubernetes Ingress
 resource](https://kubernetes.io/docs/concepts/services-networking/ingress/) to
-get traffic into your JupyterHub. This varies wildly based on how your cluster
-was set up, which is why this is in the 'Advanced' section.
+expose JupyterHub using an [Ingress
+controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
 
-You can enable the required Ingress resources with the following in your
-`config.yaml`
+```note
+Not all k8s clusters are setup with an Ingress controller by default. If you need to
+install one manually, we recommend using
+[ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/master/docs/deploy/index.md#using-helm).
+```
+
+The minimal example to expose JupyterHub using an Ingress resource is the following:
+
+```yaml
+ingress:
+  enabled: true
+```
+
+Typically you should declare that only traffic to a certain domain name should
+be accepted though to avoid conflicts with other Ingress resources.
 
 ```yaml
 ingress:
   enabled: true
   hosts:
-    - <hostname>
+    - hub.example.com
 ```
-
-You can specify multiple hosts that should be routed to the hub by listing them
-under `ingress.hosts`.
-
-Note that you need to install and configure an [Ingress
-controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)
-for the ingress object to work.
-
-We recommend the community-maintained [nginx-ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress)
-controller, [**kubernetes/ingress-nginx**](https://github.com/kubernetes/ingress-nginx).
-Note that Nginx maintains two additional ingress controllers.
-For most use cases, we recommend the community maintained **kubernetes/ingress-nginx** since that
-is the ingress controller that the development team has the most experience using.
 
 ### Ingress and Automatic HTTPS with kube-lego & Let's Encrypt
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -10,7 +10,7 @@ and watching for both those pods to be in status 'Running'.
 
 You can find the public IP of the JupyterHub by doing:
 
- kubectl --namespace={{ .Release.Namespace }} get svc proxy-public
+ kubectl --namespace={{ .Release.Namespace }} get svc {{ include "jupyterhub.proxy-public.fullname" . }}
 
 It might take a few minutes for it to appear!
 

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
   defaultBackend:
     service:
-      name: proxy-public
+      name: {{ include "jupyterhub.proxy-public.fullname" . }}
       port:
         name: http
   {{- else }}
@@ -36,7 +36,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: proxy-public
+                name: {{ include "jupyterhub.proxy-public.fullname" $ }}
                 port:
                   name: http
             {{- else }}

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -22,9 +22,10 @@ spec:
         name: http
   {{- else }}
   backend:
-    serviceName: {{ include "jupyterhub.proxy-public.fullname" $ }}
+    serviceName: {{ include "jupyterhub.proxy-public.fullname" . }}
     servicePort: 80
   {{- end }}
+  {{- if .Values.ingress.hosts }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host | quote }}
@@ -44,6 +45,7 @@ spec:
               servicePort: 80
             {{- end }}
     {{- end }}
+  {{- end }}
   {{- with .Values.ingress.tls }}
   tls:
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -14,17 +14,6 @@ metadata:
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-  defaultBackend:
-    service:
-      name: {{ include "jupyterhub.proxy-public.fullname" . }}
-      port:
-        name: http
-  {{- else }}
-  backend:
-    serviceName: {{ include "jupyterhub.proxy-public.fullname" . }}
-    servicePort: 80
-  {{- end }}
   {{- if .Values.ingress.hosts }}
   rules:
     {{- range $host := .Values.ingress.hosts }}

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -14,11 +14,9 @@ metadata:
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.hosts }}
   rules:
-    {{- range $host := .Values.ingress.hosts }}
-    - host: {{ $host | quote }}
-      http:
+    {{- range $host := .Values.ingress.hosts | default (list "") }}
+    - http:
         paths:
           - path: {{ $.Values.hub.baseUrl }}{{ $.Values.ingress.pathSuffix }}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
@@ -33,8 +31,10 @@ spec:
               serviceName: {{ include "jupyterhub.proxy-public.fullname" $ }}
               servicePort: 80
             {{- end }}
+      {{- if $host }}
+      host: {{ $host | quote }}
+      {{- end }}
     {{- end }}
-  {{- end }}
   {{- with .Values.ingress.tls }}
   tls:
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -14,6 +14,17 @@ metadata:
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+  defaultBackend:
+    service:
+      name: proxy-public
+      port:
+        name: http
+  {{- else }}
+  backend:
+    serviceName: {{ include "jupyterhub.proxy-public.fullname" $ }}
+    servicePort: 80
+  {{- end }}
   rules:
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host | quote }}


### PR DESCRIPTION
## Review points
Feedback greatly appreciated if this seem to make sense as I've not thought it through so much myself!

1. __Complications__
   This won't cause complications for existing users, right?
1. __Customization__
   Do we need to let some part of this new section be configurable in any way, and if so, in what way and why?
1. __Implementation__
   Does the change technically seem to be correct?

## References
- [v1 Ingress](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressspec-v1-networking-k8s-io) `backend` -> {`serviceName`, `servicePort`}
- [v1beta1 Ingress](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressspec-v1beta1-networking-k8s-io) - `defaultBackend` -> `service` -> {`name`, `port` -> {`name`, `number`}}

Closes #1314