### PR TITLE
Update NOTES.txt

### DIFF
--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -1,54 +1,90 @@
-Thank you for installing JupyterHub!
+{{- $proxy_service := include "jupyterhub.proxy-public.fullname" . -}}
 
-Your release is named "{{ .Release.Name }}" and installed into the namespace "{{ .Release.Namespace }}".
+.      __                             __                   __  __            __
+      / /  __  __    ____    __  __  / /_  ___    _____   / / / /  __  __   / /_
+ __  / /  / / / /   / __ \  / / / / / __/ / _ \  / ___/  / /_/ /  / / / /  / __ \
+/ /_/ /  / /_/ /   / /_/ / / /_/ / / /_  /  __/ / /     / __  /  / /_/ /  / /_/ /
+\____/   \__,_/   / .___/  \__, /  \__/  \___/ /_/     /_/ /_/   \__,_/  /_.___/
+                 /_/      /____/
 
-You can check whether the hub and proxy are ready by running:
+       You have successfully installed the official JupyterHub Helm chart!
 
- kubectl --namespace={{ .Release.Namespace }} get pod
+### Installation info
 
-and watching for both those pods to be in status 'Running'.{{ println }}
+  - Kubernetes namespace: {{ .Release.Namespace }}
+  - Helm release name:    {{ .Release.Name }}
+  - Helm chart version:   {{ .Chart.Version }}
+  - JupyterHub version:   {{ .Chart.AppVersion }}
+  - Hub pod software:     See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/{{ include "jupyterhub.chart-version-to-git-ref" .Chart.Version }}/images/hub/requirements.txt
 
-{{- if eq .Values.proxy.service.type "LoadBalancer" }}
-You can find the public (load-balancer) IP of JupyterHub by running:
+### Followup links
 
-  kubectl -n {{ .Release.Namespace }} get svc {{ include "jupyterhub.proxy-public.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[].ip}'
+  - Documentation:  https://z2jh.jupyter.org
+  - Help forum:     https://discourse.jupyter.org
+  - Social chat:    https://gitter.im/jupyterhub/jupyterhub
+  - Issue tracking: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues
 
-It might take a few minutes for it to appear!
-{{- end }}
-{{- if eq .Values.proxy.service.type "ClusterIP" }}
-You can find the internal (cluster) IP of JupyterHub by running:
+### Post-installation checklist
 
-  kubectl get -n {{ .Release.Namespace }} svc {{ include "jupyterhub.proxy-public.fullname" . }} -o jsonpath='{.spec.clusterIP}'
-{{- end }}
-{{- if eq .Values.proxy.service.type "NodePort" }}
-You can find the NodePorts of JupyterHub by running:
+  - Verify that created Pods enter a Running state:
 
-  kubectl --namespace={{ .Release.Namespace }} get svc {{ include "jupyterhub.proxy-public.fullname" . }} -o jsonpath='{range .spec.ports[*]} {.name}: {.port}{"\n"} {end}'
-{{- end }}
+      kubectl --namespace={{ .Release.Namespace }} get pod
 
-{{- if .Values.ingress.enabled }}
+    If a pod is stuck with a Pending or ContainerCreating status, diagnose with:
 
-You should be able to access JupyterHub using your configured ingress at:
-{{ range $host := .Values.ingress.hosts }}
-  http://{{ $host }}{{ $.Values.hub.baseUrl | trimSuffix "/" }}/
-{{- end }}
-{{- range $tls := .Values.ingress.tls }}
-  {{- range $host := $tls.hosts }}
-  https://{{ $host }}{{ $.Values.hub.baseUrl | trimSuffix "/" }}/
+      kubectl --namespace={{ .Release.Namespace }} describe pod <name of pod>
+
+    If a pod keeps restarting, diagnose with:
+
+      kubectl --namespace={{ .Release.Namespace }} logs --previous <name of pod>
+  {{- println }}
+
+  {{- if eq .Values.proxy.service.type "LoadBalancer" }}
+  - Verify an external IP is provided for the k8s Service {{ $proxy_service }}.
+
+      kubectl --namespace={{ .Release.Namespace }} get service {{ $proxy_service }}
+
+    If the external ip remains <pending>, diagnose with:
+
+      kubectl --namespace={{ .Release.Namespace }} describe service {{ $proxy_service }}
   {{- end }}
-{{- end }}
 
-{{- end }}
+  - Verify web based access:
+  {{- println }}
+  {{- if .Values.ingress.enabled }}
+    {{- range $host := .Values.ingress.hosts }}
+    Try insecure HTTP access: http://{{ $host }}{{ $.Values.hub.baseUrl | trimSuffix "/" }}/
+    {{- end }}
 
-To get full information about the JupyterHub proxy service run:
+    {{- range $tls := .Values.ingress.tls }}
+    {{- range $host := $tls.hosts }}
+    Try secure HTTPS access: https://{{ $host }}{{ $.Values.hub.baseUrl | trimSuffix "/" }}/
+    {{- end }}
+    {{- end }}
+  {{- else }}
+    You have not configured a k8s Ingress resource so you need to access the k8s
+    Service {{ $proxy_service }} directly.
+    {{- println }}
 
-  kubectl --namespace={{ .Release.Namespace }} get svc {{ include "jupyterhub.proxy-public.fullname" . }}
+    {{- if eq .Values.proxy.service.type "NodePort" }}
+    The k8s Service {{ $proxy_service }} is exposed via NodePorts. That means
+    that all the k8s cluster's nodes are exposing the k8s Service via those
+    ports.
 
-If you have questions, please:
+    Try insecure HTTP access: http://<any k8s nodes ip>:{{ .Values.proxy.service.nodePorts.http | default "no-http-nodeport-set"}}
+    Try secure HTTPS access: https://<any k8s nodes address>:{{ .Values.proxy.service.nodePorts.https | default "no-https-nodeport-set" }}
 
-  1. Read the guide at https://z2jh.jupyter.org
-  2. Ask for help or chat to us on https://discourse.jupyter.org/
-  3. If you find a bug please report it at https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues
+    {{- else }}
+    If your computer is outside the k8s cluster, you can port-forward traffic to
+    the k8s Service {{ $proxy_service }} with kubectl to access it from your
+    computer.
+
+      kubectl --namespace={{ .Release.Namespace }} port-forward service/{{ $proxy_service }} 8080:http
+
+    Try insecure HTTP access: http://localhost:8080
+    {{- end }}
+  {{- end }}
+  {{- println }}
 
 
 
@@ -58,7 +94,7 @@ If you have questions, please:
   Warnings for likely misconfiguration
 */}}
 
-{{- if and (not .Values.scheduling.podPriority.enabled) (and .Values.scheduling.userPlaceholder.enabled .Values.scheduling.userPlaceholder.replicas) }}{{ println }}
+{{- if and (not .Values.scheduling.podPriority.enabled) (and .Values.scheduling.userPlaceholder.enabled .Values.scheduling.userPlaceholder.replicas) }}
 #################################################################################
 ######   WARNING: You are using user placeholders without pod priority      #####
 ######            enabled*, either enable pod priority or stop using the    #####
@@ -69,16 +105,18 @@ If you have questions, please:
 ######            **scheduling.userPlaceholder.enabled                      #####
 ######            **scheduling.userPlaceholder.replicas                     #####
 #################################################################################
+{{- println }}
 {{- end }}
 
 
 {{- if eq .Values.proxy.https.enabled false }}
-{{- if or (not (eq .Values.proxy.https.type "letsencrypt")) (not (eq (.Values.proxy.https.letsencrypt.contactEmail | default "") "")) }}{{ println }}
+{{- if or (not (eq .Values.proxy.https.type "letsencrypt")) (not (eq (.Values.proxy.https.letsencrypt.contactEmail | default "") "")) }}
 #################################################################################
 ######   WARNING: proxy.https.enabled is set to false by default since      #####
 ######            version 0.10.0. It is now set to false but proxy.https    #####
 ######            has been modified indicating you may want it enabled.     #####
 #################################################################################
+{{- println }}
 {{- end }}
 {{- end }}
 
@@ -112,5 +150,5 @@ If you have questions, please:
 
 
 {{- if $breaking }}
-{{- fail (print $breaking_title $breaking) }}
+{{- fail (print $breaking_title $breaking "\n\n") }}
 {{- end }}

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -1,5 +1,6 @@
 {{- $proxy_service := include "jupyterhub.proxy-public.fullname" . -}}
 
+{{- /* Generated with https://patorjk.com/software/taag/#p=display&h=0&f=Slant&t=JupyterHub */}}
 .      __                             __                   __  __            __
       / /  __  __    ____    __  __  / /_  ___    _____   / / / /  __  __   / /_
  __  / /  / / / /   / __ \  / / / / / __/ / _ \  / ___/  / /_/ /  / / / /  / __ \
@@ -15,7 +16,7 @@
   - Helm release name:    {{ .Release.Name }}
   - Helm chart version:   {{ .Chart.Version }}
   - JupyterHub version:   {{ .Chart.AppVersion }}
-  - Hub pod software:     See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/{{ include "jupyterhub.chart-version-to-git-ref" .Chart.Version }}/images/hub/requirements.txt
+  - Hub pod packages:     See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/{{ include "jupyterhub.chart-version-to-git-ref" .Chart.Version }}/images/hub/requirements.txt
 
 ### Followup links
 

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -361,3 +361,21 @@ limits:
         {{- print "\n\nextraFiles entries (" $file_key ") must only contain one of the fields: 'data', 'stringData', and 'binaryData'." | fail }}
     {{- end }}
 {{- end }}
+
+{{- /*
+  jupyterhub.chart-version-to-git-ref:
+    Renders a valid git reference from a chartpress generated version string.
+    In practice, either a git tag or a git commit hash will be returned.
+
+    - The version string will follow a chartpress pattern, see
+      https://github.com/jupyterhub/chartpress#examples-chart-versions-and-image-tags.
+
+    - The regexReplaceAll function is a sprig library function, see
+      http://masterminds.github.io/sprig/strings.html.
+
+    - The regular expression is in golang syntax, but \d had to become \\d for
+      example.
+*/}}
+{{- define "jupyterhub.chart-version-to-git-ref" -}}
+{{- regexReplaceAll ".*[.-]n\\d+[.]h(.*)" . "${1}" }}
+{{- end }}


### PR DESCRIPTION
This PR rephrases and makes suggested command a bit less magical to help the user learn some relevant things instead of relying on being provided magic commands. Otherwise, its mostly style changes. This is how it looks when installed without any changes to the chart's default values. If ingress or node ports were configured etc, it would look a bit different.

```
NOTES:
.      __                             __                   __  __            __
      / /  __  __    ____    __  __  / /_  ___    _____   / / / /  __  __   / /_
 __  / /  / / / /   / __ \  / / / / / __/ / _ \  / ___/  / /_/ /  / / / /  / __ \
/ /_/ /  / /_/ /   / /_/ / / /_/ / / /_  /  __/ / /     / __  /  / /_/ /  / /_/ /
\____/   \__,_/   / .___/  \__, /  \__/  \___/ /_/     /_/ /_/   \__,_/  /_.___/
                 /_/      /____/

       You have successfully installed the official JupyterHub Helm chart!

### Installation info

  - Kubernetes namespace: jupyterhub
  - Helm release name:    jupyterhub
  - Helm chart version:   2.0.0-alpha.1
  - JupyterHub version:   2.0.0b1
  - Hub pod software:     See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/2.0.0-alpha.1/images/hub/requirements.txt

### Followup links

  - Documentation:  https://z2jh.jupyter.org
  - Help forum:     https://discourse.jupyter.org
  - Social chat:    https://gitter.im/jupyterhub/jupyterhub
  - Issue tracking: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues

### Post-installation checklist

  - Verify that created Pods enter a Running state:

      kubectl --namespace=jupyterhub get pod

    If a pod is stuck with a Pending or ContainerCreating status, diagnose with:

      kubectl --namespace=jupyterhub describe pod <name of pod>

    If a pod keeps restarting, diagnose with:

      kubectl --namespace=jupyterhub logs --previous <name of pod>

  - Verify an external IP is provided for the k8s Service proxy-public.

      kubectl --namespace=jupyterhub get service proxy-public

    If the external ip remains <pending>, diagnose with:

      kubectl --namespace=jupyterhub describe service proxy-public

  - Verify web based access:

    You have not configured a k8s Ingress resource so you need to access the k8s
    Service proxy-public directly.

    If your computer is outside the k8s cluster, you can port-forward traffic to
    the k8s Service proxy-public with kubectl to access it from your
    computer.

      kubectl --namespace=jupyterhub port-forward service/proxy-public 8080:http

    Try insecure HTTP access: http://localhost:8080
```

### Notes about the text

- The ASCII art is generated via https://patorjk.com/software/taag/#p=display&h=0&f=Slant&t=JupyterHub
- The initial `.` as the absolute first character is needed to avoid a whitespace trim made by the helm CLI
- The git reference used in the link to Hub pod software will work also for dev releases
- I added a link to gitter as "social chat"