### PR TITLE
Set author and pin SHA in vuln-scan workflow PR

### DIFF
--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -185,6 +185,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
+          author: jupyterhub vuln-scan bot <noreply@github.com>
           reviewers: "consideratio"
           branch: "vuln-scan-${{ matrix.image_ref }}"
           title: "Vulnerability patch in ${{ matrix.image_ref }}"

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -182,7 +182,7 @@ jobs:
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create or update a PR
         if: steps.analyze.outputs.proceed == 'yes'
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           author: jupyterhub vuln-scan bot <noreply@github.com>


### PR DESCRIPTION
Follow-up from https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2151#issuecomment-821198727

The committer defaults to `GitHub <noreply@github.com>` which is fine.