### PR TITLE
Fix proxy pod's liveness/readiness probes to be fully configurable

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -135,6 +135,8 @@ spec:
           livenessProbe:
             initialDelaySeconds: {{ .Values.proxy.chp.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.proxy.chp.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.proxy.chp.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.proxy.chp.livenessProbe.failureThreshold }}
             httpGet:
               path: /_chp_healthz
               {{- if or $manualHTTPS $manualHTTPSwithsecret }}
@@ -149,6 +151,8 @@ spec:
           readinessProbe:
             initialDelaySeconds: {{ .Values.proxy.chp.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.proxy.chp.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.proxy.chp.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.proxy.chp.readinessProbe.failureThreshold }}
             httpGet:
               path: /_chp_healthz
               {{- if or $manualHTTPS $manualHTTPSwithsecret }}


### PR DESCRIPTION
We had values and schema documenting these, but we didn't have an actual implementation for the proxy pod active.

Closes #2415.