### PR TITLE
ci: increase test timeout for test reliability

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def request_data():
         "token": token,
         "hub_url": f'{hub_url.rstrip("/")}/hub/api',
         "headers": {"Authorization": f"token {token}"},
-        "test_timeout": 30,
+        "test_timeout": 60,
         "request_timeout": 25,
     }
 


### PR DESCRIPTION
I think our test became a bit unstable due to a too short timeout for user pods to start. This PR increase a timeout in the CI system for user pods to startup.

Here is an example failure: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/runs/2040709684?check_suite_focus=true