### PR TITLE
additionalProperties should be set to True for templateVars in the schema

### DIFF
--- a/doc/source/administrator/authentication.md
+++ b/doc/source/administrator/authentication.md
@@ -364,7 +364,7 @@ can configure the GenericOAuthenticator class to authenticate against a KeyCloak
 server.
 
 To configure an OpenID Connect client, see [KeyCloak's own
-documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#oidc-clients).
+documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#_oidc_clients).
 
 ```yaml
 hub:

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1232,7 +1232,7 @@ properties:
         description: *jupyterhub-native-config-description
       templateVars:
         type: object
-        additionalProperties: false
+        additionalProperties: true
         description: *jupyterhub-native-config-description
       imagePullSecret: &deprecated-imagePullSecret
         type: object

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -122,6 +122,11 @@ hub:
   extraContainers: []
   extraVolumes: []
   extraVolumeMounts: []
+  templatePaths:
+    - /etc/jupyterhub/templates
+  templateVars:
+    announcement: 'Some text'
+    another_announcement: 'Some more text'
   resources: &resources
     requests:
       cpu: 100m

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -125,8 +125,8 @@ hub:
   templatePaths:
     - /etc/jupyterhub/templates
   templateVars:
-    announcement: 'Some text'
-    another_announcement: 'Some more text'
+    announcement: "Some text"
+    another_announcement: "Some more text"
   resources: &resources
     requests:
       cpu: 100m


### PR DESCRIPTION
While trying to set `templateVars` we can't set additionalProperties, this PR fixes that

A minimal example
```
hub:
  templateVars:
    announcement: 'Some Text'
```

and deploying with
```
helm upgrade --install jhub jupyterhub/jupyterhub --version=1.1.1 --values config.yaml
```

fails the lint with the current schema.