### PR TITLE
hub image build: fix use of PIP_OVERRIDES arg

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -45,7 +45,7 @@ RUN PYCURL_SSL_LIBRARY=openssl \
 # Support overriding a package or two through passed docker --build-args.
 # ARG PIP_OVERRIDES="jupyterhub==1.3.0 git+https://github.com/consideratio/kubespawner.git"
 ARG PIP_OVERRIDES=
-RUN if [[ -n "$PIP_OVERRIDES" ]]; then \
+RUN if test -n "$PIP_OVERRIDES"; then \
         pip install --no-cache-dir $PIP_OVERRIDES; \
     fi
 


### PR DESCRIPTION
Default shell for Docker build is `sh`, the double bracket is not supported and pip overrides wont work.
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/runs/1804962086?check_suite_focus=true#step:8:1181

I used the `test` notation as few lines below.