### PR TITLE
ci: update network tests as jupyter.org IPs changed

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -147,9 +147,9 @@ singleuser:
           # jupyter.org has multiple IPs associated with it, among them are these
           # two. We explicitly allow access to one, but leave out the the other.
           - ipBlock:
-              cidr: 104.28.8.110/32
+              cidr: 104.21.25.233/32
         # - ipBlock:
-        #     cidr: 104.28.9.110/32
+        #     cidr: 172.67.134.225/32
   extraEnv:
     TEST_ENV_FIELDREF_TO_NAMESPACE:
       valueFrom:

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -142,8 +142,8 @@ def test_spawn_netpol(api_request, jupyter_user, request_data):
         # explicitly pinned these IPs and explicitly pass the Host header in the
         # web-request in order to avoid test failures following additional IPs
         # are added.
-        allowed_jupyter_org_ip = "104.28.8.110"
-        blocked_jupyter_org_ip = "104.28.9.110"
+        allowed_jupyter_org_ip = "104.21.25.233"
+        blocked_jupyter_org_ip = "172.67.134.225"
 
         cmd_kubectl_exec = ["kubectl", "exec", pod_name, "--"]
         cmd_python_exec = ["python", "-c"]


### PR DESCRIPTION
It appears that the IPs we use to test the charts network policies have become outdated. They were IPs associated with jupyter.org's webhosting, so, the new IPs are the new IPs I got from doing `nslookup jupyter.org`.
