### PR TITLE
Fix implementation of restricted scopes for jupyterhub-idle-culler

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -335,7 +335,7 @@ if get_config("cull.enabled", False):
             "read:hub",
             "list:users",
             "read:users:activity",
-            "servers",
+            "delete:servers",
             # "admin:users", # dynamically added if --cull-users is passed
         ],
         # assign the role to a jupyterhub service, so it gains these permissions


### PR DESCRIPTION
Closes #2407.

- Add read:hub scope for idle-culler
- Reduce servers scope to delete:servers scope for idle-culler
