### PR TITLE
Bump CHP from 4.3.1 to 4.3.2 for arm64 compatibility

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -189,7 +189,7 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: jupyterhub/configurable-http-proxy
-      tag: 4.3.1
+      tag: 4.3.2
       pullPolicy:
       pullSecrets: []
     extraCommandLineFlags: []


### PR DESCRIPTION
Final piece of the checklist written down about arm64 compatible images here: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2125#issuecomment-817196142