### PR TITLE
pdb: default to maxUnavailable=1 instead of minAvailable=1

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -890,9 +890,12 @@ properties:
             description: |
               Decides if a PodDisruptionBudget is created targeting the
               Deployment's pods.
+          maxUnavailable:
+            type: [integer, "null"]
+            description: |
+              The maximum number of pods required to not be available during
+              voluntary disruptions.
           minAvailable:
-            # FIXME: support maxUnavailable alongside minAvailable, making it
-            #        make sense for both to be null also.
             type: [integer, "null"]
             description: |
               The minimum number of pods required to be available during

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -893,7 +893,7 @@ properties:
           maxUnavailable:
             type: [integer, "null"]
             description: |
-              The maximum number of pods required to not be available during
+              The maximum number of pods that can be unavailable during
               voluntary disruptions.
           minAvailable:
             type: [integer, "null"]

--- a/jupyterhub/templates/hub/pdb.yaml
+++ b/jupyterhub/templates/hub/pdb.yaml
@@ -6,7 +6,12 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
+  {{- if not (typeIs "<nil>" .Values.hub.pdb.maxUnavailable) }}
+  maxUnavailable: {{ .Values.hub.pdb.maxUnavailable }}
+  {{- end }}
+  {{- if not (typeIs "<nil>" .Values.hub.pdb.minAvailable) }}
   minAvailable: {{ .Values.hub.pdb.minAvailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/templates/proxy/autohttps/pdb.yaml
+++ b/jupyterhub/templates/proxy/autohttps/pdb.yaml
@@ -6,7 +6,12 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
+  {{- if not (typeIs "<nil>" .Values.proxy.traefik.pdb.maxUnavailable) }}
+  maxUnavailable: {{ .Values.proxy.traefik.pdb.maxUnavailable }}
+  {{- end }}
+  {{- if not (typeIs "<nil>" .Values.proxy.traefik.pdb.minAvailable) }}
   minAvailable: {{ .Values.proxy.traefik.pdb.minAvailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -6,7 +6,12 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
+  {{- if not (typeIs "<nil>" .Values.proxy.chp.pdb.maxUnavailable) }}
+  maxUnavailable: {{ .Values.proxy.chp.pdb.maxUnavailable }}
+  {{- end }}
+  {{- if not (typeIs "<nil>" .Values.proxy.chp.pdb.minAvailable) }}
   minAvailable: {{ .Values.proxy.chp.pdb.minAvailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
@@ -6,7 +6,12 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
+  {{- if not (typeIs "<nil>" .Values.scheduling.userScheduler.pdb.maxUnavailable) }}
+  maxUnavailable: {{ .Values.scheduling.userScheduler.pdb.maxUnavailable }}
+  {{- end }}
+  {{- if not (typeIs "<nil>" .Values.scheduling.userScheduler.pdb.minAvailable) }}
   minAvailable: {{ .Values.scheduling.userScheduler.pdb.minAvailable }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -431,8 +431,8 @@ scheduling:
     tolerations: []
     pdb:
       enabled: true
-      maxUnavailable:
-      minAvailable: 1
+      maxUnavailable: 1
+      minAvailable:
     resources:
       requests:
         cpu: 50m

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -94,6 +94,7 @@ hub:
   services: {}
   pdb:
     enabled: false
+    maxUnavailable:
     minAvailable: 1
   networkPolicy:
     enabled: true
@@ -222,6 +223,7 @@ proxy:
       allowedIngressPorts: [http, https]
     pdb:
       enabled: false
+      maxUnavailable:
       minAvailable: 1
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
@@ -260,6 +262,7 @@ proxy:
       allowedIngressPorts: [http, https]
     pdb:
       enabled: false
+      maxUnavailable:
       minAvailable: 1
   secretSync:
     containerSecurityContext:
@@ -428,6 +431,7 @@ scheduling:
     tolerations: []
     pdb:
       enabled: true
+      maxUnavailable:
       minAvailable: 1
     resources:
       requests:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -115,6 +115,8 @@ hub:
   imagePullPolicy: Always
   pdb:
     enabled: true
+    maxUnavailable: 1
+    minAvailable: null
   networkPolicy:
     enabled: true
     egress:
@@ -182,6 +184,8 @@ proxy:
       allowedIngressPorts: [http, https]
     pdb:
       enabled: true
+      maxUnavailable: 1
+      minAvailable: 1
   traefik:
     extraPorts:
       - name: ssh
@@ -218,6 +222,8 @@ proxy:
       allowedIngressPorts: [http, https]
     pdb:
       enabled: true
+      maxUnavailable: null
+      minAvailable: 1
   secretSync:
     resources:
       requests:


### PR DESCRIPTION
If you want to lower the replicas of user-scheduler to 1, then you will get the same PDB issues we have had with hub/proxy (#1938) where they block upgrades etc because we have `minAvailable: 1` instead of `maxUnavailable: 1` in order to handle workloads.