### PR TITLE
publish workflow: build amd64 and arm64 prerequisites added

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,12 @@ jobs:
               print("Publishing chart")
           print(f"::set-output name=publishing::{publishing}")
 
+      - name: Set up QEMU (for docker buildx)
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx (for chartpress multi-arch builds)
+        uses: docker/setup-buildx-action@v1
+
       - name: Install chart publishing dependencies (chartpress, helm)
         run: |
           . ./ci/common


### PR DESCRIPTION
This is a complementary PR for #2125 that adds QEMU / Docker buildx before chartpress tries to build and publish multi-arch images.
