### PR TITLE
Include customisation under "Administrator Guide"

### DIFF
--- a/doc/source/administrator/index.md
+++ b/doc/source/administrator/index.md
@@ -14,6 +14,7 @@ authentication
 optimization
 security
 upgrading
+../../jupyterhub/customization
 troubleshooting
 advanced
 cost


### PR DESCRIPTION
I frequently link to the items in the Z2JH customisation section when answering posts on Discourse.

Every time _without fail_ I make the same mistake :smile: 
1. Go to the Z2JH guide https://zero-to-jupyterhub.readthedocs.io/en/stable/
2. Click on `Administrator Guide`
3. Wonder why I can't find the user storage configuration section
4. Remember it's under `Setup JupyterHub`

Does anyone else have this problem? I've added customisation under the `Administrator Guide`. The downside is a the pages appear in two TOCs so I'm happy to try any other suggestions.