### PR TITLE
Add support for arm64 in singleuser-sample image

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -46,8 +46,6 @@ charts:
         valuesPath: prePuller.hook.image
 
       # singleuser-sample, a primitive user container to start with.
-      # Image is based on https://github.com/jupyter/docker-stacks/ which is amd64 only
       singleuser-sample:
         valuesPath: singleuser.image
-        skipPlatforms:
-          - linux/arm64
+        PIP_OVERRIDES: jupyterhub==1.4.2

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:5211732116f7
+FROM jupyter/base-notebook:latest
 # Built from... https://hub.docker.com/r/jupyter/base-notebook/
 #               https://github.com/jupyter/docker-stacks/blob/HEAD/base-notebook/Dockerfile
 # Built from... Ubuntu 20.04

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -10,10 +10,12 @@ FROM jupyter/base-notebook:latest
 # Example install of git and nbgitpuller.
 # NOTE: git is already available in the jupyter/minimal-notebook image.
 USER root
-RUN apt-get update && apt-get install --yes --no-install-recommends \
-    dnsutils \
-    git \
-    iputils-ping \
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y --no-install-recommends \
+        dnsutils \
+        git \
+        iputils-ping \
  && rm -rf /var/lib/apt/lists/*
 USER $NB_USER
 


### PR DESCRIPTION
This is the result of a lot of work in jupyter/docker-stacks surrounding https://github.com/jupyter/docker-stacks/issues/1019!

Thank you everyone involved! Thank you @sakuraiyuta, @holdenk, @mathbunnyru, @manics, @jiwidi, @parente, @AvverbioPronome, @step21, @akitanaka, and @romainx!

It makes me very happy to finally get the JupyterHub Helm chart 100% arm64 compatible!

Closes #2145

---

### Update 1

This PR can't be merged until https://github.com/jupyter/docker-stacks/issues/1411 is resolved sadly.

---

### Update 2

Wait what... the singleuser-sample could build without an arm64 compatible image was published? I'm not sure why that is... @manics do you think https://github.com/jupyter/docker-stacks/pull/1368 was sufficient? I'm very confused why the build of our singleuser-sample with arm64 succeeded if has a FROM statement from an image that doesn't list arm64 in its manifest.

Why did https://github.com/jupyterhub/zero-to-jupyterhub-k8s/runs/3090822567 not fail!?

### Update 3

I'm still very confused: why was it possible for our singleuser-sample to build an arm64 image from a Dockerfile that had a FROM statement referencing an amd64 image?

No matter what though, I'll go for a merge now, because we now have arm64 compatible images pushed and when retriggering the tests they still succeed.