### PR TITLE
ci: install pyyaml before publishing to generate json schema

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           . ./ci/common
           setup_helm
-          pip install --no-cache-dir chartpress
+          pip install --no-cache-dir chartpress pyyaml
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...


### PR DESCRIPTION
Forgot to add pyyaml as a dependency in the release workflow, which is used by the script generating the values.schema.json file before the chart is packaged.
