### PR TITLE
Remove deprecated logic and emit clear messages

### DIFF
--- a/doc/source/administrator/advanced.md
+++ b/doc/source/administrator/advanced.md
@@ -175,14 +175,7 @@ In your `hub.extraConfig`,
    specified as the second parameter (default)
 
 You need to have a `import z2jh` at the top of your `extraConfig` for
-`z2jh.get_config()` to work.
-
-```{versionchanged} 0.8
-`hub.extraConfigMap` used to be required for specifying additional values
-to pass, which was more restrictive.
-`hub.extraConfigMap` is deprecated in favor of the new
-top-level `custom` field, which allows fully arbitrary yaml.
-```
+`z2jh.get_config(...)` to work.
 
 ### `hub.extraEnv`
 

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -377,10 +377,7 @@ set_config_if_not_none(c.Spawner, "default_url", "singleuser.defaultUrl")
 
 cloud_metadata = get_config("singleuser.cloudMetadata", {})
 
-if (
-    cloud_metadata.get("blockWithIptables") == True
-    or cloud_metadata.get("enabled") == False
-):
+if cloud_metadata.get("blockWithIptables") == True:
     # Use iptables to block access to cloud metadata by default
     network_tools_image_name = get_config("singleuser.networkTools.image.name")
     network_tools_image_tag = get_config("singleuser.networkTools.image.tag")

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -80,12 +80,8 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
   Deprecation messages that can be removed in 2.0.0
 */}}
 
-{{- if .Values.hub.extraConfigMap }}{{ println }}
-DEPRECATION: hub.extraConfigMap is deprecated in jupyterhub chart 0.8.
-Use top-level `custom` instead:
-
-custom:
-{{- (merge dict .Values.custom .Values.hub.extraConfigMap) | toYaml | nindent 2 }}
+{{- if hasKey .Values.hub "extraConfigMap" }}
+{{- fail "\n\nHARD DEPRECATION: hub.extraConfigMap has been renamed to custom" }}
 {{- end }}
 
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -106,7 +106,7 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
 
 
 {{- if hasKey .Values.hub "uid" }}
-{{- print "\n\nDEPRECATION: hub.uid is deprecated in jupyterhub chart 0.9. Set the hub.containerSecurityContext.runAsUser value directly instead." }}
+{{- fail "\n\nHARD DEPRECATION: hub.uid must as of 1.0.0 be configured using hub.containerSecurityContext.runAsUser" }}
 {{- end }}
 
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -86,7 +86,7 @@ If you have questions, please:
 
 
 {{- /*
-  Breaking changes in 1.0.0
+  Breaking changes.
 */}}
 
 {{- $breaking := "" }}
@@ -152,11 +152,3 @@ If you have questions, please:
 {{- if $breaking }}
 {{- fail (print $breaking_title $breaking) }}
 {{- end }}
-
-
-
-
-
-{{- /*
-  Deprecation messages that can be removed in 3.0.0
-*/}}

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -77,55 +77,64 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
 
 
 {{- /*
-  Deprecation messages that can be removed in 2.0.0
+  Deprecation messages that can be removed in 2.0.0 because they have been
+  strictly enforced in 1.0.0.
 */}}
 
+{{- $hard_deprecations := "" }}
+
+
 {{- if hasKey .Values.hub "extraConfigMap" }}
-{{- fail "\n\nHARD DEPRECATION: hub.extraConfigMap has been renamed to custom" }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: hub.extraConfigMap has been renamed to custom" }}
 {{- end }}
 
 
 {{- if hasKey .Values "auth" }}
 {{- if .Values.auth }}
-{{- fail (include "jupyterhub.authDep.remapOldToNew" .) }}
+{{- $hard_deprecations = print $hard_deprecations (include "jupyterhub.authDep.remapOldToNew" .) }}
 {{- else }}
-{{- fail "\n\nHARD DEPRECATION: Please remove the empty 'auth' config" }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: Please remove the empty 'auth' config" }}
 {{- end }}
 {{- end }}
 
 
 {{- if hasKey .Values.proxy "containerSecurityContext" }}
-{{- fail "\n\nHARD DEPRECATION: proxy.containerSecurityContext has been renamed to proxy.chp.containerSecurityContext" }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: proxy.containerSecurityContext has been renamed to proxy.chp.containerSecurityContext" }}
 {{- end }}
 
 
 {{- if hasKey .Values.proxy "pdb" }}
-{{ fail "\n\nHARD DEPRECATION: proxy.pdb has renamed to proxy.chp.pdb" }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: proxy.pdb has renamed to proxy.chp.pdb" }}
 {{- end }}
 
 
 {{- if hasKey .Values.proxy "networkPolicy" }}
-{{- fail "\n\nHARD DEPRECATION: proxy.networkPolicy has been renamed to proxy.chp.networkPolicy" }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: proxy.networkPolicy has been renamed to proxy.chp.networkPolicy" }}
 {{- end }}
 
 
 {{- if hasKey .Values.hub "uid" }}
-{{- fail "\n\nHARD DEPRECATION: hub.uid must as of 1.0.0 be configured using hub.containerSecurityContext.runAsUser" }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: hub.uid must as of 1.0.0 be configured using hub.containerSecurityContext.runAsUser" }}
 {{- end }}
 
 
 {{- if hasKey .Values.hub "imagePullSecret" }}
-{{- fail "\n\nHARD DEPRECATION: hub.imagePullSecret has renamed to imagePullSecret" }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: hub.imagePullSecret has renamed to imagePullSecret" }}
 {{- end }}
 
 
 {{- if hasKey .Values.singleuser "imagePullSecret" }}
-{{- fail "\n\nHARD DEPRECATION: singleuser.imagePullSecret has renamed to imagePullSecret" }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: singleuser.imagePullSecret has renamed to imagePullSecret" }}
 {{- end }}
 
 
 {{- if hasKey .Values.singleuser.cloudMetadata "enabled" }}
-{{- fail "\n\nHARD DEPRECATION: singleuser.cloudMetadata.enabled must as of 1.0.0 be configured using singleuser.cloudMetadata.blockWithIptables with the opposite value." }}
+{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: singleuser.cloudMetadata.enabled must as of 1.0.0 be configured using singleuser.cloudMetadata.blockWithIptables with the opposite value." }}
+{{- end }}
+
+
+{{- if $hard_deprecations }}
+{{- fail $hard_deprecations }}
 {{- end }}
 
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -58,17 +58,26 @@ If you have questions, please:
   Warnings for likely misconfiguration
 */}}
 
-{{- if and (not .Values.scheduling.podPriority.enabled) (and .Values.scheduling.userPlaceholder.enabled .Values.scheduling.userPlaceholder.replicas) }}
-
-WARNING: You are using user placeholders without pod priority enabled, either
-enable pod priority or stop using the user placeholders to avoid wasting cloud
-resources.
+{{- if and (not .Values.scheduling.podPriority.enabled) (and .Values.scheduling.userPlaceholder.enabled .Values.scheduling.userPlaceholder.replicas) }}{{ println }}
+#################################################################################
+######   WARNING: You are using user placeholders without pod priority      #####
+######            enabled*, either enable pod priority or stop using the    #####
+######            user placeholders** to avoid having placeholders that     #####
+######            refuse to make room for a real user.                      #####
+######                                                                      #####
+######            *scheduling.podPriority.enabled                           #####
+######            **scheduling.userPlaceholder.enabled                      #####
+######            **scheduling.userPlaceholder.replicas                     #####
+#################################################################################
 {{- end }}
 
 
 {{- if eq .Values.proxy.https.enabled false }}
 {{- if or (not (eq .Values.proxy.https.type "letsencrypt")) (not (eq (.Values.proxy.https.letsencrypt.contactEmail | default "") "")) }}{{ println }}
-WARNING: Configuring proxy.https without setting proxy.https.enabled to true is no longer allowed.
+#################################################################################
+######   WARNING: Configuring proxy.https without setting                   #####
+######            proxy.https.enabled to true is no longer allowed.         #####
+#################################################################################
 {{- end }}
 {{- end }}
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -77,8 +77,7 @@ If you have questions, please:
 #################################################################################
 ######   WARNING: proxy.https.enabled is set to false by default since      #####
 ######            version 0.10.0. It is now set to false but proxy.https    #####
-######            seem to have been modified indicating you may want it     #####
-######            enabled.                                                  #####
+######            has been modified indicating you may want it enabled.     #####
 #################################################################################
 {{- end }}
 {{- end }}
@@ -142,7 +141,7 @@ If you have questions, please:
 
 
 {{- if hasKey .Values.singleuser "imagePullSecret" }}
-{{- $breaking = print $breaking "\n\nCHANGED: singleuser.imagePullSecret has been removed, but there is now a chart wide wide configuration named imagePullSecret" }}
+{{- $breaking = print $breaking "\n\nREMOVED: singleuser.imagePullSecret has been removed, but there is now a chart wide wide configuration named imagePullSecret" }}
 {{- end }}
 
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -121,7 +121,7 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
 
 
 {{- if (.Values.singleuser | dig "cloudMetadata" "enabled" "") }}
-{{- print "\n\nDEPRECATION: singleuser.cloudMetadata.enabled is deprecated, instead use singleuser.cloudMetadata.blockWithIptables with the inverted value." }}
+{{- fail "\n\nHARD DEPRECATION: singleuser.cloudMetadata.enabled must as of 1.0.0 be configured using singleuser.cloudMetadata.blockWithIptables with the opposite value." }}
 {{- end }}
 
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -75,8 +75,10 @@ If you have questions, please:
 {{- if eq .Values.proxy.https.enabled false }}
 {{- if or (not (eq .Values.proxy.https.type "letsencrypt")) (not (eq (.Values.proxy.https.letsencrypt.contactEmail | default "") "")) }}{{ println }}
 #################################################################################
-######   WARNING: Configuring proxy.https without setting                   #####
-######            proxy.https.enabled to true is no longer allowed.         #####
+######   WARNING: proxy.https.enabled is set to false by default since      #####
+######            version 0.10.0. It is now set to false but proxy.https    #####
+######            seem to have been modified indicating you may want it     #####
+######            enabled.                                                  #####
 #################################################################################
 {{- end }}
 {{- end }}

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -77,64 +77,71 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
 
 
 {{- /*
-  Deprecation messages that can be removed in 2.0.0 because they have been
-  strictly enforced in 1.0.0.
+  Breaking changes in 1.0.0
 */}}
 
-{{- $hard_deprecations := "" }}
+{{- $breaking := "" }}
+{{- $breaking_title := "\n" }}
+{{- $breaking_title = print $breaking_title "\n#################################################################################" }}
+{{- $breaking_title = print $breaking_title "\n######   BREAKING: The config values passed contained no longer accepted    #####" }}
+{{- $breaking_title = print $breaking_title "\n######             options. See the messages below for more details.        #####" }}
+{{- $breaking_title = print $breaking_title "\n######                                                                      #####" }}
+{{- $breaking_title = print $breaking_title "\n######             To verify your updated config is accepted, you can use   #####" }}
+{{- $breaking_title = print $breaking_title "\n######             the `helm template` command.                             #####" }}
+{{- $breaking_title = print $breaking_title "\n#################################################################################" }}
 
 
 {{- if hasKey .Values.hub "extraConfigMap" }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: hub.extraConfigMap has been renamed to custom" }}
+{{- $breaking = print $breaking "\n\nRENAMED: hub.extraConfigMap has been renamed to custom" }}
 {{- end }}
 
 
 {{- if hasKey .Values "auth" }}
 {{- if .Values.auth }}
-{{- $hard_deprecations = print $hard_deprecations (include "jupyterhub.authDep.remapOldToNew" .) }}
+{{- $breaking = print $breaking (include "jupyterhub.authDep.remapOldToNew" .) }}
 {{- else }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: Please remove the empty 'auth' config" }}
+{{- $breaking = print $breaking "\n\nREMOVED: Please remove the empty 'auth' config" }}
 {{- end }}
 {{- end }}
 
 
 {{- if hasKey .Values.proxy "containerSecurityContext" }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: proxy.containerSecurityContext has been renamed to proxy.chp.containerSecurityContext" }}
+{{- $breaking = print $breaking "\n\nRENAMED: proxy.containerSecurityContext has been renamed to proxy.chp.containerSecurityContext" }}
 {{- end }}
 
 
 {{- if hasKey .Values.proxy "pdb" }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: proxy.pdb has renamed to proxy.chp.pdb" }}
+{{- $breaking = print $breaking "\n\nRENAMED: proxy.pdb has renamed to proxy.chp.pdb" }}
 {{- end }}
 
 
 {{- if hasKey .Values.proxy "networkPolicy" }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: proxy.networkPolicy has been renamed to proxy.chp.networkPolicy" }}
+{{- $breaking = print $breaking "\n\nRENAMED: proxy.networkPolicy has been renamed to proxy.chp.networkPolicy" }}
 {{- end }}
 
 
 {{- if hasKey .Values.hub "uid" }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: hub.uid must as of 1.0.0 be configured using hub.containerSecurityContext.runAsUser" }}
+{{- $breaking = print $breaking "\n\nRENAMED: hub.uid must as of 1.0.0 be configured using hub.containerSecurityContext.runAsUser" }}
 {{- end }}
 
 
 {{- if hasKey .Values.hub "imagePullSecret" }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: hub.imagePullSecret has renamed to imagePullSecret" }}
+{{- $breaking = print $breaking "\n\nREMOVED: hub.imagePullSecret has been removed, but there is now a chart wide wide configuration named imagePullSecret" }}
 {{- end }}
 
 
 {{- if hasKey .Values.singleuser "imagePullSecret" }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: singleuser.imagePullSecret has renamed to imagePullSecret" }}
+{{- $breaking = print $breaking "\n\nCHANGED: singleuser.imagePullSecret has been removed, but there is now a chart wide wide configuration named imagePullSecret" }}
 {{- end }}
 
 
 {{- if hasKey .Values.singleuser.cloudMetadata "enabled" }}
-{{- $hard_deprecations = print $hard_deprecations "\n\nHARD DEPRECATION: singleuser.cloudMetadata.enabled must as of 1.0.0 be configured using singleuser.cloudMetadata.blockWithIptables with the opposite value." }}
+{{- $breaking = print $breaking "\n\nCHANGED: singleuser.cloudMetadata.enabled must as of 1.0.0 be configured using singleuser.cloudMetadata.blockWithIptables with the opposite value." }}
 {{- end }}
 
 
-{{- if $hard_deprecations }}
-{{- fail $hard_deprecations }}
+{{- if $breaking }}
+{{- fail (print $breaking_title $breaking) }}
 {{- end }}
 
 

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -85,12 +85,16 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
 {{- end }}
 
 
+{{- if hasKey .Values "auth" }}
 {{- if .Values.auth }}
-{{ fail (include "jupyterhub.authDep.remapOldToNew" .) }}
+{{- fail (include "jupyterhub.authDep.remapOldToNew" .) }}
+{{- else }}
+{{- fail "\n\nHARD DEPRECATION: Please remove the empty 'auth' config" }}
+{{- end }}
 {{- end }}
 
 
-{{- if .Values.proxy.containerSecurityContext }}
+{{- if hasKey .Values.proxy "containerSecurityContext" }}
 {{- fail "\n\nHARD DEPRECATION: proxy.containerSecurityContext has been renamed to proxy.chp.containerSecurityContext" }}
 {{- end }}
 
@@ -100,7 +104,7 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
 {{- end }}
 
 
-{{- if .Values.proxy.networkPolicy }}
+{{- if hasKey .Values.proxy "networkPolicy" }}
 {{- fail "\n\nHARD DEPRECATION: proxy.networkPolicy has been renamed to proxy.chp.networkPolicy" }}
 {{- end }}
 
@@ -110,17 +114,17 @@ WARNING: Configuring proxy.https without setting proxy.https.enabled to true is 
 {{- end }}
 
 
-{{- if (.Values.hub | dig "imagePullSecret" "enabled" "") }}
+{{- if hasKey .Values.hub "imagePullSecret" }}
 {{- fail "\n\nHARD DEPRECATION: hub.imagePullSecret has renamed to imagePullSecret" }}
 {{- end }}
 
 
-{{- if (.Values.singleuser | dig "imagePullSecret" "enabled" "") }}
+{{- if hasKey .Values.singleuser "imagePullSecret" }}
 {{- fail "\n\nHARD DEPRECATION: singleuser.imagePullSecret has renamed to imagePullSecret" }}
 {{- end }}
 
 
-{{- if (.Values.singleuser | dig "cloudMetadata" "enabled" "") }}
+{{- if hasKey .Values.singleuser.cloudMetadata "enabled" }}
 {{- fail "\n\nHARD DEPRECATION: singleuser.cloudMetadata.enabled must as of 1.0.0 be configured using singleuser.cloudMetadata.blockWithIptables with the opposite value." }}
 {{- end }}
 

--- a/jupyterhub/templates/_helpers-auth-rework.tpl
+++ b/jupyterhub/templates/_helpers-auth-rework.tpl
@@ -203,7 +203,9 @@ ldap.dn.user.useLookupName: LDAPAuthenticator.use_lookup_dn_username
     {{- end }}
 
     {{- /* UPDATE c dict authenticator_class */}}
-    {{- $_ := merge $c (dict "JupyterHub" (dict "authenticator_class" $class_new_entrypoint)) }}
+    {{- if ne $class_new_entrypoint "<no value>" }}
+        {{- $_ := merge $c (dict "JupyterHub" (dict "authenticator_class" $class_new_entrypoint)) }}
+    {{- end }}
 
 {{- /* Output a sensible error message */}}
 

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -169,15 +169,9 @@ spec:
           {{- with .Values.hub.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
-          {{- /* Below is deprecation logic of .Values.hub.uid */}}
-          {{- if .Values.hub.containerSecurityContext }}
-          {{- $securityContext := dict }}
-          {{- if hasKey .Values.hub "uid" }}
-          {{- $_ := merge $securityContext (dict "runAsUser" .Values.hub.uid) }}
-          {{- end }}
-          {{- $_ := merge $securityContext .Values.hub.containerSecurityContext }}
+          {{- with .Values.hub.containerSecurityContext }}
           securityContext:
-            {{- $securityContext | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
           {{- with .Values.hub.lifecycle }}
           lifecycle:

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -7,9 +7,7 @@ metadata:
 type: Opaque
 data:
   {{- $values := merge dict .Values }}
-  {{- /* preserve behavior of deprecated hub.extraConfigMap */}}
-  {{- $_ := set $values "custom" (merge dict $values.custom .Values.hub.extraConfigMap) }}
-  {{- /* passthrough subset of Chart / Release */}}
+  {{- /* also passthrough subset of Chart / Release */}}
   {{- $_ := set $values "Chart" (dict "Name" .Chart.Name "Version" .Chart.Version) }}
   {{- $_ := set $values "Release" (pick .Release "Name" "Namespace" "Service") }}
   values.yaml: {{ $values | toYaml | b64enc | quote }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -72,7 +72,6 @@ hub:
   command: []
   args: []
   extraConfig: {}
-  extraConfigMap: {}
   extraFiles: {}
   extraEnv: {}
   extraContainers: []

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -107,8 +107,6 @@ hub:
   extraConfig:
     test: |-
       c.Spawner.cmd = 'mock'
-  extraConfigMap:
-    mock.entry: mock-config-map-entry
   extraEnv: &extraEnv
     IGNORED_KEY_NAME:
       name: MOCK_ENV_VAR_NAME1


### PR DESCRIPTION
### Summary

- [x] Forcing deprecated values to become unset during template rendering and providing a clear error message if they aren't.
- [x] Ensuring all messages are shown together to help users fix all failures at once instead of one at the time.
- [x] Removes no longer needed logic to handle deprecated values

### Motivation for breaking changes

- __Complexity reduction of templates by removal of deprecation logic.__
- __Future complexity reduction of schema.__
  Our deprecation messages are triggered by detecting deprecated values being passed, which requires them to be accepted by the schema. So by ensuring all users have stopped using deprecated values when they upgrade to 1.0.0, we can in 2.0.0 remove them from the schema.

### Breaking changes

All of the breaking changes will lead to clear error messages emitted by a `fail` statement in `NOTES.txt`. This happens before any communication to the k8s api-server has been made.

- Previously deprecated options that were required to be falsy, are now required to be _unset_.
  - `auth` -> `hub.config`
  - `hub.imagePullSecret` -> `imagePullSecret` (new chart wide config)
  - `singleuser.cloudMetadata.enabled` -> `singleuser.cloudMetadata.blockWithIptables` (renamed / inverted value)
  - `singleuser.imagePullSecret` -> `imagePullSecret` (new chart wide config)
  - `proxy.containerSecurityContext` -> `proxy.chp.containerSecurityContext` (relocated)
  - `proxy.networkPolicy` -> `proxy.chp.networkPolicy` (relocated)
  - `proxy.pdb` -> `proxy.chp.networkPolicy` (relocated)
- Previously deprecated options that were still functional are now _required_ to be unset.
  - `hub.extraConfigMap` is now required to unset and configured using `custom` (renamed)
  - `hub.uid` is now required to be unset and configured using `hub.containerSecurityContext.runAsUser` (coalesced into k8s native config)

Closes #2157 by providing more visually standing out messages for warnings and breaking changes.
Closes #1412 by making NOTES.txt failures grouped into a single message, which I think is sufficient for now.