### PR TITLE
Bump CHP version to 4.4.0 (statsd dropped)

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -190,7 +190,7 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: jupyterhub/configurable-http-proxy
-      tag: 4.3.2
+      tag: 4.4.0
       pullPolicy:
       pullSecrets: []
     extraCommandLineFlags: []


### PR DESCRIPTION
CHP 4.4.0 dropped support for statsd metrics and added support for prometheus metrics if `--metrics-ip=<port>` is passed.