### PR TITLE
Fix indentation in local-storage-dir.yaml

### DIFF
--- a/doc/source/kubernetes/other-infrastructure/step-zero-microk8s.md
+++ b/doc/source/kubernetes/other-infrastructure/step-zero-microk8s.md
@@ -74,14 +74,14 @@ This guide describes how to configure MicroK8s to work with Zero to Juptyerhub f
    apiVersion: storage.k8s.io/v1
    kind: StorageClass
    metadata:
-   name: local-storage-dir
-   annotations:
+     name: local-storage-dir
+     annotations:
        storageclass.kubernetes.io/is-default-class: "true"
        openebs.io/cas-type: local
        cas.openebs.io/config: |
-       - name: StorageType
+         - name: StorageType
            value: hostpath
-       - name: BasePath
+         - name: BasePath
            value: /path/to/your/storage
    provisioner: openebs.io/local
    reclaimPolicy: Delete


### PR DESCRIPTION
Otherwise results in error: 
```
error parsing local-storage-dir.yaml: error converting YAML to JSON: yaml: line 9: did not find expected key
```
or
```
error: error validating "local-storage-dir.yaml": error validating data: [ValidationError(StorageClass): unknown field "annotations" in io.k8s.api.storage.v1.StorageClass, ValidationError(StorageClass): unknown field "name" in io.k8s.api.storage.v1.StorageClass]; if you choose to ignore these errors, turn validation off with --validate=false
```