### PR TITLE
Add annotations to rbac serviceAccount

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1132,6 +1132,18 @@ properties:
         deprecated: true
         description: |
           DEPRECATED: Use [`imagePullSecret`](schema_imagePullSecret) instead.
+      serviceAccount: &serviceAccount
+        type: object
+        additionalProperties: false
+        description: |
+          Configuration for a k8s ServiceAccount dedicated for use by the
+          specific pod which this configuration is nested under.
+        properties:
+          annotations:
+            type: object
+            additionalProperties: true
+            description: |
+              Kubernetes annotations to apply to the k8s ServiceAccount.
 
   proxy:
     type: object
@@ -1544,6 +1556,7 @@ properties:
                 type: boolean
           image: *image-spec
           resources: *resources-spec
+          serviceAccount: *serviceAccount
       labels:
         type: object
         additionalProperties: true
@@ -2062,6 +2075,7 @@ properties:
                         weight:
                           type: integer
           resources: *resources-spec
+          serviceAccount: *serviceAccount
       podPriority:
         type: object
         additionalProperties: false
@@ -2333,6 +2347,7 @@ properties:
           containerSecurityContext: *containerSecurityContext-spec
           image: *image-spec
           resources: *resources-spec
+          serviceAccount: *serviceAccount
       continuous:
         type: object
         additionalProperties: false

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "jupyterhub.hub.fullname" . }}
+  {{- with .Values.hub.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -17,6 +17,9 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "0"
+    {{- with .Values.prePuller.hook.serviceAccount.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
 ---
 {{- /*
 ... will be used by this role...

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ include "jupyterhub.autohttps.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- with .Values.proxy.traefik.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- with .Values.scheduling.userScheduler.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -263,6 +263,8 @@ proxy:
       enabled: false
       maxUnavailable:
       minAvailable: 1
+    serviceAccount:
+      annotations: {}
   secretSync:
     containerSecurityContext:
       runAsUser: 65534 # nobody user
@@ -433,6 +435,8 @@ scheduling:
       maxUnavailable: 1
       minAvailable:
     resources: {}
+    serviceAccount:
+      annotations: {}
   podPriority:
     enabled: false
     globalDefault: false
@@ -498,6 +502,8 @@ prePuller:
     nodeSelector: {}
     tolerations: []
     resources: {}
+    serviceAccount:
+      annotations: {}
   continuous:
     enabled: true
   pullProfileListImages: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -134,6 +134,8 @@ hub:
     failureThreshold: 1000
     timeoutSeconds: 1
   existingSecret:
+  serviceAccount:
+    annotations: {}
 
 rbac:
   enabled: true

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -159,6 +159,8 @@ hub:
       operator: Equal
       value: mock-taint-value-hub
       effect: NoSchedule
+  serviceAccount: &serviceAccount
+    annotations: *annotations
 
 rbac:
   enabled: true
@@ -228,6 +230,7 @@ proxy:
       enabled: true
       maxUnavailable: null
       minAvailable: 1
+    serviceAccount: *serviceAccount
   secretSync:
     resources: *resources
   labels: *labels
@@ -392,6 +395,7 @@ scheduling:
           - name: NodePreferAvoidPods
             weight: 161051
           - name: NodeAffinity
+    serviceAccount: *serviceAccount
   podPriority:
     enabled: true
   userPlaceholder:
@@ -430,6 +434,7 @@ prePuller:
         operator: Equal
         value: mock-taint-value-hook
         effect: NoSchedule
+    serviceAccount: *serviceAccount
   continuous:
     enabled: true
   extraImages:


### PR DESCRIPTION
I am using this helm chart on GKE. The preferred method to authorize GKE workloads is using Google workload identity ( https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity )

In order to use workload identity it's necessary to add a specific annotation( `iam.gke.io/gcp-service-account` ) to the k8s serviceaccount. In this way we can link the k8s serviceaccount with google's service account. 

Adding annotations to the hub's serviceAccount was not possible with the current helm chart so I implemented it in this PR.

Let me know if you have any question