### PR TITLE
idle-culler: fix the new restricted scopes to include read:servers

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -334,6 +334,7 @@ if get_config("cull.enabled", False):
         "scopes": [
             "list:users",
             "read:users:activity",
+            "read:servers",
             "delete:servers",
             # "admin:users", # dynamically added if --cull-users is passed
         ],


### PR DESCRIPTION
Thank you @snickell for catching this and reporting it very clearly from https://github.com/jupyterhub/jupyterhub-idle-culler/issues/40!!! :heart: :tada: