### PR TITLE
Fix Chart.yaml annotations for artifacthub.io image scanning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,14 @@ jobs:
         env:
           GITHUB_REPOSITORY: "${{ github.repository }}"
         run: |
+          # Create values.schema.yaml from schema.yaml.
           ./tools/generate-json-schema.py
+
+          # Append annotations to Chart.yaml with current images so that
+          # artifacthub.io can scan and provide vulnerability reports for them.
+          chartpress --no-build
           ./tools/set-chart-yaml-annotations.py
+
+          # Package the Helm chart and publish it to the gh-pages branch of
+          # the jupyterhub/helm-chart repo.
           ./ci/publish

--- a/README.md
+++ b/README.md
@@ -60,4 +60,3 @@ This repository is dual licensed under the Apache2 (to match the upstream
 Kubernetes [charts](https://github.com/helm/charts) repository) and
 3-clause BSD (to match the rest of Project Jupyter repositories) licenses. See
 the `LICENSE` file for more information!
-

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ This repository is dual licensed under the Apache2 (to match the upstream
 Kubernetes [charts](https://github.com/helm/charts) repository) and
 3-clause BSD (to match the rest of Project Jupyter repositories) licenses. See
 the `LICENSE` file for more information!
+


### PR DESCRIPTION
Followup of #2045 which worked except for I didn't make sure chartpress had updated values.yaml with relevant image tags before reading values.yaml as basis for the annotations to add to Chart.yaml.

This PR fixes that by running chartpress --skip-build before. Dummy commits ensure the chart will be republished with a new version in order to get the correct annotations in Chart.yaml and test the process works out correctly artifacthub.io 