### PR TITLE
Add configuration for arbitrary extra pod spec

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1160,13 +1160,13 @@ properties:
             patternProperties: *labels-and-annotations-patternProperties
             description: |
               Kubernetes annotations to apply to the k8s ServiceAccount.
-      extraPodSpec: &jupyterhub-extra-pod-spec
+      extraPodSpec: &extraPodSpec-spec
         type: object
         additionalProperties: true
         description: |
           Arbitrary extra k8s pod specification as a YAML object. The default
           value of this setting is an empty object, i.e. no extra configuration.
-          The value of this property is merged into the pod specification as-is.
+          The value of this property is augmented to the pod specification as-is.
 
           This is a powerful tool for expert k8s administrators with advanced
           configuration requirements. This setting should only be used for
@@ -1293,7 +1293,7 @@ properties:
               or produce more informative error messages than the Hub's default,
               e.g. in highly customized deployments such as BinderHub.
               See Configurable HTTP Proxy for details on implementing an error target.
-          extraPodSpec: *jupyterhub-extra-pod-spec
+          extraPodSpec: *extraPodSpec-spec
       secretToken:
         type: [string, "null"]
         description: |
@@ -1614,7 +1614,7 @@ properties:
           image: *image-spec
           resources: *resources-spec
           serviceAccount: *serviceAccount
-          extraPodSpec: *jupyterhub-extra-pod-spec
+          extraPodSpec: *extraPodSpec-spec
       labels:
         type: object
         additionalProperties: false
@@ -2139,7 +2139,7 @@ properties:
                           type: integer
           resources: *resources-spec
           serviceAccount: *serviceAccount
-          extraPodSpec: *jupyterhub-extra-pod-spec
+          extraPodSpec: *extraPodSpec-spec
       podPriority:
         type: object
         additionalProperties: false

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1174,7 +1174,17 @@ properties:
           Misusing this setting can break your deployment and/or compromise
           your system security.
 
-          One use of this setting is to configure the hub pod with host networking:
+          This is one of four related settings for inserting arbitrary pod
+          specification:
+
+          1. hub.extraPodSpec
+          2. proxy.chp.extraPodSpec
+          3. proxy.traefik.extraPodSpec
+          4. scheduling.userScheduler.extraPodSpec
+
+          One real-world use of these settings is to enable host networking. For
+          example, to configure host networking for the hub pod, add the
+          following to your helm configuration values:
 
           ```yaml
           hub:
@@ -1183,7 +1193,8 @@ properties:
               dnsPolicy: ClusterFirstWithHostNet
           ```
 
-          To configure the proxy pod with host networking:
+          Likewise, to configure host networking for the proxy pod, add the
+          following:
 
           ```yaml
           proxy:
@@ -1193,10 +1204,11 @@ properties:
                 dnsPolicy: ClusterFirstWithHostNet
           ```
 
-          and so on...
+          N.B. Host networking has special security implications and can easily
+          break your deployment. This is an example—not an endorsement.
 
           See [PodSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
-          for the latest, complete definition of the pod specification.
+          for the latest pod resource specification.
 
   proxy:
     type: object

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1168,14 +1168,13 @@ properties:
           value of this setting is an empty object, i.e. no extra configuration.
           The value of this property is merged into the pod specification as-is.
 
-          This is a powerful tool for _expert_ k8s administrators with advanced
+          This is a powerful tool for expert k8s administrators with advanced
           configuration requirements. This setting should only be used for
-          configuration that cannot be accomplished through the other settings
-          in your values.yaml. Misusing this setting can break your deployment
-          and/or compromise your system security.
+          configuration that cannot be accomplished through the other settings.
+          Misusing this setting can break your deployment and/or compromise
+          your system security.
 
-          For example, to configure the hub pod with host networking, you could
-          include the following in your chart values:
+          One use of this setting is to configure the hub pod with host networking:
 
           ```yaml
           hub:
@@ -1196,7 +1195,7 @@ properties:
 
           and so on...
 
-          See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+          See [PodSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec)
           for the latest, complete definition of the pod specification.
 
   proxy:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1160,6 +1160,44 @@ properties:
             patternProperties: *labels-and-annotations-patternProperties
             description: |
               Kubernetes annotations to apply to the k8s ServiceAccount.
+      extraPodSpec: &jupyterhub-extra-pod-spec
+        type: object
+        additionalProperties: true
+        description: |
+          Arbitrary extra k8s pod specification as a YAML object. The default
+          value of this setting is an empty object, i.e. no extra configuration.
+          The value of this property is merged into the pod specification as-is.
+
+          This is a powerful tool for _expert_ k8s administrators with advanced
+          configuration requirements. This setting should only be used for
+          configuration that cannot be accomplished through the other settings
+          in your values.yaml. Misusing this setting can break your deployment
+          and/or compromise your system security.
+
+          For example, to configure the hub pod with host networking, you could
+          include the following in your chart values:
+
+          ```yaml
+          hub:
+            extraPodSpec:
+              hostNetwork: true
+              dnsPolicy: ClusterFirstWithHostNet
+          ```
+
+          To configure the proxy pod with host networking:
+
+          ```yaml
+          proxy:
+            chp:
+              extraPodSpec:
+                hostNetwork: true
+                dnsPolicy: ClusterFirstWithHostNet
+          ```
+
+          and so on...
+
+          See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+          for the latest, complete definition of the pod specification.
 
   proxy:
     type: object
@@ -1256,6 +1294,7 @@ properties:
               or produce more informative error messages than the Hub's default,
               e.g. in highly customized deployments such as BinderHub.
               See Configurable HTTP Proxy for details on implementing an error target.
+          extraPodSpec: *jupyterhub-extra-pod-spec
       secretToken:
         type: [string, "null"]
         description: |
@@ -1576,6 +1615,7 @@ properties:
           image: *image-spec
           resources: *resources-spec
           serviceAccount: *serviceAccount
+          extraPodSpec: *jupyterhub-extra-pod-spec
       labels:
         type: object
         additionalProperties: false
@@ -2100,6 +2140,7 @@ properties:
                           type: integer
           resources: *resources-spec
           serviceAccount: *serviceAccount
+          extraPodSpec: *jupyterhub-extra-pod-spec
       podPriority:
         type: object
         additionalProperties: false

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -230,3 +230,6 @@ spec:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
               port: http
           {{- end }}
+      {{- if .Values.hub.extraPodSpec }}
+      {{ toYaml .Values.hub.extraPodSpec | nindent 6 }}
+      {{- end }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -230,6 +230,6 @@ spec:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
               port: http
           {{- end }}
-      {{- if .Values.hub.extraPodSpec }}
-      {{ toYaml .Values.hub.extraPodSpec | nindent 6 }}
+      {{- with .Values.hub.extraPodSpec }}
+      {{- . | toYaml | trimSuffix "\n" | nindent 6 }}
       {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -135,7 +135,7 @@ spec:
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
-      {{- if .Values.proxy.traefik.extraPodSpec }}
-      {{ toYaml .Values.proxy.traefik.extraPodSpec | nindent 6 }}
+      {{- with .Values.proxy.traefik.extraPodSpec }}
+      {{- . | toYaml | trimSuffix "\n" | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -135,4 +135,7 @@ spec:
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
+      {{- if .Values.proxy.traefik.extraPodSpec }}
+      {{ toYaml .Values.proxy.traefik.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -163,6 +163,6 @@ spec:
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
-      {{- if .Values.proxy.chp.extraPodSpec }}
-      {{ toYaml .Values.proxy.chp.extraPodSpec | nindent 6 }}
+      {{- with .Values.proxy.chp.extraPodSpec }}
+      {{- . | toYaml | trimSuffix "\n" | nindent 6 }}
       {{- end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -163,3 +163,6 @@ spec:
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
+      {{- if .Values.proxy.chp.extraPodSpec }}
+      {{ toYaml .Values.proxy.chp.extraPodSpec | nindent 6 }}
+      {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -79,4 +79,7 @@ spec:
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
+      {{- if .Values.scheduling.userScheduler.extraPodSpec }}
+      {{ toYaml .Values.scheduling.userScheduler.extraPodSpec | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -79,7 +79,7 @@ spec:
           securityContext:
             {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
           {{- end }}
-      {{- if .Values.scheduling.userScheduler.extraPodSpec }}
-      {{ toYaml .Values.scheduling.userScheduler.extraPodSpec | nindent 6 }}
+      {{- with .Values.scheduling.userScheduler.extraPodSpec }}
+      {{- . | toYaml | trimSuffix "\n" | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -136,6 +136,7 @@ hub:
   existingSecret:
   serviceAccount:
     annotations: {}
+  extraPodSpec: {}
 
 rbac:
   enabled: true
@@ -224,6 +225,7 @@ proxy:
       enabled: false
       maxUnavailable:
       minAvailable: 1
+    extraPodSpec: {}
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
   traefik:
@@ -265,6 +267,7 @@ proxy:
       minAvailable: 1
     serviceAccount:
       annotations: {}
+    extraPodSpec: {}
   secretSync:
     containerSecurityContext:
       runAsUser: 65534 # nobody user
@@ -437,6 +440,7 @@ scheduling:
     resources: {}
     serviceAccount:
       annotations: {}
+    extraPodSpec: {}
   podPriority:
     enabled: false
     globalDefault: false

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -162,6 +162,9 @@ hub:
       effect: NoSchedule
   serviceAccount: &serviceAccount
     annotations: *annotations
+  extraPodSpec: &extraPodSpec
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
 
 rbac:
   enabled: true
@@ -212,6 +215,7 @@ proxy:
       enabled: true
       maxUnavailable: 1
       minAvailable: 1
+    extraPodSpec: *extraPodSpec
   traefik:
     extraPorts:
       - name: ssh
@@ -239,6 +243,7 @@ proxy:
       maxUnavailable: null
       minAvailable: 1
     serviceAccount: *serviceAccount
+    extraPodSpec: *extraPodSpec
   secretSync:
     resources: *resources
   labels: *labels
@@ -402,6 +407,7 @@ scheduling:
             weight: 161051
           - name: NodeAffinity
     serviceAccount: *serviceAccount
+    extraPodSpec: *extraPodSpec
   podPriority:
     enabled: true
   userPlaceholder:


### PR DESCRIPTION
Add configuration for arbitrary extra pod spec for the hub, chp, traefik and user scheduler deployments.

This change arose from a desire to deploy the hub and proxy on the host network. See PR #2300 for that discussion.

Following that conversation, I am pursuing an alternate strategy whereby we provide an escape hatch for the end user to specify arbitrary pod specification for the hub, chp, traefik and user scheduler deployments.

The extra pod specification can be provided in four locations in values.yaml:

  1. hub.extraPodSpec
  1. proxy.chp.extraPodSpec
  1. proxy.traefik.extraPodSpec
  1. scheduling.userScheduler.extraPodSpec

For example,

```yaml
hub:
  extraPodSpec:
    hostNetwork: true
    dnsPolicy: ClusterFirstWithHostNet
```