### PR TITLE
Allow CHP to function in a IPv4 only and/or IPv6 only context

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -152,16 +152,20 @@ jobs:
           - k3s-channel: v1.19
             test: upgrade
             upgrade-from: stable
+            # FIXME: After z2jh 1.1.0 release, remove the proxy tag pin
             upgrade-from-extra-args: >-
               --set proxy.secretToken=aaaa1111
               --set hub.cookieSecret=bbbb2222
               --set hub.config.CryptKeeper.keys[0]=cccc3333
+              --set proxy.chp.image.tag=4.5.0
             create-k8s-test-resources: true
           - k3s-channel: v1.19
             test: upgrade
             upgrade-from: dev
+            # FIXME: After z2jh 1.1.0 release, remove the proxy tag pin
             upgrade-from-extra-args: >-
               --set proxy.secretToken=aaaa1111
+              --set proxy.chp.image.tag=4.5.0
 
     steps:
       - uses: actions/checkout@v2

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -71,8 +71,8 @@ spec:
           {{- $hubHost := printf "http://%s:$(%s_SERVICE_PORT)" (include "jupyterhub.hub.fullname" .) $hubNameAsEnv }}
           command:
             - configurable-http-proxy
-            - "--ip=::"
-            - "--api-ip=::"
+            - "--ip="
+            - "--api-ip="
             - --api-port=8001
             - --default-target={{ .Values.proxy.chp.defaultTarget | default $hubHost }}
             - --error-target={{ .Values.proxy.chp.errorTarget | default (printf "%s/hub/error" $hubHost) }}


### PR DESCRIPTION
# PR summary

This changes relies on CHP 4.5.0 that was patched with https://github.com/jupyterhub/configurable-http-proxy/pull/333 to be able to listen to all available network interfaces, IPv4, IPv6, or both.

---

# Outdated notes from debugging

I note that code in CHP, that is influenced by how Z2JH configures CHP via flags, could potentially be set differently to avoid issues in different contextswhere IPv4/IPv6 either both or only one is available. I consider this due to the discussion in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2254#issuecomment-878951182.

I created this PR to trial if setting `--ip=` to a blank string would make a difference. I consider this because of @minrk's comment saying `Preferred usage is 0.0.0.0 for all IPv4 or '' for all-interfaces.` and was thinking that all-interfaces may potentially be either all IPv4 and IPv6 if both is available, or only IPv4 or IPv6 if only one of them are available. Then, I think we have a solution to #2254 that experience issues as `--ip=::` causes trouble if IPv6 is disabled.

### Z2JH [code of relevance](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/04fcd411deee0a62a60876f62d824da81eb89420/jupyterhub/templates/proxy/deployment.yaml#L73-L75)

```yaml
          command:
            - configurable-http-proxy
            - "--ip=::"
            - "--api-ip=::"
```

### CHP [code of relevance](https://github.com/jupyterhub/configurable-http-proxy/blob/94cd6f525d92e70a8412a191b9587e716edc18c9/bin/configurable-http-proxy#L310-L329)

Note `args.ip` and `args.apiIp` etc map to `--ip` and `--api-ip` via a command line parser.

```node
var listen = {};
listen.port = parseInt(args.port) || 8000;
if (args.ip === "*") {
  // handle ip=* alias for all interfaces
  log.warn(
    "Interpreting ip='*' as all-interfaces. Preferred usage is 0.0.0.0 for all IPv4 or '' for all-interfaces."
  );
  args.ip = "";
}
listen.ip = args.ip;
listen.apiIp = args.apiIp || "localhost";
listen.apiPort = args.apiPort || listen.port + 1;
listen.metricsIp = args.metricsIp || "0.0.0.0";
listen.metricsPort = args.metricsPort;

proxy.proxyServer.listen(listen.port, listen.ip);
proxy.apiServer.listen(listen.apiPort, listen.apiIp);
if (listen.metricsPort) {
  proxy.metricsServer.listen(listen.metricsPort, listen.metricsIp);
}
```

### Outcome of setting `--ip=` and`--api-ip=`

```
### $ kubectl logs --all-containers deploy/proxy
20:32:26.351 [ConfigProxy] info: Adding route / -> http://hub:8081
20:32:26.359 [ConfigProxy] info: Proxying http://*:8000 to http://hub:8081
20:32:26.359 [ConfigProxy] info: Proxy API at http://localhost:8001/api/routes
20:32:26.361 [ConfigProxy] info: Route added / -> http://hub:8081
```

Ah... But if we make the following modifications...

```diff
-listen.apiIp = args.apiIp || "localhost";
+listen.apiIp = args.apiIp;
```

```
### $ kubectl logs --all-containers deploy/proxy
21:30:18.584 [ConfigProxy] info: Adding route / -> http://hub:8081
21:30:18.592 [ConfigProxy] info: Proxying http://*:8000 to http://hub:8081
21:30:18.593 [ConfigProxy] info: Proxy API at http://*:8001/api/routes
21:30:18.594 [ConfigProxy] info: Route added / -> http://hub:8081
```