### PR TITLE
Fix docs typo

### DIFF
--- a/doc/source/jupyterhub/customizing/user-environment.md
+++ b/doc/source/jupyterhub/customizing/user-environment.md
@@ -148,7 +148,7 @@ You can choose JupyterLab as the default UI with the following config in your {t
 singleuser:
   defaultUrl: "/lab"
   extraEnv:
-    JUPYERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
+    JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
 ```
 
 You can also make JupyterLab the default UI _without_ upgrading to the newer server implementation.
@@ -158,7 +158,7 @@ This may help users who need to stick to the legacy UI with extensions that may 
 singleuser:
   defaultUrl: "/lab"
   extraEnv:
-    JUPYERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
+    JUPYTERHUB_SINGLEUSER_APP: "notebook.notebookapp.NotebookApp"
 ```
 
 ```{note}
@@ -217,7 +217,7 @@ To install such an extension:
 singleuser:
   defaultUrl: /retro/
   extraEnv:
-    JUPYTERHUB_SINGLEUSER_APP: jupyter_server.serverapp.ServerApp
+    JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
 ```
 
 (custom-docker-image)=

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1473,7 +1473,7 @@ properties:
               Object to set NodePorts to expose the service on for http and https.
 
               See [the Kubernetes
-              documentation](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport)
+              documentation](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
               for more details about NodePorts.
             properties:
               http:


### PR DESCRIPTION
Following [1] and other instances in the same doc
this fixes the typo on the env var to set to use
jupyter-server in the singleuser server pod.

Also make the retro example set the env var value
in a quotes since it's a string.

Also fix the docs linkcheck job failure while in here.

[1] https://jupyterhub.readthedocs.io/en/stable/reference/config-user-env.html#switching-to-jupyter-server