### PR TITLE
Fix failure to set imagePullSecrets for user-placeholder pods (scheduling.userPlaceholder.image config added)

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2181,6 +2181,7 @@ properties:
         properties:
           enabled:
             type: boolean
+          image: *image-spec
           replicas:
             type: integer
             description: |

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -44,6 +44,9 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
+      {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.prePuller.pause.image) }}
+      imagePullSecrets: {{ . }}
+      {{- end }}
       containers:
         - name: pause
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -44,18 +44,21 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: 0
       automountServiceAccountToken: false
-      {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.prePuller.pause.image) }}
+      {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.scheduling.userPlaceholder.image) }}
       imagePullSecrets: {{ . }}
       {{- end }}
       containers:
         - name: pause
-          image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}
+          image: {{ .Values.scheduling.userPlaceholder.image.name }}:{{ .Values.scheduling.userPlaceholder.image.tag }}
           {{- if .Values.scheduling.userPlaceholder.resources }}
           resources:
             {{- .Values.scheduling.userPlaceholder.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- else if (include "jupyterhub.singleuser.resources" .) }}
           resources:
             {{- include "jupyterhub.singleuser.resources" . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.scheduling.userPlaceholder.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
           {{- end }}
           {{- with .Values.scheduling.userPlaceholder.containerSecurityContext }}
           securityContext:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -444,6 +444,11 @@ scheduling:
     userPlaceholderPriority: -10
   userPlaceholder:
     enabled: true
+    image:
+      name: k8s.gcr.io/pause
+      tag: "3.2" # https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/pause?gcrImageListsize=30
+      pullPolicy:
+      pullSecrets: []
     replicas: 0
     containerSecurityContext:
       runAsUser: 65534 # nobody user

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -91,9 +91,10 @@ hub:
       subPath: /mock
       storageClassName: custom-storage-class
     url: custom-db-url
-  image:
+  image: &image
     name: dummy-name
     tag: dummy-tag
+    pullPolicy: Always
     pullSecrets: [c]
   initContainers:
     - name: mock-init-container-name
@@ -384,9 +385,7 @@ scheduling:
     enabled: true
     replicas: 1
     logLevel: 10
-    image:
-      name: gcr.io/google_containers/kube-scheduler-amd64
-      tag: v1.11.2
+    image: *image
     nodeSelector:
       node-type: mock
     tolerations:


### PR DESCRIPTION
### Updated summary by Erik

`prePuller.pause.image.name|tag` was used to set the user-placeholder pods image, but the user-placeholder pods didn't make use of the `prePuller.pause.image.pullPolicy|pullSecrets` or any other config to set imagePullPolicy or imagePullSecrets. With this PR the dedicated option `scheduling.userPlaceholer.image` and respective fields are added and respected for the user-placeholder pods.

### Original PR summary

`prePuller.pause.image.pullSecrets` was already defined in `values.yaml` but it was never actually used in the placeholder statefulset template.