### PR TITLE
fix schema: accept proxy.traefik.extra[Static|Dynamic]Config

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1584,7 +1584,7 @@ properties:
           containerSecurityContext: *containerSecurityContext-spec
           extraDynamicConfig:
             type: object
-            additionalProperties: false
+            additionalProperties: true
             description: |
               This refers to traefik's post-startup configuration.
 
@@ -1600,7 +1600,7 @@ properties:
               that you would like to expose, formatted in a k8s native way.
           extraStaticConfig:
             type: object
-            additionalProperties: false
+            additionalProperties: true
             description: |
               This refers to traefik's startup configuration.
 

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -222,9 +222,6 @@ proxy:
       minAvailable: 1
     extraPodSpec: *extraPodSpec
   traefik:
-    extraPorts:
-      - name: ssh
-        containerPort: 8022
     labels: *labels
     resources: *resources
     extraEnv: *extraEnv
@@ -242,13 +239,33 @@ proxy:
             - ipBlock:
                 cidr: 0.0.0.0/0
       interNamespaceAccessLabels: accept
-      allowedIngressPorts: [http, https]
+      allowedIngressPorts: [http, https, ssh]
     pdb:
       enabled: true
       maxUnavailable: null
       minAvailable: 1
     serviceAccount: *serviceAccount
     extraPodSpec: *extraPodSpec
+    extraPorts:
+      - name: ssh
+        containerPort: 8022
+    extraStaticConfig:
+      entryPoints:
+        ssh:
+          address: ":8022"
+    extraDynamicConfig:
+      tcp:
+        services:
+          ssh:
+            loadBalancer:
+              servers:
+                - address: jupyterhub-ssh:22
+        routers:
+          ssh-router:
+            entrypoints:
+              - ssh
+            rule: "HostSNI(`*`)"
+            service: ssh
   secretSync:
     resources: *resources
   labels: *labels


### PR DESCRIPTION
The schema was too strict by mistake and didn't allow for any values to be passed to `proxy.traefik.extra[Static|Dynamic]Config`.