### PR TITLE
upload chart as github artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ name: Publish
 
 # Trigger the workflow's on pushed tags or commits to main/master branch.
 on:
+  pull_request:
   push:
     branches: ["main", "master"]
     tags: ["[0-9]+.[0-9]+.[0-9]+*"]
@@ -16,15 +17,15 @@ jobs:
   #
   # ref: https://github.com/jupyterhub/helm-chart
   # ref: https://hub.docker.com/orgs/jupyterhub
-  #
+
   publish:
-    if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
           # chartpress requires the full history
           fetch-depth: 0
+
       - uses: actions/setup-python@v2
         with:
           python-version: "3.8"
@@ -33,7 +34,7 @@ jobs:
         run: |
           . ./ci/common
           setup_helm
-          pip install --no-cache-dir chartpress pyyaml
+          pip install chartpress pyyaml
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...
@@ -45,7 +46,9 @@ jobs:
         # 3. Registering the public key (/tmp/id_ed25519.pub) as a deploy key
         #    with push rights for the jupyterhub/helm chart repo:
         #    https://github.com/jupyterhub/helm-chart/settings/keys
-        #
+        if: >
+          github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
+          && github.event_name == 'push'
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -60,7 +63,9 @@ jobs:
         #    https://hub.docker.com/orgs/jupyterhub/teams/bots/permissions
         # 3. Registering the username and password as a secret for this repo:
         #    https://github.com/jupyterhub/zero-to-jupyterhub-k8s/settings/secrets/actions
-        #
+        if: >
+          github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
+          && github.event_name == 'push'
         run: |
           docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
 
@@ -73,9 +78,7 @@ jobs:
           git config --global user.email "github-actions@example.local"
           git config --global user.name "GitHub Actions user"
 
-      - name: Publish images and chart with chartpress
-        env:
-          GITHUB_REPOSITORY: "${{ github.repository }}"
+      - name: build chart with chartpress
         run: |
           # Create values.schema.yaml from schema.yaml.
           ./tools/generate-json-schema.py
@@ -85,6 +88,25 @@ jobs:
           chartpress --no-build
           ./tools/set-chart-yaml-annotations.py
 
+      - name: Publish images and chart with chartpress
+        if: >
+          github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
+          && github.event_name == 'push'
+        env:
+          GITHUB_REPOSITORY: "${{ github.repository }}"
+        run: |
           # Package the Helm chart and publish it to the gh-pages branch of
           # the jupyterhub/helm-chart repo.
           ./ci/publish
+
+      - name: Package helm chart as a CI artifact
+        if: github.event_name == 'pull_request'
+        run: helm package jupyterhub
+
+      # ref: https://github.com/actions/upload-artifact
+      - uses: actions/upload-artifact@v2
+        if: github.event_name == 'pull_request'
+        with:
+          name: jupyterhub-${{ github.sha }}
+          path: "jupyterhub-*.tgz"
+          if-no-files-found: error

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,9 @@ name: Publish
 # Trigger the workflow's on pushed tags or commits to main/master branch.
 on:
   pull_request:
+    paths-ignore:
+      - "doc/**"
   push:
-    branches: ["main", "master"]
-    tags: ["[0-9]+.[0-9]+.[0-9]+*"]
 
 jobs:
   # Builds and pushes docker images to DockerHub and package the Helm chart and
@@ -30,6 +30,33 @@ jobs:
         with:
           python-version: "3.8"
 
+      - name: store whether we are publishing the chart
+        id: publishing
+        shell: python
+        env:
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.event.ref }}
+        run: |
+          import os
+          repo = os.environ["REPO"]
+          event = os.environ["EVENT"]
+          ref = os.environ["REF"]
+          publishing = ""
+          if (
+              repo == "jupyterhub/zero-to-jupyterhub-k8s"
+              and event == "push"
+              and (
+                  # any tag
+                  ref.startswith("refs/tags/")
+                  # or default branch
+                  or ref in {"refs/heads/main", "refs/heads/master"}
+              )
+          ):
+              publishing = "true"
+              print("Publishing chart")
+          print(f"::set-output name=publishing::{publishing}")
+
       - name: Install chart publishing dependencies (chartpress, helm)
         run: |
           . ./ci/common
@@ -46,9 +73,7 @@ jobs:
         # 3. Registering the public key (/tmp/id_ed25519.pub) as a deploy key
         #    with push rights for the jupyterhub/helm chart repo:
         #    https://github.com/jupyterhub/helm-chart/settings/keys
-        if: >
-          github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
-          && github.event_name == 'push'
+        if: steps.publishing.outputs.publishing
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -63,9 +88,7 @@ jobs:
         #    https://hub.docker.com/orgs/jupyterhub/teams/bots/permissions
         # 3. Registering the username and password as a secret for this repo:
         #    https://github.com/jupyterhub/zero-to-jupyterhub-k8s/settings/secrets/actions
-        if: >
-          github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
-          && github.event_name == 'push'
+        if: steps.publishing.outputs.publishing
         run: |
           docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
 
@@ -89,9 +112,7 @@ jobs:
           ./tools/set-chart-yaml-annotations.py
 
       - name: Publish images and chart with chartpress
-        if: >
-          github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
-          && github.event_name == 'push'
+        if: steps.publishing.outputs.publishing
         env:
           GITHUB_REPOSITORY: "${{ github.repository }}"
         run: |
@@ -100,12 +121,12 @@ jobs:
           ./ci/publish
 
       - name: Package helm chart as a CI artifact
-        if: github.event_name == 'pull_request'
+        if: steps.publishing.outputs.publishing == ''
         run: helm package jupyterhub
 
       # ref: https://github.com/actions/upload-artifact
       - uses: actions/upload-artifact@v2
-        if: github.event_name == 'pull_request'
+        if: steps.publishing.outputs.publishing == ''
         with:
           name: jupyterhub-${{ github.sha }}
           path: "jupyterhub-*.tgz"

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -13,12 +13,16 @@ on:
       - "**/test-docs.yaml"
       - "**.md"
       - "**/schema.yaml"
+      - ".github/workflows/*"
+      - "!.github/workflows/test-chart.yaml"
   push:
     paths-ignore:
       - "doc/**"
       - "**/test-docs.yaml"
       - "**.md"
       - "**/schema.yaml"
+      - ".github/workflows/*"
+      - "!.github/workflows/test-chart.yaml"
     branches-ignore:
       - "dependabot/**"
   workflow_dispatch:

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -174,7 +174,7 @@ jobs:
       # Build our images if needed and update values.yaml with the tags
       - name: Install and run chartpress
         run: |
-          pip3 install --no-cache-dir -r dev-requirements.txt
+          pip3 install -r dev-requirements.txt
           chartpress
 
       # Generate values.schema.json from schema.yaml


### PR DESCRIPTION
- runs publish workflow for push and pull request
- moves credential-requiring conditions to individual steps instead of workflow as a whole
- on pull request, upload as artifact instead of publishing to the chart repository

This will only *fully* work if there are no changes to images in the PR, since image upload won't happen without credentials.

closes #2043