### PR TITLE
maint: revert a workaround to make our priorityclass resources helm hooks

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -280,7 +280,7 @@ jobs:
         uses: jupyterhub/action-k8s-await-workloads@v1
         with:
           timeout: 150
-          max-restarts: 0
+          max-restarts: 1
 
       - name: Await local chart cert acquisition
         run: |

--- a/jupyterhub/templates/scheduling/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/priorityclass.yaml
@@ -6,11 +6,6 @@ metadata:
   labels:
     {{- $_ := merge (dict "componentLabel" "default-priority") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
-  annotations:
-    # PriorityClasses must be added before the other resources reference them.
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "-100"
 value: {{ .Values.scheduling.podPriority.defaultPriority }}
 globalDefault: {{ .Values.scheduling.podPriority.globalDefault }}
 description: "A default priority higher than user placeholders priority."

--- a/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
@@ -6,11 +6,6 @@ metadata:
   name: {{ include "jupyterhub.user-placeholder-priority.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
-  annotations:
-    # PriorityClasses must be added before the other resources reference them.
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "-100"
 value: {{ .Values.scheduling.podPriority.userPlaceholderPriority }}
 globalDefault: false
 description: "With a priority higher or eqaul to a cluster autoscalers priority cutoff, a pod can trigger a cluster scale up. At the same time, placeholder pods priority should be lower than other pods to make them evictable."


### PR DESCRIPTION
At one point in time, `helm` installed PriorityClass resources too late - after they were referenced. Due to that, we added a workaround to make them _helm hooks_ - resources that could be installed _pre-upgrade_. The need for this workaround is long gone though, and the resources can just as well be normal resources. This PR makes them normal resources after having been helm hook resources.

I wasn't sure this would work without name collisions, but it seems like `helm` 3 manages this fine as our CI tests making a `helm` upgrade didn't have any issues.

Closes #1035.

---

Note that the commit 62b41b5 just addressed an intermittent unrelated harmless CI failure.
