### PR TITLE
Fix regression where hub.services require an apiToken to be specified

### DIFF
--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -43,6 +43,8 @@ hub:
       apiToken: give-pytest-control
     test-hub-existing-secret:
       apiToken: dddd4444
+    test-dummy-service:
+      url: http://dummy-service
   networkPolicy:
     egress: # overrides allowance of 0.0.0.0/0
       # In kind/k3s clusters the Kubernetes API server is exposing this port

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -367,6 +367,7 @@ for name, service in get_config("hub.services", {}).items():
     # As the api_token could be exposed in hub.existingSecret, we need to read
     # it it from there or fall back to the chart managed k8s Secret's value.
     service.pop("apiToken", None)
+    service.pop("api_token", None)
     api_token = get_secret_value(f"hub.services.{service['name']}.apiToken", None)
     if api_token:
         service["api_token"] = api_token

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -379,7 +379,7 @@ for name, service in get_config("hub.services", {}).items():
     c.JupyterHub.services.append(service)
 
 print("------------------after assignment------------------")
-print(c.JupyterHub.services)
+print(list(c.JupyterHub.services))
 
 
 set_config_if_not_none(c.Spawner, "cmd", "singleuser.cmd")

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -374,11 +374,12 @@ for name, service in get_config("hub.services", {}).items():
     print(f"api_token received: {api_token}")
     if api_token:
         service["api_token"] = api_token
-    else:
-        service["api_token"] = None
     print("------------------after assignment------------------", service)
 
     c.JupyterHub.services.append(service)
+
+print("------------------after assignment------------------")
+print(c.JupyterHub.services)
 
 
 set_config_if_not_none(c.Spawner, "cmd", "singleuser.cmd")

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -366,11 +366,17 @@ for name, service in get_config("hub.services", {}).items():
 
     # As the api_token could be exposed in hub.existingSecret, we need to read
     # it it from there or fall back to the chart managed k8s Secret's value.
+    print("------------------before------------------", service)
     service.pop("apiToken", None)
     service.pop("api_token", None)
+    print("------------------after pop------------------", service)
     api_token = get_secret_value(f"hub.services.{service['name']}.apiToken", None)
+    print(f"api_token received: {api_token}")
     if api_token:
         service["api_token"] = api_token
+    else:
+        service["api_token"] = None
+    print("------------------after assignment------------------", service)
 
     c.JupyterHub.services.append(service)
 


### PR DESCRIPTION
This is not a regression in Z2JH itself, but with JupyterHub 1.4.0 and 1.4.1, but it is fixed in current main branch. See https://github.com/jupyterhub/jupyterhub/pull/3531