### PR TITLE
images/hub - a regular run of script: hub/images/dependencies freeze --upgrade

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    ./dependencies freeze --upgrade
 #
-alembic==1.4.3
+alembic==1.5.8
     # via jupyterhub
 async-generator==1.10
     # via
@@ -16,7 +16,7 @@ bcrypt==3.2.0
     # via
     #   jupyterhub-firstuseauthenticator
     #   jupyterhub-nativeauthenticator
-cachetools==4.1.1
+cachetools==4.2.2
     # via google-auth
 certifi==2020.12.5
     # via
@@ -24,20 +24,22 @@ certifi==2020.12.5
     #   requests
 certipy==0.1.3
     # via jupyterhub
-cffi==1.14.4
+cffi==1.14.5
     # via
     #   bcrypt
     #   cryptography
-chardet==3.0.4
+chardet==4.0.0
     # via requests
-cryptography==3.4.4
+cryptography==3.4.7
     # via pyopenssl
 entrypoints==0.3
     # via jupyterhub
 escapism==1.0.1
     # via jupyterhub-kubespawner
-google-auth==1.23.0
+google-auth==1.30.0
     # via kubernetes
+greenlet==1.0.0
+    # via sqlalchemy
 idna==2.10
     # via requests
 ipython-genutils==0.2.0
@@ -78,9 +80,9 @@ jupyterhub==1.4.0
     #   oauthenticator
 kubernetes==12.0.1
     # via jupyterhub-kubespawner
-ldap3==2.8.1
+ldap3==2.9
     # via jupyterhub-ldapauthenticator
-mako==1.1.3
+mako==1.1.4
     # via alembic
 markupsafe==1.1.1
     # via
@@ -102,7 +104,7 @@ onetimepass==1.0.1
     # via jupyterhub-nativeauthenticator
 pamela==1.0.0
     # via jupyterhub
-prometheus-client==0.9.0
+prometheus-client==0.10.1
     # via jupyterhub
 psycopg2-binary==2.8.6
     # via -r requirements.in
@@ -125,7 +127,7 @@ pyjwt==1.7.1
     #   mwoauth
 pymysql==1.0.2
     # via -r requirements.in
-pyopenssl==20.0.0
+pyopenssl==20.0.1
     # via certipy
 pyrsistent==0.17.3
     # via jsonschema
@@ -139,7 +141,7 @@ python-editor==1.0.4
     # via alembic
 python-json-logger==2.0.1
     # via jupyter-telemetry
-python-slugify==4.0.1
+python-slugify==5.0.0
     # via jupyterhub-kubespawner
 pyyaml==5.4.1
     # via
@@ -149,7 +151,7 @@ requests-oauthlib==1.3.0
     # via
     #   kubernetes
     #   mwoauth
-requests==2.25.0
+requests==2.25.1
     # via
     #   jupyterhub
     #   kubernetes
@@ -157,7 +159,9 @@ requests==2.25.0
     #   requests-oauthlib
 rsa==4.7.2
     # via google-auth
-ruamel.yaml==0.16.12
+ruamel.yaml.clib==0.2.2
+    # via ruamel.yaml
+ruamel.yaml==0.17.4
     # via jupyter-telemetry
 six==1.15.0
     # via
@@ -170,7 +174,7 @@ six==1.15.0
     #   pyopenssl
     #   python-dateutil
     #   websocket-client
-sqlalchemy==1.3.23
+sqlalchemy==1.4.12
     # via
     #   alembic
     #   jupyterhub
@@ -193,7 +197,7 @@ urllib3==1.26.4
     #   jupyterhub-kubespawner
     #   kubernetes
     #   requests
-websocket-client==0.57.0
+websocket-client==0.58.0
     # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Dependabot only updates what we have in requirements.in, but leaves the dependencies of these libraries. So, I ran `./dependencies freeze --upgrade` from the /images/hub folder to do that.
