### PR TITLE
refactor: stop manual hex-to-bytes conversion

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -425,9 +425,10 @@ if os.path.isdir(config_dir):
 #
 # NOTE: ConfigurableHTTPProxy.auth_token is set through an environment variable
 #       that is set using the chart managed secret.
-c.JupyterHub.cookie_secret = a2b_hex(
-    get_secret_value("hub.config.JupyterHub.cookie_secret")
-)
+c.JupyterHub.cookie_secret = get_secret_value("hub.config.JupyterHub.cookie_secret")
+# NOTE: CryptKeeper.keys should be a list of strings, but we have encoded as a
+#       single string joined with ; in the k8s Secret.
+#
 c.CryptKeeper.keys = get_secret_value("hub.config.CryptKeeper.keys").split(";")
 
 # load hub.config values, except potentially seeded secrets already loaded


### PR DESCRIPTION
JupyterHub 1.4.0 supports automatic hex-to-bytes conversion of hex
strings in cookie_secret now. This makes us no longer need to manually
convert the hex string to bytes.

Anyone that builds their own hub image will need to rebuild it when installing 1.0.0 after this so JupyterHub 1.4.0+ is included.