### PR TITLE
Add option to disable http port on LoadBalancer service

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -857,7 +857,7 @@ properties:
             description: |
               Default `false`.
 
-              If `true` disables service HTTP traffic on port 80, and therefore forcing use of HTTPS.
+              If `true`, port 80 for incoming HTTP traffic will no longer be exposed. This should not be used with `proxy.https.type=letsencrypt` or `proxy.https.enabled=false` as it would remove the only exposed port.
           extraPorts:
             type: list
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -852,6 +852,12 @@ properties:
                 type: integer
                 description: |
                   The HTTPS port the proxy-public service should be exposed on.
+          disableHttpPort:
+            type: boolean
+            description: |
+              Default `false`.
+
+              If `true` disables service HTTP traffic on port 80, and therefore forcing use of HTTPS. 
           extraPorts:
             type: list
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -857,7 +857,7 @@ properties:
             description: |
               Default `false`.
 
-              If `true` disables service HTTP traffic on port 80, and therefore forcing use of HTTPS. 
+              If `true` disables service HTTP traffic on port 80, and therefore forcing use of HTTPS.
           extraPorts:
             type: list
             description: |

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -57,12 +57,14 @@ spec:
       nodePort: {{ . }}
       {{- end }}
     {{- end }}
+    {{- if eq .Values.proxy.service.disableHttp true }}
     - name: http
       port: 80
       targetPort: http
       {{- with .Values.proxy.service.nodePorts.http }}
       nodePort: {{ . }}
       {{- end }}
+    {{- end }}
     {{- with .Values.proxy.service.extraPorts }}
     {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
     {{- end }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -57,7 +57,7 @@ spec:
       nodePort: {{ . }}
       {{- end }}
     {{- end }}
-    {{- if eq .Values.proxy.service.disableHttp true }}
+    {{- if ne .Values.proxy.service.disableHttpPort true }}
     - name: http
       port: 80
       targetPort: http

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -175,7 +175,7 @@ proxy:
     nodePorts:
       http:
       https:
-    disableHttp: false
+    disableHttpPort: false
     extraPorts: []
     loadBalancerIP:
     loadBalancerSourceRanges: []

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -175,6 +175,7 @@ proxy:
     nodePorts:
       http:
       https:
+    disableHttp: false
     extraPorts: []
     loadBalancerIP:
     loadBalancerSourceRanges: []


### PR DESCRIPTION
This is to disable `http/80` LoadBalancer port when deploying with `offload` proxy service type.
Without this, even though the hub resides behind the https terminating proxy, `http/80` port is still available, and even reuses the cookies from `https/443` endpoint.