### PR TITLE
Remove pre-commit from GHA

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -43,7 +43,6 @@ jobs:
           pip install chartpress yamllint
 
       - uses: pre-commit/action@v2.0.3
-      - uses: pre-commit/action@v2.0.3
         with:
           extra_args: --config .pre-commit-config-shellcheck.yaml
 


### PR DESCRIPTION
runs on pre-commit.ci now

leaves shellcheck in there, which requires additional dependency and is run separately

It would be nice to bring shellcheck in so that it works like everything else. It can run in docker, but also needs the entrypoint wrapper in https://github.com/gruntwork-io/pre-commit/blob/HEAD/hooks/shellcheck.sh