### PR TITLE
[NetPol] Fix notebook port in singleuser network policy

### DIFF
--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -40,7 +40,7 @@ spec:
 
     # allowed pods (hub.jupyter.org/network-access-singleuser) --> singleuser-server
     - ports:
-        - port: notebook-port
+        - port: 8888 
       from:
         # source 1 - labeled pods
         - podSelector:


### PR DESCRIPTION
The commit from #1670  breaks network policy in singleuser server.
Previously in version `0.9.1`, the default notebook port was set to `8888`, while from that commit onward, it was changed to `notebook-port`, which is not defined anywhere in the helm values. 
```
ingress:
  # allowed pods (hub.jupyter.org/network-access-singleuser) --> singleuser-server
  - ports:
      - port: notebook-port
```
compared to the one in `0.9.1`
```
ingress:
  - ports:
      - port: 8888
```

Is it supposed to be set via helm or was it just a mistake?

Cheers,
