### PR TITLE
traefik / autohttps: bump v2.4.2 to v2.4.3

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -232,7 +232,7 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: traefik
-      tag: v2.4.1 # ref: https://hub.docker.com/_/traefik?tab=tags
+      tag: v2.4.2 # ref: https://hub.docker.com/_/traefik?tab=tags
       pullPolicy: ""
       pullSecrets: []
     hsts:


### PR DESCRIPTION
Contains a bugfix related to ACME, so potentially relevant to us.

https://github.com/traefik/traefik/releases/tag/v2.4.2