### PR TITLE
Relax extraEnv schema to allow for array values

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -787,7 +787,7 @@ properties:
                 command: ['sh', '-c', 'command2']
           ```
       extraEnv:
-        type: object
+        type: [object, array]
         additionalProperties: true
         description: |
           Extra environment variables that should be set for the hub pod.
@@ -1194,7 +1194,7 @@ properties:
               flag twice, the last flag will be used, which mean you can
               override the default flag values as well.
           extraEnv:
-            type: object
+            type: [object, array]
             additionalProperties: true
             description: |
               Extra environment variables that should be set for the chp pod.
@@ -1481,7 +1481,7 @@ properties:
               to learn more about labels.
           networkPolicy: *networkPolicy-spec
           extraEnv:
-            type: object
+            type: [object, array]
             additionalProperties: true
             description: |
               Extra environment variables that should be set for the traefik pod.
@@ -1735,7 +1735,7 @@ properties:
           ```
       extraFiles: *extraFiles
       extraEnv:
-        type: object
+        type: [object, array]
         additionalProperties: true
         description: |
           Extra environment variables that should be set for the user pods.

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -184,7 +184,14 @@ proxy:
     resources: *resources
     defaultTarget: http://dummy.local/hello
     errorTarget: http://dummy.local/error
-    extraEnv: *extraEnv
+    extraEnv:
+      - name: MOCK_ENV_VAR_NAME1
+        value: MOCK_ENV_VAR_VALUE1
+      - name: MOCK_ENV_VAR_NAME2
+        valueFrom:
+          secretKeyRef:
+            name: my-k8s-secret
+            key: my-k8s-secret-key
     nodeSelector:
       node-type: mock
     tolerations:


### PR DESCRIPTION
This is a fix of a regression that stopped allowing extraEnv accepting lists. The recommended approach is to use a map, but lists were still supposed to be supported.

Closes #2290