### PR TITLE
Add ingress.pathType config

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2302,6 +2302,13 @@ properties:
           Suffix added to Ingress's routing path pattern.
 
           Specify `*` if your ingress matches path by glob pattern.
+      pathType:
+        enum: [Prefix, Exact, ImplementationSpecific]
+        description: |
+          The path type to use. The default value is 'Prefix'. Only applies on Kubernetes v1.18+.
+
+          See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) 
+          for more details about path types.
       tls:
         type: array
         description: |

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         paths:
           - path: {{ $.Values.hub.baseUrl | trimSuffix "/" }}/{{ $.Values.ingress.pathSuffix }}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-            pathType: Prefix
+            pathType: {{ $.Values.ingress.pathType }}
             backend:
               service:
                 name: {{ include "jupyterhub.proxy-public.fullname" $ }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -529,6 +529,7 @@ ingress:
   annotations: {}
   hosts: []
   pathSuffix:
+  pathType: Prefix
   tls: []
 
 cull:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -457,6 +457,8 @@ ingress:
   hosts:
     - mocked1.domain.name
     - mocked2.domain.name
+  pathSuffix: dummy-pathSuffix
+  pathType: ImplementationSpecific
   tls:
     - secretName: jupyterhub-tls
       hosts:


### PR DESCRIPTION
This adds the ability to set the pathType field on ingress rules for situations where Prefix is not available or appropriate, such as on GKE 1.19+ with the native ingress controller which only accepts 'ImplementationSpecific' as the pathType.