### PR TITLE
Don't restart the proxy pod with each deploy

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -24,8 +24,9 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
       annotations:
-        # This lets us autorestart when the secret changes!
-        checksum/hub-secret: {{ include (print $.Template.BasePath "/hub/secret.yaml") . | sha256sum }}
+        # This restarts the pod when the proxy secret changes.
+        # The proxy secret is *only* present when doing manual HTTPS
+        # certs, so restarting is required to get those changes.
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum }}
         {{- with .Values.proxy.annotations }}
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
@@ -106,14 +107,13 @@ spec:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
           env:
+            # Restarting the proxy pod causes a temporary outage,
+            # so we should do it as few times as possible. Including
+            # the auth token here directly means the pod only restarts
+            # if the auth token changes, rather than when the hub-secret
+            # changes, since the latter happens all the time.
             - name: CONFIGPROXY_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  # NOTE: References the chart managed k8s Secret even if
-                  #       hub.existingSecret is specified to avoid using the
-                  #       lookup function on the user managed k8s Secret.
-                  name: {{ include "jupyterhub.hub.fullname" . }}
-                  key: hub.config.ConfigurableHTTPProxy.auth_token
+              value: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | quote }}
             {{- include "jupyterhub.extraEnv" .Values.proxy.chp.extraEnv | nindent 12 }}
           {{- with .Values.proxy.chp.image.pullPolicy }}
           imagePullPolicy: {{ . }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -26,8 +26,8 @@ spec:
       annotations:
         # We want to restart proxy only if the auth token changes
         # Other changes to the hub config should not restart.
-+       # We truncate to 4 chars to avoid leaking auth token info,
-+       # since someone could brute force the hash to obtain the token
+        # We truncate to 4 chars to avoid leaking auth token info,
+        # since someone could brute force the hash to obtain the token
         checksum/auth-token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | sha256sum | trunc 4 }}
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum }}
         {{- with .Values.proxy.annotations }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -25,8 +25,10 @@ spec:
         {{- end }}
       annotations:
         # We want to restart proxy only if the auth token changes
-        # Other changes to the hub config should not restart
-        checksum/auth-token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | sha256sum }}
+        # Other changes to the hub config should not restart.
++       # We truncate to 4 chars to avoid leaking auth token info,
++       # since someone could brute force the hash to obtain the token
+        checksum/auth-token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | sha256sum | trunc 4 }}
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum }}
         {{- with .Values.proxy.annotations }}
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -24,8 +24,9 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
       annotations:
-        # This lets us autorestart when the secret changes!
-        checksum/hub-secret: {{ include (print $.Template.BasePath "/hub/secret.yaml") . | sha256sum }}
+        # We want to restart proxy only if the auth token changes
+        # Other changes to the hub config should not restart
+        checksum/auth-token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | sha256sum }}
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum }}
         {{- with .Values.proxy.annotations }}
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -24,9 +24,8 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
       annotations:
-        # This restarts the pod when the proxy secret changes.
-        # The proxy secret is *only* present when doing manual HTTPS
-        # certs, so restarting is required to get those changes.
+        # This lets us autorestart when the secret changes!
+        checksum/hub-secret: {{ include (print $.Template.BasePath "/hub/secret.yaml") . | sha256sum }}
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum }}
         {{- with .Values.proxy.annotations }}
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
@@ -107,13 +106,14 @@ spec:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
           env:
-            # Restarting the proxy pod causes a temporary outage,
-            # so we should do it as few times as possible. Including
-            # the auth token here directly means the pod only restarts
-            # if the auth token changes, rather than when the hub-secret
-            # changes, since the latter happens all the time.
             - name: CONFIGPROXY_AUTH_TOKEN
-              value: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | quote }}
+              valueFrom:
+                secretKeyRef:
+                  # NOTE: References the chart managed k8s Secret even if
+                  #       hub.existingSecret is specified to avoid using the
+                  #       lookup function on the user managed k8s Secret.
+                  name: {{ include "jupyterhub.hub.fullname" . }}
+                  key: hub.config.ConfigurableHTTPProxy.auth_token
             {{- include "jupyterhub.extraEnv" .Values.proxy.chp.extraEnv | nindent 12 }}
           {{- with .Values.proxy.chp.image.pullPolicy }}
           imagePullPolicy: {{ . }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -28,8 +28,8 @@ spec:
         # Other changes to the hub config should not restart.
         # We truncate to 4 chars to avoid leaking auth token info,
         # since someone could brute force the hash to obtain the token
-        checksum/auth-token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | sha256sum | trunc 4 }}
-        checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum }}
+        checksum/auth-token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | sha256sum | trunc 4 | quote }}
+        checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum | quote }}
         {{- with .Values.proxy.annotations }}
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Restarting the proxy pod causes current user sessions to
drop until the pod restarts, the hub notices it, and sets up
all the routes again. On a hub with a few thousand users, this
can be minutes. Instead, we provide the proxy pod with just the
one key it needs, so it'll restart only if that changes.