### PR TITLE
Support setting resources to null to omit them

### DIFF
--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -208,10 +208,10 @@ strings become the name keys' values into $_.res */}}
 {{- end }}
 
 {{- /*
-  jupyterhub.resources:
+  jupyterhub.singleuser.resources:
     The resource request of a singleuser.
 */}}
-{{- define "jupyterhub.resources" -}}
+{{- define "jupyterhub.singleuser.resources" -}}
 {{- $r1 := .Values.singleuser.cpu.guarantee -}}
 {{- $r2 := .Values.singleuser.memory.guarantee -}}
 {{- $r3 := .Values.singleuser.extraResource.guarantees -}}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -161,8 +161,10 @@ spec:
               subPath: {{ . | quote }}
               {{- end }}
             {{- end }}
+          {{- with .Values.hub.resources }}
           resources:
-            {{- .Values.hub.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           {{- with .Values.hub.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -81,8 +81,10 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          {{- with .Values.prePuller.resources }}
           resources:
-            {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           {{- with .Values.prePuller.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
@@ -96,8 +98,10 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          {{- with .Values.prePuller.resources }}
           resources:
-            {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           {{- with .Values.prePuller.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
@@ -111,8 +115,10 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          {{- with $.Values.prePuller.resources }}
           resources:
-            {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           {{- with $.Values.prePuller.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
@@ -130,8 +136,10 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          {{- with $.Values.prePuller.resources }}
           resources:
-            {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           {{- with $.Values.prePuller.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
@@ -149,8 +157,10 @@ spec:
             - /bin/sh
             - -c
             - echo "Pulling complete"
+          {{- with $.Values.prePuller.resources }}
           resources:
-            {{- $.Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           {{- with $.Values.prePuller.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
@@ -159,8 +169,10 @@ spec:
       containers:
         - name: pause
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}
+          {{- with .Values.prePuller.resources }}
           resources:
-            {{- .Values.prePuller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           {{- with .Values.prePuller.pause.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -66,6 +66,8 @@ spec:
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
+          {{- with .Values.prePuller.hook.resources }}
           resources:
-            {{- .Values.prePuller.hook.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -88,8 +88,10 @@ spec:
           {{- with .Values.proxy.traefik.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
+          {{- with .Values.proxy.traefik.resources }}
           resources:
-            {{- .Values.proxy.traefik.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -101,8 +101,10 @@ spec:
               mountPath: /etc/chp/tls
               readOnly: true
           {{- end }}
+          {{- with .Values.proxy.chp.resources }}
           resources:
-            {{- .Values.proxy.chp.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           env:
             - name: CONFIGPROXY_AUTH_TOKEN
               valueFrom:

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -45,12 +45,13 @@ spec:
       containers:
         - name: pause
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}
+          {{- if .Values.scheduling.userPlaceholder.resources }}
           resources:
-            {{- if .Values.scheduling.userPlaceholder.resources }}
             {{- .Values.scheduling.userPlaceholder.resources | toYaml | trimSuffix "\n" | nindent 12 }}
-            {{- else }}
+          {{- else if (include "jupyterhub.singleuser.resources" .) }}
+          resources:
             {{- include "jupyterhub.singleuser.resources" . | nindent 12 }}
-            {{- end }}
+          {{- end }}
           {{- with .Values.scheduling.userPlaceholder.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
             {{- if .Values.scheduling.userPlaceholder.resources }}
             {{- .Values.scheduling.userPlaceholder.resources | toYaml | trimSuffix "\n" | nindent 12 }}
             {{- else }}
-            {{- include "jupyterhub.resources" . | nindent 12 }}
+            {{- include "jupyterhub.singleuser.resources" . | nindent 12 }}
             {{- end }}
           {{- with .Values.scheduling.userPlaceholder.containerSecurityContext }}
           securityContext:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -79,8 +79,10 @@ spec:
             httpGet:
               path: /healthz
               port: 10251
+          {{- with .Values.scheduling.userScheduler.resources }}
           resources:
-            {{- .Values.scheduling.userScheduler.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+          {{- end }}
           {{- with .Values.scheduling.userScheduler.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}


### PR DESCRIPTION
It wasn't possible to reset the resource requests such as `hub.resources` to `null` because of our helm template logic assumed an object. This PR makes it so that if a .resources chart config value is `null`, then the resources section will be omitted.