### PR TITLE
update k8 version for DO to currently available version

### DIFF
--- a/doc/source/kubernetes/digital-ocean/step-zero-digital-ocean.md
+++ b/doc/source/kubernetes/digital-ocean/step-zero-digital-ocean.md
@@ -31,7 +31,7 @@ If you prefer to use the Digital Ocean portal see the [Digital Ocean Get Started
 
    ```
    export DIGITALOCEAN_ENABLE_BETA=1
-   doctl k8s cluster create jupyter-kubernetes --region lon1 --version 1.18.14-do.0 --node-pool="name=worker-pool;count=3"
+   doctl k8s cluster create jupyter-kubernetes --region lon1 --node-pool="name=worker-pool;count=3"
    ```
 
 3. Export your cluster config.

--- a/doc/source/kubernetes/digital-ocean/step-zero-digital-ocean.md
+++ b/doc/source/kubernetes/digital-ocean/step-zero-digital-ocean.md
@@ -31,7 +31,7 @@ If you prefer to use the Digital Ocean portal see the [Digital Ocean Get Started
 
    ```
    export DIGITALOCEAN_ENABLE_BETA=1
-   doctl k8s cluster create jupyter-kubernetes --region lon1 --version 1.18.8-do.0 --node-pool="name=worker-pool;count=3"
+   doctl k8s cluster create jupyter-kubernetes --region lon1 --version 1.18.14-do.0 --node-pool="name=worker-pool;count=3"
    ```
 
 3. Export your cluster config.


### PR DESCRIPTION
Not using the version that was there gets error: 

```
Error: POST https://api.digitalocean.com/v2/kubernetes/clusters: 422 validation error: invalid version slug
```

For latest errors, calling `doctl kubernetes options versions` shows: 

```
=> doctl kubernetes options versions
Slug            Kubernetes Version
1.20.2-do.0     1.20.2
1.19.6-do.0     1.19.6
1.18.14-do.0    1.18.14
```