### PR TITLE
templates: quote namespace in case they are only contain numbers

### DIFF
--- a/doc/source/administrator/advanced.md
+++ b/doc/source/administrator/advanced.md
@@ -227,7 +227,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "jupyterhub.hub.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role
   name: my-role

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -33,7 +33,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "jupyterhub.hub.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role
   name: {{ include "jupyterhub.hub.fullname" . }}

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -57,7 +57,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role
   name: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}

--- a/jupyterhub/templates/scheduling/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/priorityclass.yaml
@@ -16,8 +16,8 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-100"
-    meta.helm.sh/release-name: {{ .Release.Name }}
-    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/managed-by: Helm
     {{- $_ := merge (dict "componentLabel" "default-priority") . }}

--- a/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
@@ -17,8 +17,8 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "-100"
-    meta.helm.sh/release-name: {{ .Release.Name }}
-    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/managed-by: Helm
     {{- include "jupyterhub.labels" . | nindent 4 }}

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -13,7 +13,7 @@ data:
     leaderElection:
       resourceLock: endpoints
       resourceName: {{ include "jupyterhub.user-scheduler-lock.fullname" . }}
-      resourceNamespace: {{ .Release.Namespace }}
+      resourceNamespace: "{{ .Release.Namespace }}"
     profiles:
       - schedulerName: {{ include "jupyterhub.user-scheduler.fullname" . }}
         plugins:

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -204,7 +204,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: ClusterRole
   name: {{ include "jupyterhub.user-scheduler.fullname" . }}


### PR DESCRIPTION
I'm not sure we would be able to install the Helm chart in a namespace with only numbers in its name, but now there is a change it could work at least.