### PR TITLE
fix: respect hub.config entries to override seeded secrets

### DIFF
--- a/jupyterhub/templates/hub/_helpers-passwords.tpl
+++ b/jupyterhub/templates/hub/_helpers-passwords.tpl
@@ -29,7 +29,9 @@
 {{- end }}
 
 {{- define "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" -}}
-    {{- if .Values.proxy.secretToken }}
+    {{- if (.Values.hub.config | dig "ConfigurableHTTPProxy" "auth_token" "") }}
+        {{- .Values.hub.config.ConfigurableHTTPProxy.auth_token }}
+    {{- else if .Values.proxy.secretToken }}
         {{- .Values.proxy.secretToken }}
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub.fullname" .) | default (dict "data" (dict)) }}
@@ -42,7 +44,9 @@
 {{- end }}
 
 {{- define "jupyterhub.hub.config.JupyterHub.cookie_secret" -}}
-    {{- if .Values.hub.cookieSecret }}
+    {{- if (.Values.hub.config | dig "JupyterHub" "cookie_secret" "") }}
+        {{- .Values.hub.config.JupyterHub.cookie_secret }}
+    {{- else if .Values.hub.cookieSecret }}
         {{- .Values.hub.cookieSecret }}
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub.fullname" .) | default (dict "data" (dict)) }}
@@ -55,7 +59,7 @@
 {{- end }}
 
 {{- define "jupyterhub.hub.config.CryptKeeper.keys" -}}
-    {{- if .Values.hub.config.CryptKeeper }}
+    {{- if (.Values.hub.config | dig "CryptKeeper" "keys" "") }}
         {{- .Values.hub.config.CryptKeeper.keys | join ";" }}
     {{- else }}
         {{- $k8s_state := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.hub.fullname" .) | default (dict "data" (dict)) }}


### PR DESCRIPTION
Self merging this to quicken up release process and avoid some merge conflicts after splitting apart a PR for readability.

Note that `dig` is introduced in helm 3.5.0 (via a new version of `sprig`, a helper library). `dig` allow us to simplify logic to get nested values without making the logic ugly.

Closes minor issue #2108. Publish test failure is unrelated.