### PR TITLE
BREAKING: `singleuser.cmd` defaults to Docker image default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Here you can find upgrade changes in between releases and upgrade instructions.
 
+## [UNRELEASED]
+
+#### Breaking changes
+
+- **`singleuser.cmd` does not default to `jupyterhub-singleuser` - [#2138](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2138)**
+
+  Previous versions of Z2JH ignored the command (`CMD`) configured in the singleuser image by default.
+  This is no longer the case, when a singleuser pod is started the `CMD` from the container image will be used.
+  If you want to revert to the previous behaviour set `singleuser.cmd=jupyterhub-singleuser`.
+
+  This change was made to make it easier to support custom startup scripts such as those used in [`docker-stacks`](https://github.com/jupyter/docker-stacks),
+  as well as alternatives to jupyter-notebook including [Jupyterlab](https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html) and other applications based on [jupyter-server](https://jupyter-server.readthedocs.io/).
+
 ## [0.11]
 
 ### [0.11.1] - 2021-01-15

--- a/doc/source/jupyterhub/customizing/user-environment.md
+++ b/doc/source/jupyterhub/customizing/user-environment.md
@@ -69,6 +69,19 @@ If you'd like users to select an environment from **multiple docker images**,
 see {ref}`multiple-profiles`.
 ```
 
+The Docker image will be started with the [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint) and [`CMD`](https://docs.docker.com/engine/reference/builder/#cmd) defined in the image.
+You can override `CMD`, by setting `singleuser.cmd`.
+
+```{note}
+In versions of Z2JH prior to 1.0.0 the images default was overridden.
+To restore this behaviour:
+```
+
+```yaml
+singleuser:
+  cmd: jupyterhub-singleuser
+```
+
 (jupyterlab-by-default)=
 
 ## Use JupyterLab by default

--- a/doc/source/jupyterhub/customizing/user-environment.md
+++ b/doc/source/jupyterhub/customizing/user-environment.md
@@ -72,15 +72,16 @@ see {ref}`multiple-profiles`.
 The Docker image will be started with the [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint) and [`CMD`](https://docs.docker.com/engine/reference/builder/#cmd) defined in the image.
 You can override `CMD`, by setting `singleuser.cmd`.
 
-```{note}
-In versions of Z2JH prior to 1.0.0 the images default was overridden.
+````{note}
+In versions of Z2JH prior to 1.0.0 the image's default was overridden.
 To restore this behaviour:
-```
 
-```yaml
-singleuser:
-  cmd: jupyterhub-singleuser
-```
+   ```yaml
+   singleuser:
+     cmd: jupyterhub-singleuser
+   ```
+
+````
 
 (jupyterlab-by-default)=
 

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1681,7 +1681,18 @@ properties:
               type: string
       cmd:
         type: [array, string, "null"]
-        description: *kubespawner-native-config-description
+        description: |
+          The command and arguments passed to the container.
+          This is the equivalent of the `CMD` Dockerfile instruction.
+          If not set the default from the container image will be used.
+
+          Note that in versions of Z2JH prior to 1.0.0 this was set to
+          `jupyterhub-singleuser` instead of using the image's default.
+
+          See the [KubeSpawner
+          documentation](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html)
+          for more information.
+
       defaultUrl:
         type: [string, "null"]
         description: *kubespawner-native-config-description

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -374,7 +374,7 @@ singleuser:
   extraResource:
     limits: {}
     guarantees: {}
-  cmd: jupyterhub-singleuser
+  cmd:
   defaultUrl:
   extraPodConfig: {}
   profileList: []


### PR DESCRIPTION
This is breaking change. Instead of setting the start command to `jupyterhub-singleuser` it now defaults to whatever was set in the Docker image.

- The docker-stacks image [default command is `start-notebook.sh`](https://github.com/jupyter/docker-stacks/blob/8d32a5208ca11ffbe1f92a8464aacdd55863698e/base-notebook/Dockerfile#L149-L150)
- This looks for the `JUPYTERHUB_API_TOKEN` environment variable and [runs `start-singleuser.sh` if detected](https://github.com/jupyter/docker-stacks/blob/8d32a5208ca11ffbe1f92a8464aacdd55863698e/base-notebook/start-notebook.sh#L12-L14)
- Which then runs [`jupyterhub-singleuser` via `start.sh`](https://github.com/jupyter/docker-stacks/blob/8d32a5208ca11ffbe1f92a8464aacdd55863698e/base-notebook/start-singleuser.sh#L37-L39)
- Which amongst other things can [switch user or run setup hooks](https://github.com/jupyter/docker-stacks/blob/8d32a5208ca11ffbe1f92a8464aacdd55863698e/base-notebook/start.sh)
  See https://discourse.jupyter.org/t/pyspark-library-is-missing-from-jupyter-pyspark-notebook-when-running-with-jupyterhub-zero-to-jupyterhub-k8s/8450/3 for an example where this is important

In addition this may (or may not) make the [switch to JupyterLab 3 easier](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/776#issuecomment-804063583):
- If [docker-stacks switches the default to JupyterLab 3](https://github.com/jupyter/docker-stacks/issues/1217) we just need to bump the base singleuser image. We shouldn't have to worry about handling backwards compatibility since we just run whatever the default command is.
- If we make the switch ahead of docker-stacks then we could perhaps open a PR in docker-stacks to extend the use of the [`JUPYTER_ENABLE_LAB` environment variable from just `start-notebook.sh`](https://github.com/jupyter/docker-stacks/blob/8d32a5208ca11ffbe1f92a8464aacdd55863698e/base-notebook/start-notebook.sh#L15-L16) to also work in `start-singleuser.sh`. The big advantage here is we could then switch to JupyterLab 3 by setting `JUPYTER_ENABLE_LAB` without breaking images using JupyterLab 2 or those without JupyterLab. Since it's just an env var if your Docker image command doesn't care about it nothing breaks.