### PR TITLE
Publish Arm64 compatible images

### DIFF
--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -25,25 +25,21 @@ on:
 
 jobs:
   # TODO: this is just a quick test to check the arm64 docker images
-  # this should instead be done using chartpress
   # Based on
   # https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/local-registry.md
   # https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/multi-platform.md
   build_images:
     runs-on: ubuntu-20.04
-    strategy:
-      # Keep running even if one variation of the job fails
-      fail-fast: false
-      matrix:
-        image:
-          - hub
-          - image-awaiter
-          - network-tools
-          - secret-sync
-          # - singleuser-sample
-
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      # https://github.com/jupyterhub/chartpress/pull/124
+      - name: Install chartpress buildx-platforms-dev version
+        run: pip install --no-cache-dir chartpress@git+https://github.com/manics/chartpress.git@buildx-platforms-skip
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -60,9 +56,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push to local registry
-        uses: docker/build-push-action@v2
-        with:
-          context: images/${{ matrix.image }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/${{ github.repository_owner }}/z2jh-${{ matrix.image }}:dev
+        run: >-
+          chartpress --push --tag dev
+          --builder docker-buildx
+          --platform linux/amd64 --platform linux/arm64
+          --image-prefix ghcr.io/${{ github.repository_owner }}/z2jh-

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -37,9 +37,8 @@ jobs:
         with:
           python-version: "3.8"
 
-      # https://github.com/jupyterhub/chartpress/pull/124
-      - name: Install chartpress buildx-platforms-dev version
-        run: pip install --no-cache-dir chartpress@git+https://github.com/manics/chartpress.git@buildx-platforms-skip
+      - name: Install chartpress
+        run: pip install chartpress
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -46,17 +46,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      # https://github.com/docker/login-action/tree/v1.8.0#github-container-registry
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push to local registry
+      - name: Build a multiple architecture Docker image
         run: >-
-          chartpress --push --tag 0.0.1-dev
+          chartpress
           --builder docker-buildx
           --platform linux/amd64 --platform linux/arm64
-          --image-prefix ghcr.io/${{ github.repository_owner }}/z2jh-

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build and push to local registry
         run: >-
-          chartpress --push --tag dev
+          chartpress --push --tag 0.0.1-dev
           --builder docker-buildx
           --platform linux/amd64 --platform linux/arm64
           --image-prefix ghcr.io/${{ github.repository_owner }}/z2jh-

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -1,0 +1,68 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+#
+name: Test docker multiarch build
+
+# Trigger the workflow's on all PRs and pushes so that other contributors can
+# run tests in their own forks. Avoid triggering these tests on changes to
+# documentation only changes.
+on:
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - "**/test-docs.yaml"
+      - "**.md"
+      - "**/schema.yaml"
+  push:
+    paths-ignore:
+      - "doc/**"
+      - "**/test-docs.yaml"
+      - "**.md"
+      - "**/schema.yaml"
+    branches-ignore:
+      - "dependabot/**"
+  workflow_dispatch:
+
+jobs:
+  # TODO: this is just a quick test to check the arm64 docker images
+  # this should instead be done using chartpress
+  # Based on
+  # https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/local-registry.md
+  # https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/multi-platform.md
+  build_images:
+    runs-on: ubuntu-20.04
+    strategy:
+      # Keep running even if one variation of the job fails
+      fail-fast: false
+      matrix:
+        image:
+          - hub
+          - image-awaiter
+          - network-tools
+          - secret-sync
+          # - singleuser-sample
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # https://github.com/docker/login-action/tree/v1.8.0#github-container-registry
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to local registry
+        uses: docker/build-push-action@v2
+        with:
+          context: images/${{ matrix.image }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/z2jh-${{ matrix.image }}:dev

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -46,5 +46,8 @@ charts:
         valuesPath: prePuller.hook.image
 
       # singleuser-sample, a primitive user container to start with.
+      # Image is based on https://github.com/jupyter/docker-stacks/ which is amd64 only
       singleuser-sample:
         valuesPath: singleuser.image
+        skipPlatforms:
+          - linux/arm64

--- a/ci/publish
+++ b/ci/publish
@@ -6,6 +6,11 @@
 # Exit on errors, assert env vars, log commands
 set -eux
 
+PUBLISH_ARGS="--push --publish-chart \
+    --builder docker-buildx \
+    --platform linux/amd64 --platform linux/arm64 \
+    "
+
 # chartpress use git to push to our Helm chart repository, which is the gh-pages
 # branch of jupyterhub/helm-chart. We have installed a private SSH key within
 # the ~/.ssh folder with permissions to push to jupyterhub/helm-chart.
@@ -26,11 +31,11 @@ if [[ $GITHUB_REF != refs/tags/* ]]; then
     PR_OR_HASH=$(git log -1 --pretty=%h-%B | head -n1 | sed 's/^.*\(#[0-9]*\).*/\1/' | sed 's/^\([0-9a-f]*\)-.*/@\1/')
     LATEST_COMMIT_TITLE=$(git log -1 --pretty=%B | head -n1)
     EXTRA_MESSAGE="${GITHUB_REPOSITORY}${PR_OR_HASH} ${LATEST_COMMIT_TITLE}"
-    chartpress --push --publish-chart --extra-message "${EXTRA_MESSAGE}"
+    chartpress $PUBLISH_ARGS --extra-message "${EXTRA_MESSAGE}"
 else
     # Setting a tag explicitly enforces a rebuild if this tag had already been
     # built and we wanted to override it.
-    chartpress --push --publish-chart --tag "${GITHUB_REF:10}"
+    chartpress $PUBLISH_ARGS --tag "${GITHUB_REF:10}"
 fi
 
 # Let us log the changes chartpress did, it should include replacements for

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@
 #
 # ref: https://github.com/jupyterhub/chartpress
 #
-chartpress>=1.0.4
+chartpress>=1.1.0
 
 # pytest run tests that require requests and pyyaml
 pytest>=3.7.1

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -38,7 +38,17 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --upgrade --no-cache-dir \
         setuptools \
         pip
-RUN PYCURL_SSL_LIBRARY=openssl \
+
+# Automatically set by docker buildx
+ARG TARGETPLATFORM
+
+# psycopg2-binary not available for arm64
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        echo "Removing psycopg2-binary from dependencies ($TARGETPLATFORM)"; \
+        sed -i '/psycopg2-binary==/d' /tmp/requirements.txt; \
+        cat /tmp/requirements.txt; \
+    fi; \
+    PYCURL_SSL_LIBRARY=openssl \
     pip install --no-cache-dir \
         -r /tmp/requirements.txt
 

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -4,7 +4,13 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8
-RUN apt-get update && \
+
+# psycopg2-binary in requirements.txt is not compiled for linux/arm64
+# TODO: Use build stages to compile psycopg2-binary separately instead of
+# bloating the image size
+RUN EXTRA_PACKAGES=; \
+    if [ `uname -m` != 'x86_64' ]; then EXTRA_PACKAGES=libpq-dev; fi; \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
       git \
       vim \
@@ -20,6 +26,7 @@ RUN apt-get update && \
       sqlite3 \
       curl \
       dnsutils \
+      $EXTRA_PACKAGES \
       && \
     rm -rf /var/lib/apt/lists/*
 
@@ -38,17 +45,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --upgrade --no-cache-dir \
         setuptools \
         pip
-
-# Automatically set by docker buildx
-ARG TARGETPLATFORM
-
-# psycopg2-binary not available for arm64
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        echo "Removing psycopg2-binary from dependencies ($TARGETPLATFORM)"; \
-        sed -i '/psycopg2-binary==/d' /tmp/requirements.txt; \
-        cat /tmp/requirements.txt; \
-    fi; \
-    PYCURL_SSL_LIBRARY=openssl \
+RUN PYCURL_SSL_LIBRARY=openssl \
     pip install --no-cache-dir \
         -r /tmp/requirements.txt
 

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -8,8 +8,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # psycopg2-binary in requirements.txt is not compiled for linux/arm64
 # TODO: Use build stages to compile psycopg2-binary separately instead of
 # bloating the image size
-RUN EXTRA_PACKAGES=; \
-    if [ `uname -m` != 'x86_64' ]; then EXTRA_PACKAGES=libpq-dev; fi; \
+RUN EXTRA_APT_PACKAGES=; \
+    if [ `uname -m` != 'x86_64' ]; then EXTRA_APT_PACKAGES=libpq-dev; fi; \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       git \
@@ -26,7 +26,7 @@ RUN EXTRA_PACKAGES=; \
       sqlite3 \
       curl \
       dnsutils \
-      $EXTRA_PACKAGES \
+      $EXTRA_APT_PACKAGES \
       && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/secret-sync/Dockerfile
+++ b/images/secret-sync/Dockerfile
@@ -2,8 +2,11 @@ FROM python:3.8-alpine
 
 # VULN_SCAN_TIME=2021-03-27_00:01:53
 
+# Automatically set by docker buildx
+ARG TARGETPLATFORM
+
 # Note that we use tini-static, it embeds dependencies missing in alpine
-RUN wget -qO /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-static \
+RUN wget -qO /tini "https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-${TARGETPLATFORM#*/}" \
  && chmod +x /tini
 
 # Ensures written logs are made available directly

--- a/images/secret-sync/Dockerfile
+++ b/images/secret-sync/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.8-alpine
 
 # VULN_SCAN_TIME=2021-03-27_00:01:53
 
-# Automatically set by docker buildx
-ARG TARGETPLATFORM
-
 # Note that we use tini-static, it embeds dependencies missing in alpine
-RUN wget -qO /tini "https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-${TARGETPLATFORM#*/}" \
+RUN ARCH=`uname -m`; date; \
+    if [ "$ARCH" = x86_64 ]; then ARCH=amd64; fi; \
+    if [ "$ARCH" = aarch64 ]; then ARCH=arm64; fi; \
+    wget -qO /tini "https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-$ARCH" \
  && chmod +x /tini
 
 # Ensures written logs are made available directly


### PR DESCRIPTION
Part 1 of https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2119#issuecomment-812101837: Minor changes to get Docker images building on ARM64
- `hub`: `psycopg2-binary` is not available as a precompiled binary, so `libpq-dev` needs to be installed for compilation. This increases the build time and the image size. An alternative would be to omit PostgreSQL support from the arm64 image, what do you think?
- `secret-sync`: `tini` for the correct architecture needs to be downloaded.

- [x] This contains a temporary workflow just for testing, this will be removed. In the meantime you can pull the test images from `docker pull ghcr.io/manics/z2jh-{hub,image-awaiter,network-tools,secret-sync}:dev`. Not yet tested in a deployment