### PR TITLE
fix: prePuller.hook.pullOnlyOnChanges didn't work, now it does

### DIFF
--- a/jupyterhub/templates/hub/configmap.yaml
+++ b/jupyterhub/templates/hub/configmap.yaml
@@ -27,4 +27,4 @@ data:
     Store away a checksum of the hook-image-puller daemonset so future upgrades
     can compare and decide if it should run or not using the `lookup` function.
   */}}
-  checksum_hook-image-puller: {{ include "jupyterhub.imagePuller.daemonset.hook" . | sha256sum | quote }}
+  checksum_hook-image-puller: {{ include "jupyterhub.imagePuller.daemonset.hook.checksum" . | quote }}

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -1,8 +1,8 @@
 {{- /*
 Permissions to be used by the hook-image-awaiter job
 */}}
-{{- if .Values.prePuller.hook.enabled }}
 {{- if .Values.rbac.enabled }}
+{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) }}
 {{- /*
 This service account...
 */ -}}


### PR DESCRIPTION
Closes #2172 by the strategy described in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2172#issuecomment-832234254.

In brief:
1. the checksum of the hook-image-puller daemonset that was calculated became different based on from what template origin calculated the checksum as `.Templates.Name` changed which in turn influenced rendered labels.
2. the checksum of the hook-image-puller daemonset that was calculated became different based on .Chart.Version as found in labels as well, which was irrelevant to re-pull on.
3. the rbac resources used by hook-image-awaiter were created no matter what, but now they are created based on if the hook-image-awaiter job is created.

Note though that we do want to pull again if something has changed about node affinity etc, so instead of just creating a list of the images it makes sense to still use a checksum of the k8s resource with some parts omitted, like the labels in the metadata section.

