### PR TITLE
traefik/autohttps: bump traefik to v2.4.5 from v2.4.2

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -16,4 +16,3 @@ The JupyterHub Helm chart is accompanied with an installation guide at [z2jh.jup
 Much of the initial groundwork for this documentation is information learned from the successful use of JupyterHub and Kubernetes at UC Berkeley in their [Data 8](http://data8.org/) program.
 
 ![](https://raw.githubusercontent.com/jupyterhub/zero-to-jupyterhub-k8s/master/doc/source/_static/images/data8_audience.jpg)
-

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -234,7 +234,7 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: traefik
-      tag: v2.4.2 # ref: https://hub.docker.com/_/traefik?tab=tags
+      tag: v2.4.5 # ref: https://hub.docker.com/_/traefik?tab=tags
       pullPolicy:
       pullSecrets: []
     hsts:


### PR DESCRIPTION
Contain some ACME bugfixes as usual.