### PR TITLE
docs: fix syntax error in markdown table

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -34,7 +34,7 @@ properties:
       part of the Helm chart are named.
 
       Name format               | Resource types | fullnameOverride | nameOverride | Note
-      -                         | -              | -                | -            | -
+      ------------------------- | -------------- | ---------------- | ------------ | -
       component                 | namespaced     | `""`             | *            | Default
       release-component         | cluster wide   | `""`             | *            | Default
       fullname-component        | *              | str              | *            | -


### PR DESCRIPTION
The table didn't render correctly with a lot of white space instead of `-` to create the space for the second line in the markdown table format.