### PR TITLE
Fix schema validation for Spawner.cpu/memory limits/guarantees

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1490,9 +1490,9 @@ properties:
           for more info.
         properties:
           limit:
-            type: [string, "null"]
+            type: [number, "null"]
           guarantee:
-            type: [string, "null"]
+            type: [number, "null"]
       memory:
         type: object
         description: |
@@ -1502,9 +1502,9 @@ properties:
           for more info.
         properties:
           limit:
-            type: [string, "null"]
+            type: [number, string, "null"]
           guarantee:
-            type: [string, "null"]
+            type: [number, string, "null"]
             description: |
               Note that this field is referred to as *requests* by the Kubernetes API.
       image: *image-spec

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -39,7 +39,6 @@ hub:
   baseUrl: /
   cookieSecret:
   initContainers: []
-  uid:
   fsGid: 1000
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
- [mem_limit / mem_guarantee](https://github.com/jupyterhub/jupyterhub/blob/c3ca924ba896bf2da40cab29e2a08784850a945b/jupyterhub/spawner.py#L567) is a ByteSpecification, which can accept numbers, strings, and None.
- [cpu_limit / cpu_guarantee](https://github.com/jupyterhub/jupyterhub/blob/c3ca924ba896bf2da40cab29e2a08784850a945b/jupyterhub/spawner.py#L590) is a Float or None.

Closes #2068, closes #2069 which is like this PR.