### PR TITLE
Support for Hub-managed services

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -369,6 +369,11 @@ for name, service in get_config("hub.services", {}).items():
     if api_token:
         service["api_token"] = api_token
 
+    # Support for Hub-managed services in k8s
+    if "k8s_managed_port" in service:
+        port = service.pop("k8s_managed_port")
+        service["url"] = f"http://hub:{port}"
+
     c.JupyterHub.services.append(service)
 
 

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -40,10 +40,10 @@ spec:
     # allowed pods (hub.jupyter.org/network-access-hub) --> hub
     - ports:
         - port: http
-          # Support for Hub-managed services in k8s
+        {{- /* Also accept traffic to ports for additional services running in hub pod /*}}
         {{- range $name, $config := .Values.hub.services }}
         {{- if hasKey $config "k8s_managed_port" }}
-        - port: {{ get $config "k8s_managed_port" }}
+        - port: {{ $config.k8s_managed_port }}
         {{- end }}
         {{- end }}
       from:

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -40,7 +40,7 @@ spec:
     # allowed pods (hub.jupyter.org/network-access-hub) --> hub
     - ports:
         - port: http
-        {{- /* Also accept traffic to ports for additional services running in the hub pod /*}}
+        {{- /* Also accept traffic to ports for additional services running in the hub pod */}}
         {{- range $name, $config := .Values.hub.services }}
         {{- if hasKey $config "k8s_managed_port" }}
         - port: {{ $config.k8s_managed_port }}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -40,6 +40,12 @@ spec:
     # allowed pods (hub.jupyter.org/network-access-hub) --> hub
     - ports:
         - port: http
+        # Support for Hub-managed services in k8s
+        {{- range $name, $config := .Values.hub.services }}
+        {{- if hasKey $config "k8s_managed_port" }}
+        - port: {{ get $config "k8s_managed_port" }}
+        {{- end }}
+        {{- end }}
       from:
         # source 1 - labeled pods
         - podSelector:

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -40,7 +40,7 @@ spec:
     # allowed pods (hub.jupyter.org/network-access-hub) --> hub
     - ports:
         - port: http
-        # Support for Hub-managed services in k8s
+          # Support for Hub-managed services in k8s
         {{- range $name, $config := .Values.hub.services }}
         {{- if hasKey $config "k8s_managed_port" }}
         - port: {{ get $config "k8s_managed_port" }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -31,11 +31,12 @@ spec:
       {{- with .Values.hub.service.ports.nodePort }}
       nodePort: {{ . }}
       {{- end }}
-      # Support for Hub-managed services in k8s
+    {{- /* Expose ports for additional services running in the hub pod /*}} 
     {{- range $name, $config := .Values.hub.services }}
     {{- if hasKey $config "k8s_managed_port" }}
-    - name: {{ $name | replace "_" "-"}}
-      port: {{ get $config "k8s_managed_port" }}
-      targetPort: {{ get $config "k8s_managed_port" }}
+    {{- $k8s_compliant_name := $name | lower | replace "_" "-" | trunc 63 | trimSuffix "-"}}
+    - name: {{ $k8s_compliant_name }}
+      port: {{ $config.k8s_managed_port }}
+      targetPort: {{ $config.k8s_managed_port }}
     {{- end }}
     {{- end }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -31,7 +31,7 @@ spec:
       {{- with .Values.hub.service.ports.nodePort }}
       nodePort: {{ . }}
       {{- end }}
-    # Support for Hub-managed services in k8s
+      # Support for Hub-managed services in k8s
     {{- range $name, $config := .Values.hub.services }}
     {{- if hasKey $config "k8s_managed_port" }}
     - name: {{ $name | replace "_" "-"}}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -35,7 +35,6 @@ spec:
     {{- range $name, $config := .Values.hub.services }}
     {{- if hasKey $config "k8s_managed_port" }}
     {{- $k8s_compliant_name := $name | lower | replace "_" "-" | trunc 63 | trimSuffix "-" }}
-    # jupyterhub service name: {{ $name }}
     - name: {{ $k8s_compliant_name }}
       port: {{ $config.k8s_managed_port }}
       targetPort: {{ $config.k8s_managed_port }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -25,8 +25,17 @@ spec:
   selector:
     {{- include "jupyterhub.matchLabels" . | nindent 4 }}
   ports:
-    - port: 8081
+    - name: http
+      port: 8081
       targetPort: http
       {{- with .Values.hub.service.ports.nodePort }}
       nodePort: {{ . }}
       {{- end }}
+    # Support for Hub-managed services in k8s
+    {{- range $name, $config := .Values.hub.services }}
+    {{- if hasKey $config "k8s_managed_port" }}
+    - name: {{ $name | replace "_" "-"}}
+      port: {{ get $config "k8s_managed_port" }}
+      targetPort: {{ get $config "k8s_managed_port" }}
+    {{- end }}
+    {{- end }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -31,7 +31,7 @@ spec:
       {{- with .Values.hub.service.ports.nodePort }}
       nodePort: {{ . }}
       {{- end }}
-    {{- /* Expose ports for additional services running in the hub pod /*}}
+    {{- /* Expose ports for additional services running in the hub pod */}}
     {{- range $name, $config := .Values.hub.services }}
     {{- if hasKey $config "k8s_managed_port" }}
     {{- $k8s_compliant_name := $name | lower | replace "_" "-" | trunc 63 | trimSuffix "-" }}


### PR DESCRIPTION
Fix https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2102

@yuvipanda @consideRatio I'll add documentation if you support the idea of a new `k8s_managed_port` option for Jupyterhub Services in values.yaml/config.yaml (or want to name it something else).  This PR would look for that value in `templates/hub/netpol.yaml` and `templates/hub/service.yaml` to add the appropriate ports, as well as a change in `jupyterhub_config.py` to translate the port into the appropriate service url.

@minrk on a somewhat related note, I think https://github.com/kafonek/fastapi_service_example is at a place where I can PR to jupyterhub examples, if you want to review it first.  The gif below is an example of using that as a Hub-managed service in z2jh.

![service_example](https://user-images.githubusercontent.com/3867768/113721553-a10e8200-96bd-11eb-9ec2-87612b41f615.gif)
