### PR TITLE
enable prePuller.hook.pullOnlyOnChanges by default

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -79,6 +79,7 @@ jupyterhub_version = chart["appVersion"]
 #        run into this issue:
 #        https://github.com/executablebooks/MyST-Parser/issues/282
 kube_version = chart["kubeVersion"].split("-", 1)[0][2:]
+helm_version = "3.5"  # minimum helm cli version
 
 # These substitution variables only work in markdown contexts, and does not work
 # within links etc. Reference using {{ variable_name }}
@@ -90,6 +91,7 @@ myst_substitutions = {
     "chart_version_git_ref": chart_version_git_ref,
     "jupyterhub_version": jupyterhub_version,
     "kube_version": kube_version,
+    "helm_version": helm_version,
     "requirements": f"[hub/images/requirements.txt](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/{chart_version_git_ref}/images/hub/requirements.txt)",
 }
 

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -26,7 +26,7 @@ you have tips or deployments that you would like to share, see the
 This documentation is for Helm chart version {{chart_version}} that deploys
 JupyterHub version {{jupyterhub_version}} and other components versioned
 in {{requirements}}. The Helm chart requires Kubernetes version >={{kube_version}}
-and Helm >=3.5.0.
+and Helm >={{helm_version}}.
 
 ## What To Expect
 

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -481,7 +481,7 @@ prePuller:
   # hook relates to the hook-image-awaiter Job and hook-image-puller DaemonSet
   hook:
     enabled: true
-    pullOnlyOnChanges: false
+    pullOnlyOnChanges: true
     # image and the configuration below relates to the hook-image-awaiter Job
     image:
       name: jupyterhub/k8s-image-awaiter


### PR DESCRIPTION
By enabling this feature by default, those with `prePuller.hook.enabled=true` will not need to wait ~10 seconds on `hook-image-awaiter` and `hook-image-puller` pods to startup and shut down if no new image has been configured.

In practice, this feature works by inspecting the rendered Helm template of the hook-image-puller DaemonSet for a change to anything besides labels since the last `helm upgrade` was made.

This feature also relies on the ability for us to lookup a value in a ConfigMap using the Helm 3 feature called `lookup`.
