### PR TITLE
inline comment: info about the state used by prePuller.hook.pullOnlyOnChanges

### DIFF
--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -199,7 +199,8 @@ spec:
 
 {{- /*
     Returns a truthy string or a blank string depending on if the
-    hook-image-puller should be installed.
+    hook-image-puller should be installed. The truthy strings are comments
+    that summarize the state that led to returning a truthy string.
 
     - prePuller.hook.enabled must be true
     - if prePuller.hook.pullOnlyOnChanges is true, the checksum of the
@@ -212,10 +213,14 @@ spec:
             {{- $k8s_state := lookup "v1" "ConfigMap" .Release.Namespace (include "jupyterhub.hub.fullname" .) | default (dict "data" (dict)) }}
             {{- $old_checksum := index $k8s_state.data "checksum_hook-image-puller" | default "" }}
             {{- if ne $new_checksum $old_checksum -}}
-                Pulling because new checksum != old checksum: "{{ $new_checksum }}" != "{{ $old_checksum}}"
+# prePuller.hook.enabled={{ .Values.prePuller.hook.enabled }}
+# prePuller.hook.pullOnlyOnChanges={{ .Values.prePuller.hook.pullOnlyOnChanges }}
+# post-upgrade checksum != pre-upgrade checksum (of the hook-image-puller DaemonSet)
+# "{{ $new_checksum }}" != "{{ $old_checksum}}"
             {{- end }}
         {{- else -}}
-            Pulling because prePuller.hook.pullOnlyOnChanges was falsy.
+# prePuller.hook.enabled={{ .Values.prePuller.hook.enabled }}
+# prePuller.hook.pullOnlyOnChanges={{ .Values.prePuller.hook.pullOnlyOnChanges }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -19,6 +19,11 @@ metadata:
     "helm.sh/hook-weight": "10"
 spec:
   template:
+    # The hook-image-awaiter Job and hook-image-puller DaemonSet was
+    # conditionally created based on this state:
+    #
+    {{- include "jupyterhub.imagePuller.daemonset.hook.install" . | nindent 4 }}
+    #
     metadata:
       labels:
         {{- /* Changes here will cause the Job to restart the pods. */}}


### PR DESCRIPTION
This PR helps debug an error observed by @yuvipanda related to the feature prePuller.hook.pullOnlyOnChanges that compares the checksum of the previously generated DaemonSet resource.

A comparison is made between two checksums, one that was stored from the last `helm install/upgrade` command in the hub ConfigMap, and one for the current `helm install/upgrade`. The checksum are for the hook-image-puller DaemonSet.

This PR anyhow, just emits those strings and prints them in the `hook-image-awaiter` Job and associated Pod.
