### PR TITLE
Transition to use pre-commit hook in jupyterhub/chartpress

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,20 +21,20 @@
 repos:
   # Autoformat: Python code
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.6b0
     hooks:
       - id: black
         args: [--target-version=py36]
 
   # Autoformat: Bash scripts
   - repo: https://github.com/lovesegfault/beautysh
-    rev: 6.0.1
+    rev: v6.1.0
     hooks:
       - id: beautysh
 
   # Autoformat: markdown, yaml (but not helm templates)
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.3.1
     hooks:
       - id: prettier
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,15 +39,10 @@ repos:
       - id: prettier
 
   # Reset Chart.yaml version and values.yaml image tags
-  - repo: local
+  - repo: https://github.com/jupyterhub/chartpress
+    rev: 1.2.0
     hooks:
       - id: chartpress
-        name: chartpress --reset
-        files: jupyterhub/Chart.yaml|jupyterhub/values.yaml
-        description: Run `chartpress --reset` to clean up helm charts before committing.
-        entry: chartpress --reset
-        language: system
-        pass_filenames: false
 
   # Check chart for possible issues
   - repo: https://github.com/gruntwork-io/pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,3 @@ repos:
     rev: 1.2.0
     hooks:
       - id: chartpress
-
-  # Check chart for possible issues
-  - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.10
-    hooks:
-      - id: helmlint


### PR DESCRIPTION
This PR stops using a locally defined pre-commit hook to run chartpress that also assumes `chartpress` has been installed ahead of time. By instead using a remotely defined pre-commit hook in https://github.com/jupyterhub/chartpress/pull/127, `chartpress` will be automatically be installed by pre-commit which enables us to not crash trying to use the pre-commit.ci service.

After fixing this, I learned that the helmlint pre-commit hook also fail in the pre-commit.ci service because `helm` isn't getting installed but is assumed. Due to this, I simply opted to drop the helmlint hook instead. It is a trade off of course, but I feel a bit committed to trying out the pre-commit.ci service now and I don't think running `helm lint` as part of pre-commit is so important, it doesn't capture much errors I would say.