### PR TITLE
ci: misc fixes post 1.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,15 +77,10 @@ jobs:
 
       - name: Install chart publishing dependencies (chartpress, helm)
         run: |
-          . ./ci/common
-          setup_helm
-          helm version
-
-          # FIXME: six is required by docker 5.0.0 but isn't explicitly required
-          #        https://github.com/docker/docker-py/issues/2807
-          #
-          pip install chartpress pyyaml six
+          pip install chartpress pyyaml
           pip list
+
+          helm version
 
       - name: Setup push rights to jupyterhub/helm-chart
         # This was setup by...

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -33,10 +33,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install dependencies
-        run: |
-          . ci/common
-          setup_helm
-          pip install chartpress yamllint
+        run: pip install chartpress yamllint
 
       - uses: pre-commit/action@v2.0.3
         with:
@@ -152,20 +149,16 @@ jobs:
           - k3s-channel: v1.19
             test: upgrade
             upgrade-from: stable
-            # FIXME: After z2jh 1.1.0 release, remove the proxy tag pin
             upgrade-from-extra-args: >-
               --set proxy.secretToken=aaaa1111
               --set hub.cookieSecret=bbbb2222
               --set hub.config.CryptKeeper.keys[0]=cccc3333
-              --set proxy.chp.image.tag=4.5.0
             create-k8s-test-resources: true
           - k3s-channel: v1.19
             test: upgrade
             upgrade-from: dev
-            # FIXME: After z2jh 1.1.0 release, remove the proxy tag pin
             upgrade-from-extra-args: >-
               --set proxy.secretToken=aaaa1111
-              --set proxy.chp.image.tag=4.5.0
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -35,11 +35,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install chartpress
-        run: |
-          # FIXME: six is required by docker 5.0.0 but isn't explicitly required
-          #        https://github.com/docker/docker-py/issues/2807
-          #
-          pip install chartpress six
+        run: pip install chartpress
 
       - name: Set up QEMU (for docker buildx)
         uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # dependabot updates to latest release

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -46,10 +46,7 @@ hub:
     test-explicit-name:
       name: some-explicitly-set-name
       apiToken: eeee5555
-    # FIXME: add this test at a later time, after 1.1.0, when upgrade tests
-    #        won't break because previous versions doesn't have support for this
-    #        config when this was added.
-    # test-generation-of-apiToken: {}
+    test-generation-of-apiToken: {}
   networkPolicy:
     egress: # overrides allowance of 0.0.0.0/0
       # In kind/k3s clusters the Kubernetes API server is exposing this port


### PR DESCRIPTION
- Chartpress now includes a workaround that made us need to install `six` before.
- `helm` ships with the GitHub actions environment and doesn't have to be installed there if we want a very recent version.
- Removed patches for upgrade tests needed to not make them break before 1.1.0 was released.