### PR TITLE
docs: package chart specific README.md with the chart

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -1,0 +1,18 @@
+# JupyterHub Helm chart
+
+[![Documentation](https://img.shields.io/badge/Documentation-z2jh.jupyter.org-blue?logo=read-the-docs&logoColor=white)](https://z2jh.jupyter.org)
+[![GitHub](https://img.shields.io/badge/Source_code-github-blue?logo=github&logoColor=white)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s)
+[![Discourse](https://img.shields.io/badge/Help_forum-discourse-blue?logo=discourse&logoColor=white)](https://discourse.jupyter.org/c/jupyterhub/z2jh-k8s)
+[![Gitter](https://img.shields.io/badge/Social_chat-gitter-blue?logo=gitter&logoColor=white)](https://gitter.im/jupyterhub/jupyterhub)
+<br>
+[![Latest stable release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20stable%20release&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.stable&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#jupyterhub)
+[![Latest pre-release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20pre-release&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.pre&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
+[![Latest development release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20dev%20release&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.latest&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
+
+The JupyterHub Helm chart is accompanied with an installation guide at [z2jh.jupyter.org](https://z2jh.jupyter.org). Together they enable you to deploy [JupyterHub](https://jupyterhub.readthedocs.io) in a Kubernetes cluster that can make Jupyter environments available to several thousands of simultaneous users.
+
+## History
+
+Much of the initial groundwork for this documentation is information learned from the successful use of JupyterHub and Kubernetes at UC Berkeley in their [Data 8](http://data8.org/) program.
+
+![](https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/_static/images/data8_audience.jpg)


### PR DESCRIPTION
### Summary
This PR adds a dedicated README.md specific to the Helm chart to packaged as part of the Helm chart and be available to read [here in artifacthub.io](https://artifacthub.io/packages/helm/jupyterhub/jupyterhub).

### Copy README.md or add chart specific README.md?
I concluded that I preferred to not copy the local GitHub repo's README.md as it was written with various assumptions that I felt would break if read at artificathub.io. This chart specific README.md was made very lightweight to ensure we minimize required maintenance.

### Preview

![image](https://user-images.githubusercontent.com/3837114/108017630-a2082900-7015-11eb-918b-d4a4ab610e79.png)

---

This PR closes #2011 and is the missing piece needed to continue with https://github.com/jupyterhub/helm-chart/issues/117.