### PR TITLE
ci: print pip packages versions for debugging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,10 @@ jobs:
         run: |
           . ./ci/common
           setup_helm
+          helm version
+
           pip install chartpress pyyaml
+          pip list
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,10 @@ jobs:
           setup_helm
           helm version
 
-          pip install chartpress pyyaml
+          # FIXME: six is required by docker 5.0.0 but isn't explicitly required
+          #        https://github.com/docker/docker-py/commit/c8fba210a222d4f7fde90da8f48db1e7faa637ec
+          #
+          pip install chartpress pyyaml six
           pip list
 
       - name: Setup push rights to jupyterhub/helm-chart


### PR DESCRIPTION
Workaround for docker 5.0.0 not importing six but referencing six: https://github.com/docker/docker-py/issues/2807