### PR TITLE
Bump patch version of: traefik, kube-scheduler, pause

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -428,7 +428,7 @@ scheduling:
       #            hand with an inspection of the user-scheduelrs RBAC resources
       #            that we have forked.
       name: k8s.gcr.io/kube-scheduler
-      tag: v1.19.10 # ref: https://github.com/kubernetes/sig-release/blob/HEAD/releases/patch-releases.md
+      tag: v1.19.13 # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
       pullPolicy:
       pullSecrets: []
     nodeSelector: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -193,7 +193,7 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: jupyterhub/configurable-http-proxy
-      tag: 4.4.0
+      tag: 4.4.0 # https://github.com/jupyterhub/configurable-http-proxy/releases
       pullPolicy:
       pullSecrets: []
     extraCommandLineFlags: []
@@ -235,7 +235,7 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: traefik
-      tag: v2.4.9 # ref: https://hub.docker.com/_/traefik?tab=tags
+      tag: v2.4.11 # ref: https://hub.docker.com/_/traefik?tab=tags
       pullPolicy:
       pullSecrets: []
     hsts:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -450,7 +450,11 @@ scheduling:
     enabled: true
     image:
       name: k8s.gcr.io/pause
-      tag: "3.2" # https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/pause?gcrImageListsize=30
+      # tag's can be updated by inspecting the output of the command:
+      # gcloud container images list-tags k8s.gcr.io/pause --sort-by=~tags
+      #
+      # If you update this, also update prePuller.pause.image.tag
+      tag: "3.5"
       pullPolicy:
       pullSecrets: []
     replicas: 0
@@ -524,7 +528,11 @@ prePuller:
       allowPrivilegeEscalation: false
     image:
       name: k8s.gcr.io/pause
-      tag: "3.2" # https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/pause?gcrImageListsize=30
+      # tag's can be updated by inspecting the output of the command:
+      # gcloud container images list-tags k8s.gcr.io/pause --sort-by=~tags
+      #
+      # If you update this, also update scheduling.userPlaceholder.image.tag
+      tag: "3.5"
       pullPolicy:
       pullSecrets: []
 


### PR DESCRIPTION
- bump: traefik from 2.4.9 to 2.4.11
- bump: kube-scheduler from 1.19.10 to 1.19.13
- bump: pause image from 3.2 to 3.5
