### PR TITLE
allow override of CHP defaultTarget, errorTarget

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1126,6 +1126,22 @@ properties:
           livenessProbe: *probe-spec
           readinessProbe: *probe-spec
           resources: *resources-spec
+          defaultTarget:
+            type: [string, "null"]
+            description: |
+              Override the URL for the default routing target for the proxy.
+              Defaults to JupyterHub itself.
+              This will generally only have an effect while JupyterHub is not running,
+              as JupyterHub adds itself as the default target after it starts.
+          errorTarget:
+            type: [string, "null"]
+            description: |
+              Override the URL for the error target for the proxy.
+              Defaults to JupyterHub itself.
+              Useful to reduce load on the Hub
+              or produce more informative error messages than the Hub's default,
+              e.g. in highly customized deployments such as BinderHub.
+              See Configurable HTTP Proxy for details on implementing an error target.
       secretToken:
         type: [string, "null"]
         description: |

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -67,13 +67,14 @@ spec:
         - name: chp
           image: {{ .Values.proxy.chp.image.name }}:{{ .Values.proxy.chp.image.tag }}
           {{- $hubNameAsEnv := include "jupyterhub.hub.fullname" . | upper | replace "-" "_" }}
+          {{- $hubHost := printf "http://%s:$(%s_SERVICE_PORT)" (include "jupyterhub.hub.fullname" .) $hubNameAsEnv }}
           command:
             - configurable-http-proxy
             - "--ip=::"
             - "--api-ip=::"
             - --api-port=8001
-            - --default-target=http://{{ include "jupyterhub.hub.fullname" . }}:$({{ $hubNameAsEnv }}_SERVICE_PORT)
-            - --error-target=http://{{ include "jupyterhub.hub.fullname" . }}:$({{ $hubNameAsEnv }}_SERVICE_PORT)/hub/error
+            - --default-target={{ .Values.proxy.chp.defaultTarget | default $hubHost }}
+            - --error-target={{ .Values.proxy.chp.errorTarget | default (printf "%s/hub/error" $hubHost) }}
             {{- if $manualHTTPS }}
             - --port=8443
             - --redirect-port=8000

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -209,6 +209,8 @@ proxy:
       requests:
         cpu: 200m
         memory: 512Mi
+    defaultTarget:
+    errorTarget:
     extraEnv: {}
     nodeSelector: {}
     tolerations: []

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -163,6 +163,8 @@ proxy:
       requests:
         cpu: 100m
         memory: 512Mi
+    defaultTarget: http://dummy.local/hello
+    errorTarget: http://dummy.local/error
     nodeSelector:
       node-type: mock
     tolerations:


### PR DESCRIPTION
mybinder.org-deploy used to set the whole CHP command, but this is no longer allowed (not quite sure how I feel about that - pros and cons), making it impossible to override these values.

- defaultTarget ~never makes sense, but it felt weird to leave it out.
  It may make sense in the future if JupyterHub develops an option
  to register itself *only* as a handler for `/hub`.
  This hasn't come up yet, as that behavior only makes sense when
  another service is providing the default target
  because requests to `/user/foo` will not behave sensibly without something handling the default route.
- errorTarget can be useful in API-only deployments like BinderHub to reduce load on the Hub
  and/or show more friendly messages to users who shouldn't need to know they are using jupyterhub