### PR TITLE
ci: accept 1 pod restart but not 2, test against k8s 1.21

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -199,7 +199,7 @@ jobs:
         uses: jupyterhub/action-k8s-await-workloads@v1
         with:
           timeout: 150
-          max-restarts: 0
+          max-restarts: 1
 
       - name: "(Upgrade) Install ${{ matrix.upgrade-from }} chart"
         if: matrix.test == 'upgrade'
@@ -258,7 +258,7 @@ jobs:
         uses: jupyterhub/action-k8s-await-workloads@v1
         with:
           timeout: 150
-          max-restarts: 0
+          max-restarts: 1
 
       - name: "(Upgrade) Await ${{ matrix.upgrade-from }} chart cert acquisition"
         if: matrix.test == 'upgrade'


### PR DESCRIPTION
Our GitHub action to await workloads that we install have a `max-restarts` parameter. It can abort the wait process quickly if we observe issues, but setting it to `0` is a bit too strict as timings on when pod/hub restarts especially during upgrade jobs can cause the hub pod for example to restart.

For good measure, I also made the max-restarts for the non-upgrade ci jobs be 1 instead of 0 - preferring to not experience erroring ci jobs for no serious reasons even though it could make sense to also enforce they install reliably. At this point, let's go for 1 restart to be acceptable.
