### PR TITLE
Add config singleuser.networkTools.resources - all containers must have configurable resources

### DIFF
--- a/dev-config-local-chart-extra-config.yaml
+++ b/dev-config-local-chart-extra-config.yaml
@@ -22,3 +22,11 @@ hub:
       users: [cyclops, gandalf]
       services: [test]
       groups: []
+
+singleuser:
+  networkTools:
+    # FIXME: move resources to dev-config.yaml after 2.0.0 is released.
+    resources:
+      requests:
+        memory: 0
+        cpu: 0

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -406,6 +406,7 @@ if cloud_metadata.get("blockWithIptables") == True:
     # Use iptables to block access to cloud metadata by default
     network_tools_image_name = get_config("singleuser.networkTools.image.name")
     network_tools_image_tag = get_config("singleuser.networkTools.image.tag")
+    network_tools_resources = get_config("singleuser.networkTools.resources")
     ip_block_container = client.V1Container(
         name="block-cloud-metadata",
         image=f"{network_tools_image_name}:{network_tools_image_tag}",
@@ -423,6 +424,7 @@ if cloud_metadata.get("blockWithIptables") == True:
             run_as_user=0,
             capabilities=client.V1Capabilities(add=["NET_ADMIN"]),
         ),
+        resources=network_tools_resources,
     )
 
     c.KubeSpawner.init_containers.append(ip_block_container)

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2045,6 +2045,7 @@ properties:
           is set to true.
         properties:
           image: *image-spec
+          resources: *resources-spec
       # FIXME: name mismatch, named service_account in kubespawner
       serviceAccountName:
         type: [string, "null"]

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -322,6 +322,7 @@ singleuser:
       tag: "set-by-chartpress"
       pullPolicy:
       pullSecrets: []
+    resources: {}
   cloudMetadata:
     # block set to true will append a privileged initContainer using the
     # iptables to block the sensitive metadata server at the provided ip.


### PR DESCRIPTION
Closes #2428 by providing a way to configure the resource requests for the init container started by for user servers pods.