### PR TITLE
Update postgres db url dialect in schema docs

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -639,7 +639,7 @@ properties:
 
                  The general format of the connection string is:
                  ```
-                 postgres+psycopg2://<db-username>:<db-password>@<db-hostname>:<db-port>/<db-name>
+                 postgresql+psycopg2://<db-username>:<db-password>@<db-hostname>:<db-port>/<db-name>
                  ```
 
                  The user specified in the connection string must have the rights to create


### PR DESCRIPTION
The `postgres` dialect is deprecated and has been removed
in sqlalchemy 1.4, we should be using `postgresql` now. See
the discussion in https://github.com/jupyterhub/jupyterhub/pull/3383.