### PR TITLE
hub.service.extraPorts config option

### DIFF
--- a/doc/source/administrator/index.md
+++ b/doc/source/administrator/index.md
@@ -11,6 +11,7 @@ cloud-based deployments and tips for maintaining your deployment.
 architecture
 debug
 authentication
+services
 optimization
 security
 upgrading

--- a/doc/source/administrator/services.md
+++ b/doc/source/administrator/services.md
@@ -2,19 +2,19 @@
 
 # Services
 
-JupyterHub services (not to be confused with Kubernetes Service objects) are processes that interact with the JupyterHub API.  [nbgrader](https://nbgrader.readthedocs.io/en/stable/configuration/jupyterhub_config.html) and [culling idle Notebooks](https://github.com/jupyterhub/jupyterhub-idle-culler) are examples of production services, and there are minimal examples of "hello world" services in the [Jupyterhub examples repo](https://github.com/jupyterhub/jupyterhub/tree/master/examples).
+JupyterHub services (not to be confused with Kubernetes Service objects) are processes that interact with the JupyterHub API. [nbgrader](https://nbgrader.readthedocs.io/en/stable/configuration/jupyterhub_config.html) and [culling idle Notebooks](https://github.com/jupyterhub/jupyterhub-idle-culler) are examples of production services, and there are minimal examples of "hello world" services in the [Jupyterhub examples repo](https://github.com/jupyterhub/jupyterhub/tree/master/examples).
 
-Services can be run [externally](https://jupyterhub.readthedocs.io/en/stable/getting-started/services-basics.html) from the Hub, meaning they are started and stopped independently of the Hub and must know about things like their Hub authentication token on their own.  Alternatively, a service can be [Hub-managed](https://jupyterhub.readthedocs.io/en/stable/reference/services.html#hub-managed-services), where the Hub starts and stops the process and passes key information to the service via environment variables.
+Services can be run [externally](https://jupyterhub.readthedocs.io/en/stable/getting-started/services-basics.html) from the Hub, meaning they are started and stopped independently of the Hub and must know about things like their Hub authentication token on their own. Alternatively, a service can be [Hub-managed](https://jupyterhub.readthedocs.io/en/stable/reference/services.html#hub-managed-services), where the Hub starts and stops the process and passes key information to the service via environment variables.
 
 ## Hub-managed services in z2jh
 
-A Hub-managed service will run in the same container/pod as the Hub itself.  First, you'll need to install or copy the appropriate files for the service into your Hub image, either by creating a custom image derived from [`jupyterhub/k8s-hub`](https://hub.docker.com/r/jupyterhub/k8s-hub) or the [hub.extraFiles](schema_hub.extraFiles) configuration.  Keep in mind that your Hub container may need to install dependency libraries like flask or fastapi, depending on the service.  In those cases, you'll need a custom image.
+A Hub-managed service will run in the same container/pod as the Hub itself. First, you'll need to install or copy the appropriate files for the service into your Hub image, either by creating a custom image derived from [`jupyterhub/k8s-hub`](https://hub.docker.com/r/jupyterhub/k8s-hub) or the [hub.extraFiles](schema_hub.extraFiles) configuration. Keep in mind that your Hub container may need to install dependency libraries like flask or fastapi, depending on the service. In those cases, you'll need a custom image.
 
-In addition to the code for the service, you need to modify the Hub Kubernetes Service object to include [multiple ports](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services), and update the Hub Network Policy.  If you want to allow access from all sources, you can use [hub.networkPolicy.allowedIngressPorts](schema_hub.networkPolicy.allowedIngressPorts).  Otherwise if you want to more precisely control access, you can use [hub.networkPolicy.ingress](schema_hub.networkPolicy.ingress).
+In addition to the code for the service, you need to modify the Hub Kubernetes Service object to include [multiple ports](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services), and update the Hub Network Policy. If you want to allow access from all sources, you can use [hub.networkPolicy.allowedIngressPorts](schema_hub.networkPolicy.allowedIngressPorts). Otherwise if you want to more precisely control access, you can use [hub.networkPolicy.ingress](schema_hub.networkPolicy.ingress).
 
 ## Example service
 
-In the following snippet, I'm using a custom image that copies over the application code and installs the dependencies listed in the [fastapi service example](https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-fastapi).  
+In the following snippet, I'm using a custom image that copies over the application code and installs the dependencies listed in the [fastapi service example](https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-fastapi).
 
 ```
 # Dockerfile
@@ -24,7 +24,6 @@ FROM jupyterhub/k8s-hub:0.11.1
 COPY ./service-fastapi /usr/src/fastapi
 RUN python3 -m pip install -r /usr/src/fastapi/requirements.txt
 ```
-
 
 ```
 # config.yaml
@@ -50,15 +49,11 @@ hub:
           - podSelector:
               matchLabels:
                 hub.jupyter.org/network-access-hub: "true"
-  
+
   service:
     ports:
       extraPorts:
         - port: 8181
           targetPort: 8181
           name: fastapi
-```          
-
-
-
-
+```

--- a/doc/source/administrator/services.md
+++ b/doc/source/administrator/services.md
@@ -1,0 +1,64 @@
+(services)=
+
+# Services
+
+JupyterHub services (not to be confused with Kubernetes Service objects) are processes that interact with the JupyterHub API.  [nbgrader](https://nbgrader.readthedocs.io/en/stable/configuration/jupyterhub_config.html) and [culling idle Notebooks](https://github.com/jupyterhub/jupyterhub-idle-culler) are examples of production services, and there are minimal examples of "hello world" services in the [Jupyterhub examples repo](https://github.com/jupyterhub/jupyterhub/tree/master/examples).
+
+Services can be run [externally](https://jupyterhub.readthedocs.io/en/stable/getting-started/services-basics.html) from the Hub, meaning they are started and stopped independently of the Hub and must know about things like their Hub authentication token on their own.  Alternatively, a service can be [Hub-managed](https://jupyterhub.readthedocs.io/en/stable/reference/services.html#hub-managed-services), where the Hub starts and stops the process and passes key information to the service via environment variables.
+
+## Hub-managed services in z2jh
+
+A Hub-managed service will run in the same container/pod as the Hub itself.  First, you'll need to install or copy the appropriate files for the service into your Hub image, either by creating a custom image derived from [`jupyterhub/k8s-hub`](https://hub.docker.com/r/jupyterhub/k8s-hub) or the [hub.extraFiles](schema_hub.extraFiles) configuration.  Keep in mind that your Hub container may need to install dependency libraries like flask or fastapi, depending on the service.  In those cases, you'll need a custom image.
+
+In addition to the code for the service, you need to modify the Hub Kubernetes Service object to include [multiple ports](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services), and update the Hub Network Policy.  If you want to allow access from all sources, you can use [hub.networkPolicy.allowedIngressPorts](schema_hub.networkPolicy.allowedIngressPorts).  Otherwise if you want to more precisely control access, you can use [hub.networkPolicy.ingress](schema_hub.networkPolicy.ingress).
+
+## Example service
+
+In the following snippet, I'm using a custom image that copies over the application code and installs the dependencies listed in the [fastapi service example](https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-fastapi).  
+
+```
+# Dockerfile
+# 0.11.1 is latest stable release at the time of this writing
+FROM jupyterhub/k8s-hub:0.11.1
+
+COPY ./service-fastapi /usr/src/fastapi
+RUN python3 -m pip install -r /usr/src/fastapi/requirements.txt
+```
+
+
+```
+# config.yaml
+
+hub:
+  image:
+    name: myregistry/my-custom-hub-image
+    tag: latest
+
+  services:
+    fastapi:
+      url: http://hub:8181
+      command: ["/home/jovyan/.local/bin/uvicorn", "app:app", "--port", "8181", "--host", "0.0.0.0", "--app-dir", "/usr/src/fastapi"]
+      oauth_redirect_uri: "https://jupyterhub.mycloud.com/services/fastapi/oauth_callback"
+      environment:
+        PUBLIC_HOST: "https://jupyterhub.mycloud.com"
+
+  networkPolicy:
+    ingress:
+      - ports:
+        - port: 8181
+        from:
+          - podSelector:
+              matchLabels:
+                hub.jupyter.org/network-access-hub: "true"
+  
+  service:
+    ports:
+      extraPorts:
+        - port: 8181
+          targetPort: 8181
+          name: fastapi
+```          
+
+
+
+

--- a/doc/source/administrator/services.md
+++ b/doc/source/administrator/services.md
@@ -51,9 +51,8 @@ hub:
                 hub.jupyter.org/network-access-hub: "true"
 
   service:
-    ports:
-      extraPorts:
-        - port: 8181
-          targetPort: 8181
-          name: fastapi
+    extraPorts:
+      - port: 8181
+        targetPort: 8181
+        name: fastapi
 ```

--- a/doc/source/administrator/services.md
+++ b/doc/source/administrator/services.md
@@ -36,10 +36,18 @@ hub:
   services:
     fastapi:
       url: http://hub:8181
-      command: ["/home/jovyan/.local/bin/uvicorn", "app:app", "--port", "8181", "--host", "0.0.0.0", "--app-dir", "/usr/src/fastapi"]
-      oauth_redirect_uri: "https://jupyterhub.mycloud.com/services/fastapi/oauth_callback"
+      command:
+        - /home/jovyan/.local/bin/uvicorn
+        - app:app
+        - --port
+        - "8181"
+        - --host
+        - "0.0.0.0"
+        - --app-dir
+        - /usr/src/fastapi
+      oauth_redirect_uri: https://jupyterhub.mycloud.com/services/fastapi/oauth_callback
       environment:
-        PUBLIC_HOST: "https://jupyterhub.mycloud.com"
+        PUBLIC_HOST: https://jupyterhub.mycloud.com
 
   networkPolicy:
     ingress:

--- a/doc/source/administrator/services.md
+++ b/doc/source/administrator/services.md
@@ -16,7 +16,7 @@ In addition to the code for the service, you need to modify the Hub Kubernetes S
 
 In the following snippet, I'm using a custom image that copies over the application code and installs the dependencies listed in the [fastapi service example](https://github.com/jupyterhub/jupyterhub/tree/master/examples/service-fastapi).
 
-```
+```Dockerfile
 # Dockerfile
 # 0.11.1 is latest stable release at the time of this writing
 FROM jupyterhub/k8s-hub:0.11.1
@@ -25,7 +25,7 @@ COPY ./service-fastapi /usr/src/fastapi
 RUN python3 -m pip install -r /usr/src/fastapi/requirements.txt
 ```
 
-```
+```yaml
 # config.yaml
 
 hub:
@@ -44,7 +44,7 @@ hub:
   networkPolicy:
     ingress:
       - ports:
-        - port: 8181
+          - port: 8181
         from:
           - podSelector:
               matchLabels:

--- a/doc/source/kubernetes/amazon/step-zero-aws-eks.md
+++ b/doc/source/kubernetes/amazon/step-zero-aws-eks.md
@@ -80,16 +80,6 @@ This guide uses AWS to set up a cluster. This mirrors the steps found at [Gettin
 
    See [Getting Started with Amazon EKS][getting started with amazon eks] _Step 3: Launch and Configure Amazon EKS Worker Nodes_
 
-10. Preparing authenticator for Helm
-
-    There might be a better way to configure this
-
-    Since the described helm deployment in the next section uses RBAC, `system:anonymous` user must be given access to administer the cluster. This can be done by the following command
-
-    ```
-    kubectl create clusterrolebinding cluster-system-anonymous --clusterrole=cluster-admin --user=system:anonymous
-    ```
-
 [getting started with amazon eks]: https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html
 [selected regions]: https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
 

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -851,6 +851,12 @@ properties:
                 minimum: 0
                 description: |
                   The nodePort to deploy the hub service on.
+              extraPorts:
+                type: array
+                description: |
+                  Extra ports to add to the Hub Service object besides `hub` / `8081`.  
+                  This should be an array that includes `name`, `port`, and `targetPort`.
+                  See [Multi-port Services](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services) for more details.
           annotations:
             type: object
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -851,16 +851,16 @@ properties:
                 minimum: 0
                 description: |
                   The nodePort to deploy the hub service on.
-              extraPorts:
-                type: array
-                description: |
-                  Extra ports to add to the Hub Service object besides `hub` / `8081`.  
-                  This should be an array that includes `name`, `port`, and `targetPort`.
-                  See [Multi-port Services](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services) for more details.
           annotations:
             type: object
             description: |
               Kubernetes annotations to apply to the hub service.
+          extraPorts:
+            type: array
+            description: |
+              Extra ports to add to the Hub Service object besides `hub` / `8081`.  
+              This should be an array that includes `name`, `port`, and `targetPort`.
+              See [Multi-port Services](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services) for more details.    
           loadBalancerIP:
             type: [string, "null"]
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -860,7 +860,7 @@ properties:
             description: |
               Extra ports to add to the Hub Service object besides `hub` / `8081`.  
               This should be an array that includes `name`, `port`, and `targetPort`.
-              See [Multi-port Services](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services) for more details.    
+              See [Multi-port Services](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services) for more details.
           loadBalancerIP:
             type: [string, "null"]
             description: |

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -25,8 +25,13 @@ spec:
   selector:
     {{- include "jupyterhub.matchLabels" . | nindent 4 }}
   ports:
-    - port: 8081
+    - name: hub
+      port: 8081
       targetPort: http
       {{- with .Values.hub.service.ports.nodePort }}
       nodePort: {{ . }}
       {{- end }}
+
+    {{- with .Values.hub.service.ports.extraPorts }}
+    {{- . | toYaml | nindent 4}}
+    {{- end }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -32,6 +32,6 @@ spec:
       nodePort: {{ . }}
       {{- end }}
 
-    {{- with .Values.hub.service.ports.extraPorts }}
+    {{- with .Values.hub.service.extraPorts }}
     {{- . | toYaml | nindent 4}}
     {{- end }}

--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -33,5 +33,5 @@ spec:
       {{- end }}
 
     {{- with .Values.hub.service.extraPorts }}
-    {{- . | toYaml | nindent 4}}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -35,6 +35,7 @@ hub:
     annotations: {}
     ports:
       nodePort:
+      extraPorts: []
     loadBalancerIP:
   baseUrl: /
   cookieSecret:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -35,7 +35,7 @@ hub:
     annotations: {}
     ports:
       nodePort:
-      extraPorts: []
+    extraPorts: []
     loadBalancerIP:
   baseUrl: /
   cookieSecret:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -64,6 +64,13 @@ hub:
     type: ClusterIP
     ports:
       nodePort:
+    extraPorts:
+      - name: dummy-port-1
+        port: 8181
+        targetPort: 8181
+      - name: dummy-port-2
+        port: 8182
+        targetPort: string-named-target-port
   baseUrl: /
   activeServerLimit: 3
   deploymentStrategy:


### PR DESCRIPTION
This can close/replace https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2132 if you prefer this direction @consideRatio, and fixes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2102

This PR adds a `hub.service.extraPorts` empty array in `values.yaml`.  If it's filled out in `config.yaml` then the array gets dropped into `service.yaml` underneath the default `name: hub / port: 8081 / targetPort: http` item.  This is pretty much identical to `proxy.service.extraPorts`.

I updated `schema.yaml` and added an example into the Administrator section below Authentication because that's the closest layout match to the [JupyterHub docs](https://jupyterhub.readthedocs.io/en/stable/reference/services.html).

@consideRatio I still don't really understand what to put in the `tools/lint-and-validate-values.yaml`.  Should I just copy over what is in `proxy.service.extraPorts`?  
