### PR TITLE
refactor: remove redundant trimSuffix of new lines after toYaml

### DIFF
--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -322,9 +322,9 @@ limits:
         {{- if $file_details.data }}
             {{- $file_key | quote }}: |
               {{- if or (eq (ext $file_name) ".yaml") (eq (ext $file_name) ".yml") }}
-              {{- $file_details.data | toYaml | trimSuffix "\n" | nindent 2 }}{{ println }}
+              {{- $file_details.data | toYaml | nindent 2 }}{{ println }}
               {{- else if eq (ext $file_name) ".json" }}
-              {{- $file_details.data | toJson | trimSuffix "\n" | nindent 2 }}{{ println }}
+              {{- $file_details.data | toJson | nindent 2 }}{{ println }}
               {{- else if eq (ext $file_name) ".toml" }}
               {{- $file_details.data | toToml | trimSuffix "\n" | nindent 2 }}{{ println }}
               {{- else }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}
   strategy:
-    {{- .Values.hub.deploymentStrategy | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- .Values.hub.deploymentStrategy | toYaml | nindent 4 }}
   template:
     metadata:
       labels:
@@ -20,14 +20,14 @@ spec:
         hub.jupyter.org/network-access-proxy-http: "true"
         hub.jupyter.org/network-access-singleuser: "true"
         {{- with .Values.hub.labels }}
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         {{- /* This lets us autorestart when the secret changes! */}}
         checksum/config-map: {{ include (print .Template.BasePath "/hub/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/hub/secret.yaml") . | sha256sum }}
         {{- with .Values.hub.annotations }}
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.scheduling.podPriority.enabled }}
@@ -65,7 +65,7 @@ spec:
               {{- end }}
         {{- end }}
         {{- with .Values.hub.extraVolumes }}
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
         {{- if eq .Values.hub.db.type "sqlite-pvc" }}
         - name: pvc
@@ -82,11 +82,11 @@ spec:
       {{- end }}
       {{- with .Values.hub.initContainers }}
       initContainers:
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         {{- with .Values.hub.extraContainers }}
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
         - name: hub
           image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
@@ -153,7 +153,7 @@ spec:
               name: files
             {{- end }}
             {{- with .Values.hub.extraVolumeMounts }}
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
             {{- end }}
             {{- if eq .Values.hub.db.type "sqlite-pvc" }}
             - mountPath: /srv/jupyterhub
@@ -164,18 +164,18 @@ spec:
             {{- end }}
           {{- with .Values.hub.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.hub.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
           {{- with .Values.hub.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.hub.lifecycle }}
           lifecycle:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           env:
             - name: PYTHONUNBUFFERED
@@ -231,5 +231,5 @@ spec:
               port: http
           {{- end }}
       {{- with .Values.hub.extraPodSpec }}
-      {{- . | toYaml | trimSuffix "\n" | nindent 6 }}
+      {{- . | toYaml | nindent 6 }}
       {{- end }}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -56,7 +56,7 @@ spec:
 
     {{- with .Values.hub.networkPolicy.ingress }}
     # depends, but default is nothing --> hub
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 
   egress:
@@ -86,6 +86,6 @@ spec:
 
     {{- with .Values.hub.networkPolicy.egress }}
     # hub --> depends, but the default is everything
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/hub/pvc.yaml
+++ b/jupyterhub/templates/hub/pvc.yaml
@@ -7,18 +7,18 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   {{- with .Values.hub.db.pvc.annotations }}
   annotations:
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.hub.db.pvc.selector }}
   selector:
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
   {{- if typeIs "string" .Values.hub.db.pvc.storageClassName }}
   storageClassName: {{ .Values.hub.db.pvc.storageClassName | quote }}
   {{- end }}
   accessModes:
-    {{- .Values.hub.db.pvc.accessModes | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- .Values.hub.db.pvc.accessModes | toYaml | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.hub.db.pvc.storage | quote }}

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -40,7 +40,7 @@ spec:
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
       {{- with .Values.prePuller.annotations }}
       annotations:
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
     spec:
       {{- /*
@@ -82,11 +82,11 @@ spec:
             - echo "Pulling complete"
           {{- with .Values.prePuller.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.prePuller.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
         {{- end }}
 
@@ -99,11 +99,11 @@ spec:
             - echo "Pulling complete"
           {{- with .Values.prePuller.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.prePuller.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
 
         {{- /* --- Pull extra containers' images --- */}}
@@ -116,11 +116,11 @@ spec:
             - echo "Pulling complete"
           {{- with $.Values.prePuller.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with $.Values.prePuller.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
         {{- end }}
 
@@ -137,11 +137,11 @@ spec:
             - echo "Pulling complete"
           {{- with $.Values.prePuller.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with $.Values.prePuller.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- end }}
@@ -158,11 +158,11 @@ spec:
             - echo "Pulling complete"
           {{- with $.Values.prePuller.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with $.Values.prePuller.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
         {{- end }}
       containers:
@@ -170,11 +170,11 @@ spec:
           image: {{ .Values.prePuller.pause.image.name }}:{{ .Values.prePuller.pause.image.tag }}
           {{- with .Values.prePuller.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.prePuller.pause.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
 {{- end }}
 

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -30,7 +30,7 @@ spec:
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
       {{- with .Values.prePuller.annotations }}
       annotations:
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
     spec:
       restartPolicy: Never
@@ -61,10 +61,10 @@ spec:
             - -pod-scheduling-wait-duration={{ .Values.prePuller.hook.podSchedulingWaitDuration }}
           {{- with .Values.prePuller.hook.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.prePuller.hook.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
 {{- end }}

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   rules:
@@ -37,6 +37,6 @@ spec:
     {{- end }}
   {{- with .Values.ingress.tls }}
   tls:
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-http: "true"
         {{- with .Values.proxy.traefik.labels }}
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         # Only force a restart through a change to this checksum when the static
@@ -46,7 +46,7 @@ spec:
           configMap:
             name: {{ include "jupyterhub.autohttps.fullname" . }}
         {{- with .Values.proxy.traefik.extraVolumes }}
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
       {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.proxy.traefik.image) }}
       imagePullSecrets: {{ . }}
@@ -74,7 +74,7 @@ spec:
               mountPath: /etc/acme
           {{- with .Values.proxy.secretSync.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
       containers:
         - name: traefik
@@ -84,7 +84,7 @@ spec:
           {{- end }}
           {{- with .Values.proxy.traefik.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           ports:
             - name: http
@@ -92,7 +92,7 @@ spec:
             - name: https
               containerPort: 8443
             {{- with .Values.proxy.traefik.extraPorts }}
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: traefik-config
@@ -100,7 +100,7 @@ spec:
             - name: certificates
               mountPath: /etc/acme
             {{- with .Values.proxy.traefik.extraVolumeMounts }}
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
             {{- end }}
           {{- with .Values.proxy.traefik.extraEnv }}
           env:
@@ -108,7 +108,7 @@ spec:
           {{- end }}
           {{- with .Values.proxy.traefik.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
         - name: secret-sync
           image: "{{ .Values.proxy.secretSync.image.name }}:{{ .Values.proxy.secretSync.image.tag }}"
@@ -133,9 +133,9 @@ spec:
               mountPath: /etc/acme
           {{- with .Values.proxy.secretSync.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
       {{- with .Values.proxy.traefik.extraPodSpec }}
-      {{- . | toYaml | trimSuffix "\n" | nindent 6 }}
+      {{- . | toYaml | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -59,7 +59,7 @@ spec:
 
     {{- with .Values.proxy.traefik.networkPolicy.ingress}}
     # depends, but default is nothing --> proxy
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 
   egress:
@@ -81,6 +81,6 @@ spec:
 
     {{- with .Values.proxy.traefik.networkPolicy.egress }}
     # autohttps --> depends, but the default is everything
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/service.yaml
+++ b/jupyterhub/templates/proxy/autohttps/service.yaml
@@ -8,11 +8,11 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     {{- with .Values.proxy.service.labels }}
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
   {{- with .Values.proxy.service.annotations }}
   annotations:
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       {{- include "jupyterhub.matchLabels" . | nindent 6 }}
   strategy:
-    {{- .Values.proxy.deploymentStrategy | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- .Values.proxy.deploymentStrategy | toYaml | nindent 4 }}
   template:
     metadata:
       labels:
@@ -21,7 +21,7 @@ spec:
         hub.jupyter.org/network-access-hub: "true"
         hub.jupyter.org/network-access-singleuser: "true"
         {{- with .Values.proxy.labels }}
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         # We want to restart proxy only if the auth token changes
@@ -37,7 +37,7 @@ spec:
         checksum/auth-token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | sha256sum | trunc 4 | quote }}
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum | quote }}
         {{- with .Values.proxy.annotations }}
-        {{- . | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 60
@@ -105,7 +105,7 @@ spec:
           {{- end }}
           {{- with .Values.proxy.chp.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           env:
             - name: CONFIGPROXY_AUTH_TOKEN
@@ -161,8 +161,8 @@ spec:
           {{- end }}
           {{- with .Values.proxy.chp.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
       {{- with .Values.proxy.chp.extraPodSpec }}
-      {{- . | toYaml | trimSuffix "\n" | nindent 6 }}
+      {{- . | toYaml | nindent 6 }}
       {{- end }}

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -80,7 +80,7 @@ spec:
 
     {{- with .Values.proxy.chp.networkPolicy.ingress}}
     # depends, but default is nothing --> proxy
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 
   egress:
@@ -111,6 +111,6 @@ spec:
 
     {{- with .Values.proxy.chp.networkPolicy.egress }}
     # proxy --> depends, but the default is everything
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -27,11 +27,11 @@ metadata:
     {{- $_ := merge (dict "componentSuffix" "-public") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
     {{- with .Values.proxy.service.labels }}
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
   {{- with .Values.proxy.service.annotations }}
   annotations:
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   selector:
@@ -66,7 +66,7 @@ spec:
       {{- end }}
     {{- end }}
     {{- with .Values.proxy.service.extraPorts }}
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
   type: {{ .Values.proxy.service.type }}
   {{- with .Values.proxy.service.loadBalancerIP }}
@@ -75,6 +75,6 @@ spec:
   {{- if eq .Values.proxy.service.type "LoadBalancer" }}
   {{- with .Values.proxy.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
   {{- end }}

--- a/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
+++ b/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
@@ -6,7 +6,7 @@
     values: [user]
 {{- end }}
 {{- with .Values.singleuser.extraNodeAffinity.required }}
-{{- . | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- . | toYaml | nindent 0 }}
 {{- end }}
 {{- end }}
 
@@ -20,31 +20,31 @@
         values: [user]
 {{- end }}
 {{- with .Values.singleuser.extraNodeAffinity.preferred }}
-{{- . | toYaml | trimSuffix "\n" | nindent 0 }}
+{{- . | toYaml | nindent 0 }}
 {{- end }}
 {{- end }}
 
 {{- define "jupyterhub.userPodAffinityRequired" -}}
 {{- with .Values.singleuser.extraPodAffinity.required -}}
-{{ . | toYaml | trimSuffix "\n" }}
+{{ . | toYaml }}
 {{- end }}
 {{- end }}
 
 {{- define "jupyterhub.userPodAffinityPreferred" -}}
 {{- with .Values.singleuser.extraPodAffinity.preferred -}}
-{{ . | toYaml | trimSuffix "\n" }}
+{{ . | toYaml }}
 {{- end }}
 {{- end }}
 
 {{- define "jupyterhub.userPodAntiAffinityRequired" -}}
 {{- with .Values.singleuser.extraPodAntiAffinity.required -}}
-{{ . | toYaml | trimSuffix "\n" }}
+{{ . | toYaml }}
 {{- end }}
 {{- end }}
 
 {{- define "jupyterhub.userPodAntiAffinityPreferred" -}}
 {{- with .Values.singleuser.extraPodAntiAffinity.preferred -}}
-{{ . | toYaml | trimSuffix "\n" }}
+{{ . | toYaml }}
 {{- end }}
 {{- end }}
 

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
           image: {{ .Values.scheduling.userPlaceholder.image.name }}:{{ .Values.scheduling.userPlaceholder.image.tag }}
           {{- if .Values.scheduling.userPlaceholder.resources }}
           resources:
-            {{- .Values.scheduling.userPlaceholder.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- .Values.scheduling.userPlaceholder.resources | toYaml | nindent 12 }}
           {{- else if (include "jupyterhub.singleuser.resources" .) }}
           resources:
             {{- include "jupyterhub.singleuser.resources" . | nindent 12 }}
@@ -62,6 +62,6 @@ spec:
           {{- end }}
           {{- with .Values.scheduling.userPlaceholder.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -17,5 +17,5 @@ data:
     profiles:
       - schedulerName: {{ include "jupyterhub.user-scheduler.fullname" . }}
         plugins:
-          {{- .Values.scheduling.userScheduler.plugins | toYaml | trimSuffix "\n" | nindent 10 }}
+          {{- .Values.scheduling.userScheduler.plugins | toYaml | nindent 10 }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -73,13 +73,13 @@ spec:
               port: 10251
           {{- with .Values.scheduling.userScheduler.resources }}
           resources:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.scheduling.userScheduler.containerSecurityContext }}
           securityContext:
-            {{- . | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
       {{- with .Values.scheduling.userScheduler.extraPodSpec }}
-      {{- . | toYaml | trimSuffix "\n" | nindent 6 }}
+      {{- . | toYaml | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -57,7 +57,7 @@ spec:
 
     {{- with .Values.singleuser.networkPolicy.ingress }}
     # depends, but default is nothing --> singleuser-server
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 
   egress:
@@ -79,6 +79,6 @@ spec:
 
     {{- with .Values.singleuser.networkPolicy.egress }}
     # singleuser-server --> depends, but the default is everything
-    {{- . | toYaml | trimSuffix "\n" | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/tools/templates/yamllint-config.yaml
+++ b/tools/templates/yamllint-config.yaml
@@ -62,6 +62,6 @@ rules:
 #
 # # template.yaml
 # myList:
-#   {{- .Values.list | toYaml | trimSuffix "\n" | nindent 0 }}
+#   {{- .Values.list | toYaml | nindent 0 }}
 # myDict:
-#   {{- .Values.dict | toYaml | trimSuffix "\n" | nindent 2 }}
+#   {{- .Values.dict | toYaml | nindent 2 }}


### PR DESCRIPTION
In the past `toYaml` created a new line that we trimmed away - but I contributed a fix to that in helm/helm so now it doesn't in the modern versions of the `helm` CLI which the JupyterHub helm chart now require anyhow :)