### PR TITLE
ci: stop accepting test failures in k8s 1.20

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -100,10 +100,6 @@ jobs:
         include:
           - k3s-channel: v1.20
             test: install
-            # FIXME: stop accepting failure when 1.20.3 is available for k3s and
-            #        this issue is resolved:
-            #        https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1962
-            accept-failure: true
           - k3s-channel: v1.19
             test: install
           - k3s-channel: v1.18


### PR DESCRIPTION
Closes #1962. We no longer need to accept test failures intermittently caused by a regression in k8s 1.20, as it is fixed in 1.20.4