### PR TITLE
fix: remove no longer needed safeguard for enable_auth_state

### DIFF
--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -115,12 +115,6 @@ directly instead.
 {{ "HARD DEPRECATION: proxy.pdb has renamed to proxy.chp.pdb" | fail }}
 {{- end }}
 
-{{- if include "jupyterhub.digToTrue" (list "hub.config.Authenticator.enable_auth_state" .Values) }}
-{{- if not (include "jupyterhub.digToTrue" (list "hub.config.CryptKeeper.keys" .Values)) }}
-{{ "Using Authenticator.enable_auth_state, you also need to CryptKeeper.keys to a list with at least one key in it." | fail }}
-{{- end }}
-{{- end }}
-
 {{- if .Values.auth }}
 {{ include "jupyterhub.authDep.remapOldToNew" . | fail }}
 {{- end }}

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -291,42 +291,6 @@ limits:
 {{- end }} {{- /* end of definition */}}
 
 {{- /*
-  jupyterhub.digToJson:
-    This is a workaround to not having a function like dig available yet
-    as it was added to recently to the helper library called sprig used
-    by helm.
-
-    ref: http://masterminds.github.io/sprig/dicts.html
-    ref: https://github.com/Masterminds/sprig/pull/254
-*/}}
-{{- define "jupyterhub.digToJson" -}}
-    {{- $path := index . 0 }}
-    {{- $context := index . 1 }}
-    {{- $path_parts := splitList "." $path }}
-    {{- range $i, $p := $path_parts }}
-        {{- if eq (add 1 $i) (len $path_parts) }}
-            {{- index ($context | default dict) $p | toJson }}
-        {{- else }}
-            {{- $context = index ($context | default dict) $p }}
-        {{- end }}
-    {{- end }}
-{{- end }}
-
-{{- /*
-  jupyterhub.digToTrue:
-    This is a helper to translate digToJson to a truthy value.
-
-    Note that the "[]" equality check is a workaround of
-    https://github.com/helm/helm/issues/9153.
-*/}}
-{{- define "jupyterhub.digToTrue" -}}
-{{- $json_string := include "jupyterhub.digToJson" . }}
-{{- if and ($json_string | fromJson) (ne $json_string "[]") }}
-true
-{{- end }}
-{{- end }}
-
-{{- /*
   jupyterhub.extraFiles.data:
     Renders content for a k8s Secret's data field, coming from extraFiles with
     binaryData entries.


### PR DESCRIPTION
This fixes a bug where we could not properly use a seeded cookie secret because we had a failsafe checking that we explicitly had set a cookie secret. Since we now seed those secrets if they aren't explicitly set, this is no longer relevant.