### PR TITLE
Fix spawner env injection example.

### DIFF
--- a/doc/source/administrator/advanced.md
+++ b/doc/source/administrator/advanced.md
@@ -105,9 +105,23 @@ Code. Some examples of things you can do:
 Unfortunately, you have to write your python _in_ your YAML file. There's no way
 to include a file in `config.yaml`.
 
-You must specify `hub.extraConfig` as a dictionary. This enables you to
-logically split your customizations when there is more than one. The code will
-be evaluated in alphabetical sorted order of the key.
+You can specify `hub.extraConfig` as a raw string (remember to use the `|` for multi-line
+YAML strings):
+
+```yaml
+hub:
+  extraConfig: |
+    import time
+    c.KubeSpawner.environment.update(
+        {
+            "CURRENT_TIME": str(time.time())
+        }
+    )
+```
+
+You can also specify `hub.extraConfig` as a dictionary, if you want to logically
+split your customizations. The code will be evaluated in alphabetical sorted
+order of the key.
 
 ```yaml
 hub:
@@ -118,6 +132,7 @@ hub:
           {
               "CURRENT_TIME": str(time.time())
           }
+      # some code
     10-second-config: |
       # some other code
 ```

--- a/doc/source/administrator/advanced.md
+++ b/doc/source/administrator/advanced.md
@@ -114,7 +114,7 @@ hub:
   extraConfig:
     00-first-config: |
       import time
-      c.Spawner.environment.update(
+      c.KubeSpawner.environment.update(
           {
               "CURRENT_TIME": str(time.time())
           }

--- a/doc/source/administrator/advanced.md
+++ b/doc/source/administrator/advanced.md
@@ -132,7 +132,7 @@ hub:
           {
               "CURRENT_TIME": str(time.time())
           }
-      # some code
+      )
     10-second-config: |
       # some other code
 ```

--- a/doc/source/administrator/advanced.md
+++ b/doc/source/administrator/advanced.md
@@ -105,27 +105,19 @@ Code. Some examples of things you can do:
 Unfortunately, you have to write your python _in_ your YAML file. There's no way
 to include a file in `config.yaml`.
 
-You can specify `hub.extraConfig` as a raw string (remember to use the `|` for multi-line
-YAML strings):
-
-```yaml
-hub:
-  extraConfig: |
-    import time
-    c.Spawner.environment += {
-       "CURRENT_TIME": str(time.time())
-    }
-```
-
-You can also specify `hub.extraConfig` as a dictionary, if you want to logically
-split your customizations. The code will be evaluated in alphabetical sorted
-order of the key.
+You must specify `hub.extraConfig` as a dictionary. This enables you to
+logically split your customizations when there is more than one. The code will
+be evaluated in alphabetical sorted order of the key.
 
 ```yaml
 hub:
   extraConfig:
     00-first-config: |
-      # some code
+      import time
+      c.Spawner.environment.update(
+          {
+              "CURRENT_TIME": str(time.time())
+          }
     10-second-config: |
       # some other code
 ```


### PR DESCRIPTION
I think there are three separate problems with the documented example for injecting an environment variable into the user container environment.

```yaml
hub:
  extraConfig: |
    import time
    c.Spawner.environment += {
       "CURRENT_TIME": str(time.time())
    }
```

1. The documentation claims that `extraConfig` accepts either a dict of strings or a single string (of Python code), but it actually only accepts the first one. If you give it a single string, following the documented example, it warns
    ```
    coalesce.go:196: warning: cannot overwrite table with non table for extraConfig (map[])
    ```
    and it does not take effect. See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/653 which seems to observe the same issue.
2. The documentation uses `+=` to update the `Spawner.environment` configurable, but that is not a legal operation on a dict or on the corresponding Configurable object. The logs:
    ```
    Loading /etc/jupyterhub/secret/values.yaml
    Loading extra config: 00-spawner-env-config
    [E 2021-02-23 18:07:58.648 JupyterHub app:2859]
        Traceback (most recent call last):
          File "/usr/local/lib/python3.8/dist-packages/jupyterhub/app.py", line 2856, in launch_instance_async
            await self.initialize(argv)
          File "/usr/local/lib/python3.8/dist-packages/jupyterhub/app.py", line 2347, in initialize
            self.load_config_file(self.config_file)
          File "/usr/local/lib/python3.8/dist-packages/traitlets/config/application.py", line 87, in inner
            return method(app, *args, **kwargs)
          File "/usr/local/lib/python3.8/dist-packages/traitlets/config/application.py", line 775, in load_config_file
            for (config, filename) in self._load_config_files(filename, path=path, log=self.log,
          File "/usr/local/lib/python3.8/dist-packages/traitlets/config/application.py", line 737, in _load_config_files
            config = loader.load_config()
          File "/usr/local/lib/python3.8/dist-packages/traitlets/config/loader.py", line 616, in load_config
            self._read_file_as_dict()
          File "/usr/local/lib/python3.8/dist-packages/traitlets/config/loader.py", line 648, in _read_file_as_dict
            exec(compile(f.read(), conf_filename, 'exec'), namespace, namespace)
          File "/etc/jupyterhub/jupyterhub_config.py", line 412, in <module>
            exec(config_py)
          File "<string>", line 3, in <module>
        TypeError: unsupported operand type(s) for +=: 'LazyConfigValue' and 'dict'
    ```
3. Configuring `c.Spawner.environment` has no effect on the environment. Instead, `c.KubeSpawner.environment` must be used.

I have confirmed that the revised example works as expected with Helm Chart version 0.11.1.