### PR TITLE
Adds a livenessProbe to traefik for LE TLS

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1727,14 +1727,14 @@ properties:
           extraPodSpec: *extraPodSpec-spec
           livenessProbe:
             type: object
-            additionalProperties: true
+            additionalProperties: false
             properties:
               enabled:
-                type: [boolean, "false"]
+                type: boolean
               initialDelaySeconds:
-                type: [integer, 30]
+                type: integer
               periodSeconds:
-                type: [integer, 15]
+                type: integer
             description: |
               This `livenessProbe` is provided to check for a successful certificate issuance from Let's Encrypt.
               You can enable this if you are having issues with race conditions in your infrastructure or 

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1725,6 +1725,34 @@ properties:
           resources: *resources-spec
           serviceAccount: *serviceAccount
           extraPodSpec: *extraPodSpec-spec
+          livenessProbe:
+            type: object
+            additionalProperties: true
+            properties:
+              enabled:
+                type: [boolean, "false"]
+              initialDelaySeconds:
+                type: [integer, 30]
+              periodSeconds:
+                type: [integer, 15]
+            description: |
+              This `livenessProbe` is provided to check for a successful certificate issuance from Let's Encrypt.
+              You can enable this if you are having issues with race conditions in your infrastructure or 
+              cloud provider's networking being ready before traefik starts the challenge process.
+              
+              It will poll traefik's local certificate store for a certificate value matching the *first* value listed in `proxy.https.hosts[]`.
+              It does not currently check any other hostnames.
+
+              The default values are conservative here to respect Let's Encrypt's rate limits. 
+              If you are having issues with or troubleshooting certificate issuance, it's histly recommended to change 
+              `proxy.https.letsencrypt.acmeServer` to the staging server.
+
+              ```yaml
+              livenessProbe:
+                enabled: false
+                initialDelaySeconds: 30
+                periodSeconds: 15
+              ```   
       labels:
         type: object
         additionalProperties: false

--- a/jupyterhub/templates/proxy/autohttps/configmap.yaml
+++ b/jupyterhub/templates/proxy/autohttps/configmap.yaml
@@ -24,5 +24,15 @@ data:
     {{- include "jupyterhub.traefik.yaml" . | fromYaml | merge .Values.proxy.traefik.extraStaticConfig | toYaml | nindent 4 }}
   dynamic.yaml: |
     {{- include "jupyterhub.dynamic.yaml" . | fromYaml | merge .Values.proxy.traefik.extraDynamicConfig | toYaml | nindent 4 }}
+  tls_livenessprobe.sh: |
+    #!/bin/ash
+    set -eo pipefail
 
+    # Install JSON.sh
+    wget -qO /tmp/json.sh https://raw.githubusercontent.com/dominictarr/JSON.sh/0d5e5c77365f63809bf6e77ef44a1f34b0e05840/JSON.sh
+    chmod +x /tmp/json.sh
+
+    # Grep for a certificate value for the first TLS hostname
+    hostname=$(echo "{{ first .Values.proxy.https.hosts }}" | sed -e 's/\./\\\./g')
+    cat /etc/acme/acme.json | /tmp/json.sh | egrep "\[\"default\",\"Certificates\",[0-9]+\]\s+\{\"domain\":\{\"main\":\"${hostname}\"\},\"certificate\":\".+$" > /dev/null
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -94,6 +94,15 @@ spec:
             {{- with .Values.proxy.traefik.extraPorts }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          {{- if .Values.proxy.traefik.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+              - ash
+              - /etc/traefik/tls_livenessprobe.sh
+            initialDelaySeconds: {{ .Values.proxy.traefik.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.proxy.traefik.livenessProbe.periodSeconds }}
+          {{- end }}
           volumeMounts:
             - name: traefik-config
               mountPath: /etc/traefik

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -248,6 +248,10 @@ proxy:
       maxAge: 15724800 # About 6 months
     resources: {}
     labels: {}
+    livenessProbe:
+      enabled: false
+      initialDelaySeconds: 30
+      periodSeconds: 15
     extraEnv: {}
     extraVolumes: []
     extraVolumeMounts: []


### PR DESCRIPTION
Adds a livenessProbe for traefik that checks for a successful let's encrypt certificate issuance. No change in default behaviors with this PR, all new values are optional and disabled by default.

Adds documentation for the new values to the config reference.

Attempts to address #2150 