### PR TITLE
Pivot strategy (from breaking to non-breaking) to make our PriorityClass resources no longer be helm hook resources

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -170,6 +170,8 @@ scheduling:
     # FIXME: Tweak this to include scoring, but exclude hex dumps. 10 includes
     #        hex dumps. 4 does not include scoring. Trying with 6...
     logLevel: 6
+  podPriority:
+    enabled: true
 
 debug:
   enabled: true

--- a/jupyterhub/templates/scheduling/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/priorityclass.yaml
@@ -3,7 +3,23 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "jupyterhub.priority.fullname" . }}
+  annotations:
+    # FIXME: PriorityClasses must be added before the other resources reference
+    #        them, and in the past a workaround was needed to accomplish this:
+    #        to make the resource a Helm hook.
+    #
+    #        To transition this resource to no longer be a Helm hook resource,
+    #        we explicitly add ownership annotations/labels (in 1.0.0) which
+    #        will allow a future upgrade (in 2.0.0) to remove all hook and
+    #        ownership annotations/labels.
+    #
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-100"
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/managed-by: Helm
     {{- $_ := merge (dict "componentLabel" "default-priority") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
 value: {{ .Values.scheduling.podPriority.defaultPriority }}

--- a/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
@@ -4,7 +4,23 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ include "jupyterhub.user-placeholder-priority.fullname" . }}
+  annotations:
+    # FIXME: PriorityClasses must be added before the other resources reference
+    #        them, and in the past a workaround was needed to accomplish this:
+    #        to make the resource a Helm hook.
+    #
+    #        To transition this resource to no longer be a Helm hook resource,
+    #        we explicitly add ownership annotations/labels (in 1.0.0) which
+    #        will allow a future upgrade (in 2.0.0) to remove all hook and
+    #        ownership annotations/labels.
+    #
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-100"
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
+    app.kubernetes.io/managed-by: Helm
     {{- include "jupyterhub.labels" . | nindent 4 }}
 value: {{ .Values.scheduling.podPriority.userPlaceholderPriority }}
 globalDefault: false


### PR DESCRIPTION
In #2180 I was on the lookout for a test failure. When I didn't see it I assumed everything was fine, but it wasn't. The failure didn't happen because `scheduling.podPriority.enabled` wasn't explicitly set to true in `dev-config.yaml`.

Due to this, #2180 introduced a breaking change after all. Instead of just reverting it fully, I've come up with a new strategy and to meet the goal that #2180 aimed for.

### Goal

I want to transition a Helm hook resource (kind: PriorityClass) to become a Helm chart managed resource. I want this transition a) without manual interventions, and b) without renaming the resource.

### Strategy

I've found that I can do that if the users make an upgrade in two steps:
1. During a first upgrade add three ownership annotations/labels.
2. During the second upgrade step remove all hook annotations and ownership annotations/labels.

See https://jacky-jiang.medium.com/import-existing-resources-in-helm-3-e27db11fd467 for more details.

```yaml
  annotations:
    helm.sh/hook: pre-install,pre-upgrade
    helm.sh/hook-delete-policy: before-hook-creation
    helm.sh/hook-weight: "-100"

    # step 1: I add these three ownership annotations/labels below
    meta.helm.sh/release-name: {{ .Release.Name }}
    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
  labels:
    app.kubernetes.io/managed-by: Helm
```

### Background

The priorityclass resource was a helm hook as a workaround when an early version of helm didn't install the priorityclass before resources that referenced it.

### Breaking change

This PR is supposed to remove a breaking change in #2180, but there remains a breaking change for anyone that...
1. Is upgrading _from_ a version in the range of `0.11.1-n455.h487e27eb` (#2180) to ??? (#2201 - this PR), to a later version.
2. Have had `scheduling.podPriority.enabled=true`

They will experience that the hub pod isn't getting created, because the referenced priorityclass isn't available as can be observed by watching the events (`kubectl get events`).

```
4s          Warning   FailedCreate              replicaset/hub-74d7f49fd8              Error creating: pods "hub-74d7f49fd8-" is forbidden: no PriorityClass with name jupyterhub-default-priority was found
```