### PR TITLE
Remove no longer needed arm test adjustment

### DIFF
--- a/dev-config-arm.yaml
+++ b/dev-config-arm.yaml
@@ -2,8 +2,3 @@
 proxy:
   https:
     enabled: false
-
-singleuser:
-  image:
-    name: sakuraiyuta/base-notebook
-    tag: latest


### PR DESCRIPTION
We have a arm compatible singleuser image at this point in time, no need to override it.