### PR TITLE
hub image: add sqlalchemy-cocroachdb dependency

### DIFF
--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -28,6 +28,7 @@ jupyterhub-kubespawner
 pymysql  # mysql
 psycopg2-binary  # postgres
 pycurl  # internal http requests handle more load with pycurl
+sqlalchemy-cockroachdb # cocroachdb
 statsd  # statsd metrics collection (TODO: remove soon, since folks use prometheus)
 
 # The idle culler service

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    ./dependencies freeze --upgrade
 #
-alembic==1.5.8
+alembic==1.6.5
     # via jupyterhub
 async-generator==1.10
     # via
     #   jupyterhub
     #   jupyterhub-kubespawner
-attrs==20.3.0
+attrs==21.2.0
     # via jsonschema
 bcrypt==3.2.0
     # via
@@ -18,7 +18,7 @@ bcrypt==3.2.0
     #   jupyterhub-nativeauthenticator
 cachetools==4.2.2
     # via google-auth
-certifi==2020.12.5
+certifi==2021.5.30
     # via
     #   kubernetes
     #   requests
@@ -36,15 +36,15 @@ entrypoints==0.3
     # via jupyterhub
 escapism==1.0.1
     # via jupyterhub-kubespawner
-google-auth==1.30.0
+google-auth==1.31.0
     # via kubernetes
-greenlet==1.0.0
+greenlet==1.1.0
     # via sqlalchemy
 idna==2.10
     # via requests
 ipython-genutils==0.2.0
     # via traitlets
-jinja2==2.11.3
+jinja2==3.0.1
     # via
     #   jupyterhub
     #   jupyterhub-kubespawner
@@ -78,13 +78,13 @@ jupyterhub==1.4.1
     #   jupyterhub-nativeauthenticator
     #   nullauthenticator
     #   oauthenticator
-kubernetes==12.0.1
+kubernetes==17.17.0
     # via jupyterhub-kubespawner
 ldap3==2.9
     # via jupyterhub-ldapauthenticator
 mako==1.1.4
     # via alembic
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via
     #   jinja2
     #   mako
@@ -94,7 +94,7 @@ nullauthenticator==1.0.0
     # via -r requirements.in
 oauthenticator==14.0.0
     # via -r requirements.in
-oauthlib==3.1.0
+oauthlib==3.1.1
     # via
     #   jupyterhub
     #   jupyterhub-ltiauthenticator
@@ -104,7 +104,7 @@ onetimepass==1.0.1
     # via jupyterhub-nativeauthenticator
 pamela==1.0.0
     # via jupyterhub
-prometheus-client==0.10.1
+prometheus-client==0.11.0
     # via jupyterhub
 psycopg2-binary==2.9.1
     # via -r requirements.in
@@ -141,7 +141,7 @@ python-editor==1.0.4
     # via alembic
 python-json-logger==2.0.1
     # via jupyter-telemetry
-python-slugify==5.0.0
+python-slugify==5.0.2
     # via jupyterhub-kubespawner
 pyyaml==5.4.1
     # via
@@ -161,9 +161,9 @@ rsa==4.7.2
     # via google-auth
 ruamel.yaml.clib==0.2.2
     # via ruamel.yaml
-ruamel.yaml==0.17.4
+ruamel.yaml==0.17.9
     # via jupyter-telemetry
-six==1.15.0
+six==1.16.0
     # via
     #   bcrypt
     #   google-auth
@@ -173,8 +173,9 @@ six==1.15.0
     #   onetimepass
     #   pyopenssl
     #   python-dateutil
-    #   websocket-client
-sqlalchemy==1.4.12
+sqlalchemy-cockroachdb==1.3.4
+    # via -r requirements.in
+sqlalchemy==1.4.18
     # via
     #   alembic
     #   jupyterhub
@@ -197,7 +198,7 @@ urllib3==1.26.5
     #   jupyterhub-kubespawner
     #   kubernetes
     #   requests
-websocket-client==0.58.0
+websocket-client==1.1.0
     # via kubernetes
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Based on jupyterhub's docs, it should be generally compatible with any sqlalchemy provider.

In our environment, we're relying on cocroachdb due to easier clusterization and scalability.
Aside from a tiny defect in jupyterhub (jupyterhub/jupyterhub#3484, it was not part of 1.4.1), which might not even be specific to cocroachdb (rather to the dummy authenticator), everything seems to work well.

Currently, we have to dynamically install `sqlalchemy-cockroachdb` upon container start. It'd be great to have it included in the base image.

P.S. If I got it right, I had to run the `dependencies freeze --upgrade` script to make sure all dependencies are added to the requirements.txt. That's why you can see two files updated instead of just one (requirements.in).