### PR TITLE
Relax hub.db.type schema to accept unknown database types

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -72,6 +72,8 @@ if db_password is not None:
         os.environ["MYSQL_PWD"] = db_password
     elif db_type == "postgres":
         os.environ["PGPASSWORD"] = db_password
+    else:
+        print(f"Warning: hub.db.password is ignored for hub.db.type={db_type}")
 
 
 # c.JupyterHub configuration from Helm chart's configmap

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -619,7 +619,7 @@ properties:
         additionalProperties: false
         properties:
           type:
-            enum: [sqlite-pvc, sqlite-memory, mysql, postgres]
+            enum: [sqlite-pvc, sqlite-memory, mysql, postgres, other]
             description: |
               Type of database backend to use for the hub database.
 
@@ -680,6 +680,15 @@ properties:
 
                  The user specified in the connection string must have the rights to create
                  tables in the database specified.
+
+              5. **other**
+
+                 Use an externally hosted database of some kind other than mysql
+                 or postgres.
+
+                 When using _other_, the database password must be passed as
+                 part of [hub.db.url](schema_hub.db.url) as
+                 [hub.db.password](schema_hub.db.password) will be ignored.
           pvc:
             type: object
             additionalProperties: false


### PR DESCRIPTION
Closes #2246 by allowing for `hub.db.type` schema to accept `other` as configuration.