### PR TITLE
fix: bug if z2jh is used as a dependency with an alias

### DIFF
--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -37,8 +37,10 @@
     {{- $fullname_override := .Values.fullnameOverride }}
     {{- $name_override := .Values.nameOverride }}
     {{- if ne .Chart.Name "jupyterhub" }}
-        {{- $fullname_override = .Values.jupyterhub.fullnameOverride }}
-        {{- $name_override = .Values.jupyterhub.nameOverride }}
+        {{- if .Values.jupyterhub }}
+            {{- $fullname_override = .Values.jupyterhub.fullnameOverride }}
+            {{- $name_override = .Values.jupyterhub.nameOverride }}
+        {{- end }}
     {{- end }}
 
     {{- if eq (typeOf $fullname_override) "string" }}


### PR DESCRIPTION
If z2jh was used as a dependency helm chart, and it had an alias, this bug would happen which make template rendering fail.

As an example, the following Chart.yaml would cause an error.

```yaml
apiVersion: v2
description: irrelevant
name: irrelevant
version: 0.1.0
dependencies:
  - name: jupyterhub
    version: "1.0.1"
    repository: "https://jupyterhub.github.io/helm-chart"
    alias: dep-chart-alias
```

```
executing "jupyterhub.fullname" at <.Values.jupyterhub.fullnameOverride>: nil pointer evaluating interface {}.fullnameOverride
```