### PR TITLE
Add configuration options for using host networking

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -504,6 +504,19 @@ properties:
           # to generate a value, run
           openssl rand -hex 32
           ```
+      hostNetwork:
+        type: boolean
+        description: |
+          Use host networking for the hub pod. This is disabled by default.
+
+          Host networking is an advanced configuration for use in nonstandard
+          deployments. For example, host networking is useful in deployments where
+          notebook server pods are also deployed with host networking.
+
+          Host networking is intended for expert use where the implications are
+          well-understood. Host networking has its own class of security
+          vulnerabilities. Therefore, we recommend its use only in trusted
+          environments such as private data centers.
       image: &image-spec
         type: object
         additionalProperties: false
@@ -1165,6 +1178,19 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      hostNetwork:
+        type: boolean
+        description: |
+          Use host networking for the proxy pod. This is disabled by default.
+
+          Host networking is an advanced configuration for use in nonstandard
+          deployments. For example, host networking is useful in deployments where
+          notebook server pods are also deployed with host networking.
+
+          Host networking is intended for expert use where the implications are
+          well-understood. Host networking has its own class of security
+          vulnerabilities. Therefore, we recommend its use only in trusted
+          environments such as private data centers.
       chp:
         type: object
         additionalProperties: false

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -504,10 +504,10 @@ properties:
           # to generate a value, run
           openssl rand -hex 32
           ```
-      hostNetwork:
-        type: boolean
+      hostNetwork: &hostNetwork-spec
+        type: [boolean, "null"]
         description: |
-          Use host networking for the hub pod. This is disabled by default.
+          Use host networking for this pod. This is disabled by default.
 
           Host networking is an advanced configuration for use in nonstandard
           deployments. For example, host networking is useful in deployments where
@@ -1178,19 +1178,6 @@ properties:
     type: object
     additionalProperties: false
     properties:
-      hostNetwork:
-        type: boolean
-        description: |
-          Use host networking for the proxy pod. This is disabled by default.
-
-          Host networking is an advanced configuration for use in nonstandard
-          deployments. For example, host networking is useful in deployments where
-          notebook server pods are also deployed with host networking.
-
-          Host networking is intended for expert use where the implications are
-          well-understood. Host networking has its own class of security
-          vulnerabilities. Therefore, we recommend its use only in trusted
-          environments such as private data centers.
       chp:
         type: object
         additionalProperties: false
@@ -1262,6 +1249,7 @@ properties:
           nodeSelector: *nodeSelector-spec
           tolerations: *tolerations-spec
           containerSecurityContext: *containerSecurityContext-spec
+          hostNetwork: *hostNetwork-spec
           image: *image-spec
           livenessProbe: *probe-spec
           readinessProbe: *probe-spec
@@ -1599,6 +1587,7 @@ properties:
                 type: integer
               preload:
                 type: boolean
+          hostNetwork: *hostNetwork-spec
           image: *image-spec
           resources: *resources-spec
           serviceAccount: *serviceAccount
@@ -2081,6 +2070,7 @@ properties:
             description: |
               You can have multiple schedulers to share the workload or improve
               availability on node failure.
+          hostNetwork: *hostNetwork-spec
           image: *image-spec
           pdb: *pdb-spec
           nodeSelector: *nodeSelector-spec

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.hub.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
+      {{- if .Values.proxy.traefik.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       nodeSelector: {{ toJson .Values.proxy.traefik.nodeSelector }}
       {{- with concat .Values.scheduling.corePods.tolerations .Values.proxy.traefik.tolerations }}
       tolerations:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -40,6 +40,10 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.proxy.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -40,13 +40,13 @@ spec:
         {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.proxy.hostNetwork }}
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
-      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
+      {{- end }}
+      {{- if .Values.proxy.chp.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       nodeSelector: {{ toJson .Values.proxy.chp.nodeSelector }}
       {{- with concat .Values.scheduling.corePods.tolerations .Values.proxy.chp.tolerations }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       annotations:
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.scheduling.userScheduler.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
       {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -30,6 +30,7 @@ hub:
     JupyterHub:
       admin_access: true
       authenticator_class: dummy
+  hostNetwork: false
   service:
     type: ClusterIP
     annotations: {}
@@ -171,6 +172,7 @@ proxy:
     ##     Error: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     ##     Error: UPGRADE FAILED: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     rollingUpdate:
+  hostNetwork: false
   # service relates to the proxy-public service
   service:
     type: LoadBalancer

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -172,7 +172,6 @@ proxy:
     ##     Error: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     ##     Error: UPGRADE FAILED: Deployment.apps "proxy" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
     rollingUpdate:
-  hostNetwork: false
   # service relates to the proxy-public service
   service:
     type: LoadBalancer
@@ -192,6 +191,7 @@ proxy:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+    hostNetwork: false
     image:
       name: jupyterhub/configurable-http-proxy
       tag: 4.4.0
@@ -233,6 +233,7 @@ proxy:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+    hostNetwork: false
     image:
       name: traefik
       tag: v2.4.9 # ref: https://hub.docker.com/_/traefik?tab=tags
@@ -422,6 +423,7 @@ scheduling:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+    hostNetwork: false
     image:
       # IMPORTANT: Bumping the minor version of this binary should go hand in
       #            hand with an inspection of the user-scheduelrs RBAC resources


### PR DESCRIPTION
Add configuration options for using host networking for the hub and proxy pods. This PR relates to issue #2256.

As mentioned in #2256, this will greatly simplify and ease deployment when the notebook pods are configured to run on the host network. For example, notebook pod networking is used for compatibility with Spark. Spark requires a routable client address. When Spark runs outside the kubernetes cluster, the client cannot send an address to Spark that's routable back to the notebook pod unless it's on the host network.