### PR TITLE
Add configuration options for using host networking

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -504,6 +504,19 @@ properties:
           # to generate a value, run
           openssl rand -hex 32
           ```
+      hostNetwork:
+        type: boolean
+        description: |
+          Use host networking for the hub pod. This is disabled by default.
+
+          Host networking is an advanced configuration for use in nonstandard
+          deployments. For example, host networking is useful in deployments where
+          notebook server pods are also deployed with host networking.
+
+          Host networking is intended for expert use where the implications are
+          well-understood. Host networking has its own class of security
+          vulnerabilities. Therefore, we recommend its use only in trusted
+          environments such as private data centers.
       image: &image-spec
         type: object
         additionalProperties: false
@@ -1165,6 +1178,19 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      hostNetwork:
+        type: boolean
+        description: |
+          Use host networking for the proxy pod. This is disabled by default.
+
+          Host networking is an advanced configuration for use in nonstandard
+          deployments. For example, host networking is useful in deployments where
+          notebook server pods are also deployed with host networking.
+
+          Host networking is intended for expert use where the implications are
+          well-understood. Host networking has its own class of security
+          vulnerabilities. Therefore, we recommend its use only in trusted
+          environments such as private data centers.
       chp:
         type: object
         additionalProperties: false

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hub.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -40,6 +40,10 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.proxy.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -30,6 +30,7 @@ hub:
     JupyterHub:
       admin_access: true
       authenticator_class: dummy
+  hostNetwork: false
   service:
     type: ClusterIP
     annotations: {}
@@ -171,6 +172,7 @@ proxy:
     ##     Error: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     ##     Error: UPGRADE FAILED: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     rollingUpdate:
+  hostNetwork: false
   # service relates to the proxy-public service
   service:
     type: LoadBalancer


### PR DESCRIPTION
Add configuration options for using host networking for the hub and proxy pods. This PR relates to issue #2256.

As mentioned in #2256, this will greatly simplify and ease deployment when the notebook pods are configured to run on the host network. For example, notebook pod networking is used for compatibility with Spark. Spark requires a routable client address. When Spark runs outside the kubernetes cluster, the client cannot send an address to Spark that's routable back to the notebook pod unless it's on the host network.