### PR TITLE
docs: fix rtd build by pinning docutils

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,3 +15,9 @@ pyyaml
 sphinx-autobuild
 sphinx-copybutton
 sphinxext-rediraffe
+
+# As of 0.17.0 we experience bug https://sourceforge.net/p/docutils/bugs/415/
+# when building using RTD. The build error can be seen in
+# https://readthedocs.org/projects/zero-to-jupyterhub/builds/13469169/.
+#
+docutils==0.16.*


### PR DESCRIPTION
This PR makes our documentation buil on RTD functional by pinning docutils to 0.16 as the recent version 0.17 seem to have a breaking change.

I'm not sure if there is tooling that should adjust to this, for example in myst-parser or not. Perhaps knowing about this is relevant for @chrisjsewell or @choldgraf? (EDIT: woops already reported in https://github.com/executablebooks/MyST-Parser/issues/343, and haha it is Chris Sewell who reported the docutils bug but I failed to notice ;D)

The issue we ran into is reported in docutils already: https://sourceforge.net/p/docutils/bugs/415/
The build failure we experienced is available to inspect at: https://readthedocs.org/projects/zero-to-jupyterhub/builds/13469169/
I could reproduce it locally if I ran the command ran in RTD to build the docs using docutils 0.17 but not using docutils 0.16.
