### PR TITLE
ci: test against k8s 1.22

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -115,9 +115,11 @@ jobs:
         # k3s-version: https://github.com/rancher/k3s/tags
         # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
-          - k3s-channel: v1.21
+          - k3s-channel: v1.22
             test: install
             debuggable: debuggable
+          - k3s-channel: v1.20
+            test: install
           - k3s-channel: v1.20
             test: install
           - k3s-channel: v1.19


### PR DESCRIPTION
In z2jh where we have kube-scheduler configured and running with a pinned k8s version binary, I think its relevant to run test against all k8s versions we support. In this PR I add the recent 1.22 available for k3s.

To clarify why it can be relevant to test all k8s versions we support, consider if our kube-scheduler binary is updated. It may start to fail to function on older versions of k8s because of how it speaks with the k8s api-server and such to schedule the pods. kube-scheduler the binary of a certain k8s release is supposed to function with k8s versions +-1 minor version, but we use one version against all the k8s versions we support. I've had some issues in the past with this, so due to that, I support testing all k8s versions in z2jh specifically.

Sibling PR to https://github.com/jupyterhub/binderhub/pull/1392