### PR TITLE
Don't hard-code an old tag in customizing/user-environment.md

### DIFF
--- a/doc/source/jupyterhub/customizing/user-environment.md
+++ b/doc/source/jupyterhub/customizing/user-environment.md
@@ -38,12 +38,12 @@ image containing useful tools and libraries for datascience, complete these step
    ```yaml
    singleuser:
      image:
-       # Get the latest image tag at:
+       # You should replace the "latest" tag with a fixed version from:
        # https://hub.docker.com/r/jupyter/datascience-notebook/tags/
        # Inspect the Dockerfile at:
        # https://github.com/jupyter/docker-stacks/tree/master/datascience-notebook/Dockerfile
        name: jupyter/datascience-notebook
-       tag: 177037d09156
+       tag: latest
    ```
 
    ```{note}


### PR DESCRIPTION
The tag `177037d09156` has come up a few times recently on the Discourse forum: https://discourse.jupyter.org/search?q=177037d09156
I don't know if this is the source, but given it's ancient [(6 Aug 2018)](https://github.com/jupyter/docker-stacks/tree/177037d09156e557b334e4b3be2092e5965084d7) I think we should avoid specifying a tag here.

If you're not too keen on latest then maybe we could use a placeholder like `tag: <replace-me>` instead?