### PR TITLE
ci: precautions for security, update github_token permissions, pin actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,10 +58,14 @@ jobs:
           print(f"::set-output name=publishing::{publishing}")
 
       - name: Set up QEMU (for docker buildx)
-        uses: docker/setup-qemu-action@v1
+        # NOTE: Updates to the actions commit hash should go hand in hand with
+        #       updates in the test-docker-build workflow.
+        uses: docker/setup-qemu-action@25f0500ff22e406f7191a2a8ba8cda16901ca018 # associated tag: v1.0.2
 
       - name: Set up Docker Buildx (for chartpress multi-arch builds)
-        uses: docker/setup-buildx-action@v1
+        # NOTE: Updates to the actions commit hash should go hand in hand with
+        #       updates in the test-docker-build workflow.
+        uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609 # associated tag: v1.1.2
 
       - name: Install chart publishing dependencies (chartpress, helm)
         run: |

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -10,11 +10,13 @@ on:
   pull_request:
     paths:
       - "images/**"
-      - "**/test-docker-build.yaml"
+      - "chartpress.yaml"
+      - ".github/workflows/test-docker-build.yaml"
   push:
     paths:
       - "images/**"
-      - "**/test-docker-build.yaml"
+      - "chartpress.yaml"
+      - ".github/workflows/test-docker-build.yaml"
     branches-ignore:
       - "dependabot/**"
   workflow_dispatch:

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -5,29 +5,24 @@ name: Test docker multiarch build
 
 # Trigger the workflow's on all PRs and pushes so that other contributors can
 # run tests in their own forks. Avoid triggering these tests on changes to
-# documentation only changes.
+# changes not influencing the images.
 on:
   pull_request:
-    paths-ignore:
-      - "doc/**"
-      - "**/test-docs.yaml"
-      - "**.md"
-      - "**/schema.yaml"
+    paths:
+      - "images/**"
+      - "**/test-docker-build.yaml"
   push:
-    paths-ignore:
-      - "doc/**"
-      - "**/test-docs.yaml"
-      - "**.md"
-      - "**/schema.yaml"
+    paths:
+      - "images/**"
+      - "**/test-docker-build.yaml"
     branches-ignore:
       - "dependabot/**"
   workflow_dispatch:
 
 jobs:
-  # TODO: this is just a quick test to check the arm64 docker images
-  # Based on
-  # https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/local-registry.md
-  # https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/multi-platform.md
+  # This is a quick test to check the arm64 docker images based on:
+  # - https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/local-registry.md
+  # - https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/multi-platform.md
   build_images:
     runs-on: ubuntu-20.04
     steps:
@@ -40,11 +35,15 @@ jobs:
       - name: Install chartpress
         run: pip install chartpress
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      - name: Set up QEMU (for docker buildx)
+        # NOTE: Updates to the actions commit hash should go hand in hand with
+        #       updates in the publish workflow.
+        uses: docker/setup-qemu-action@25f0500ff22e406f7191a2a8ba8cda16901ca018 # associated tag: v1.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx (for chartpress multi-arch builds)
+        # NOTE: Updates to the actions commit hash should go hand in hand with
+        #       updates in the publish workflow.
+        uses: docker/setup-buildx-action@2a4b53665e15ce7d7049afb11ff1f70ff1610609 # associated tag: v1.1.2
 
       - name: Build a multiple architecture Docker image
         run: >-

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -18,6 +18,8 @@ jobs:
   trivy_image_scan:
     if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
 
     strategy:
       fail-fast: false
@@ -68,7 +70,7 @@ jobs:
       # Action reference: https://github.com/aquasecurity/trivy-action
       - name: Scan latest published image
         id: scan_1
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@b38389f8efef9798810fe0c5b5096ac198cffd54 # associated tag: 0.0.14
         with:
           image-ref: ${{ steps.image.outputs.spec }}
           format: json # ref: https://github.com/aquasecurity/trivy#save-the-results-as-json
@@ -91,7 +93,7 @@ jobs:
       - name: Scan rebuilt image
         id: scan_2
         if: steps.rebuild.outcome == 'success'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@b38389f8efef9798810fe0c5b5096ac198cffd54 # associated tag: 0.0.14
         with:
           image-ref: rebuilt-image
           format: json # ref: https://github.com/aquasecurity/trivy#save-the-results-as-json
@@ -150,7 +152,7 @@ jobs:
 
       - name: Describe vulnerabilities
         if: steps.rebuild.outcome == 'success'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@b38389f8efef9798810fe0c5b5096ac198cffd54 # associated tag: 0.0.14
         with:
           image-ref: rebuilt-image
           format: table
@@ -169,7 +171,7 @@ jobs:
       # ref: https://github.com/jacobtomlinson/gha-find-replace
       - name: Update VULN_SCAN_TIME in Dockerfile
         if: steps.analyze.outputs.proceed == 'yes'
-        uses: jacobtomlinson/gha-find-replace@0.1.3
+        uses: jacobtomlinson/gha-find-replace@f9e200cf233bcde71011fa5e4178037881764379 # associated tag: 0.1.3
         with:
           include: "images/${{ matrix.image_ref }}/Dockerfile"
           find: "#.*VULN_SCAN_TIME=.*"
@@ -182,7 +184,7 @@ jobs:
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create or update a PR
         if: steps.analyze.outputs.proceed == 'yes'
-        uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
+        uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8 # associated tag: v3.8.2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           author: jupyterhub vuln-scan bot <noreply@github.com>


### PR DESCRIPTION
This PR is a followup of having the JupyterHub org's permission level of the available secrets.GITHUB_TOKEN now only have read access to the repo by default.

Along with this, I'm also pinning github actions referenced to specific hashes in the jobs requesting write permissions for the GITHUB_TOKEN.
