### PR TITLE
doc: Update installation docs to refer to current latest version

### DIFF
--- a/doc/source/jupyterhub/installation.md
+++ b/doc/source/jupyterhub/installation.md
@@ -75,7 +75,7 @@ can try with `nano config.yaml`.
      --install $RELEASE jupyterhub/jupyterhub \
      --namespace $NAMESPACE \
      --create-namespace \
-     --version=0.10.6 \
+     --version=0.11.1 \
      --values config.yaml
    ```
 


### PR DESCRIPTION
This actually really kicked my butt. The way that authentication is configured was changed between 0.10.6 and 0.11.1; I couldn't figure out why my Jupyterhub instance would accept any user/password combo without complaining, and logs seemed to show that it just wasn't loading any of my configuration at all. This was very confusing!

It would be great if this version number could be tied in to the actual released version somehow, but I think that may be too much to ask - although I'm no sphinx expert, maybe it can be done.

It would also be great if unexpected configuration keys got a warning of some kind in logs. Wouldn't have helped here, but it will help for future changes to the way things are configured.