### PR TITLE
hub image: run apt-get upgrade by default to patch known vulns

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -11,6 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN EXTRA_APT_PACKAGES=; \
     if [ `uname -m` != 'x86_64' ]; then EXTRA_APT_PACKAGES=libpq-dev; fi; \
     apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
       git \
       vim \


### PR DESCRIPTION
The official `ubuntu` image that we use as a base image for `hub` isn't updated so often, but various libraries in ubuntu are updated more often, where they also quite often have fixes to known vulnerabilities in them.

We have a system to detect if rebuilding the image fixes some known vulnerabilities, but in practice it requires a new ubuntu image to have been released - which is too seldom. So perhaps its worth doing `apt-get upgrade -y` to patch some known vulnerabilities in between the ubuntu image is updated?

### Image size?

I observed the image size grow from 625 to 631 which I assume is because some packages were upgraded, but overall it doesn't seem to make it grow substantially so I think this is worth it to more or less always end up with no known vulnerabilities whenever we rebuild the image.

### Fixes known vulns?

I confirmed with trivy that doing this fixed known vulns that is observed for example in #2269 to be unfixed after a rebuild.