### PR TITLE
breaking: add ...networkPolicy.egressAllowRules and don't allow singleuser pods to access PrivateIPv4 addresses by default

### DIFF
--- a/dev-config-local-chart-extra-config.yaml
+++ b/dev-config-local-chart-extra-config.yaml
@@ -24,6 +24,9 @@ hub:
       groups: []
 
 singleuser:
+  # FIXME: move resources to dev-config.yaml after 2.0.0 is released.
+  egressAllowRules:
+    nonPrivateIPs: false
   networkTools:
     # FIXME: move resources to dev-config.yaml after 2.0.0 is released.
     resources:

--- a/dev-config-local-chart-extra-config.yaml
+++ b/dev-config-local-chart-extra-config.yaml
@@ -25,8 +25,9 @@ hub:
 
 singleuser:
   # FIXME: move resources to dev-config.yaml after 2.0.0 is released.
-  egressAllowRules:
-    nonPrivateIPs: false
+  networkPolicy:
+    egressAllowRules:
+      nonPrivateIPs: false
   networkTools:
     # FIXME: move resources to dev-config.yaml after 2.0.0 is released.
     resources:

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -147,7 +147,9 @@ singleuser:
   memory:
     guarantee: null
   networkPolicy:
-    # For testing purposes in test_singleuser_netpol
+    # For testing purposes in test_spawn_netpol, we override egress and egressAllowRules.nonPrivateIPs
+    egressAllowRules:
+      nonPrivateIPs: false
     egress:
       - to:
           # jupyter.org has multiple IPs associated with it, among them are these
@@ -156,6 +158,7 @@ singleuser:
               cidr: 104.21.25.233/32
         # - ipBlock:
         #     cidr: 172.67.134.225/32
+
   extraEnv:
     TEST_ENV_FIELDREF_TO_NAMESPACE:
       valueFrom:

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -147,9 +147,8 @@ singleuser:
   memory:
     guarantee: null
   networkPolicy:
-    # For testing purposes in test_spawn_netpol, we override egress and egressAllowRules.nonPrivateIPs
-    egressAllowRules:
-      nonPrivateIPs: false
+    # For testing purposes in the test_spawn_netpol test, we override egress and
+    # egressAllowRules.nonPrivateIPs to slim the egress rules to a minimum.
     egress:
       - to:
           # jupyter.org has multiple IPs associated with it, among them are these

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -664,15 +664,13 @@ properties:
 
                   Since not all workloads in the k8s cluster may have
                   NetworkPolicies setup to restrict their incoming connections,
-                  having this set to false can be a good defence against
+                  having this set to false can be a good defense against
                   malicious intent from someone in control of software in these
                   pods.
 
-                  To improve security we recommend only allowing the private IP CIDRs required
-                  <TODO: insert example>
-                  or namespaces
-                  <TODO: insert example>
-                  instead of enabling this.
+                  If possible, try to avoid setting this to true as it gives
+                  broad permissions that could be specified more directly via
+                  the [`.egress`](schema_singleuser.networkPolicy.egress).
           interNamespaceAccessLabels:
             enum: [accept, ignore]
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -575,19 +575,48 @@ properties:
           enabled:
             type: boolean
             description: |
-              Toggle the creation of the NetworkPolicy resource for this pod.
+              Toggle the creation of the NetworkPolicy resource targeting this
+              pod, and by doing so, restricting its communication to only what
+              is explicitly allowed in the NetworkPolicy.
           ingress:
             type: array
             description: |
-              Additional ingress rules to add except those that is known to be needed by the respective pods in the Helm chart.
+              Additional ingress rules to add besides those that are required
+              for core functionality.
           egress:
             type: array
             description: |
-              Additional egress rules to add except those that is known to be needed by the respective pods in the Helm chart.
+              Additional egress rules to add besides those that are required for
+              core functionality and those added via
+              [`.egressAllowRules`](schema_hub.networkPolicy.egressAllowRules).
 
-              The default value of this egress is to allow all traffic, except for the `singleuser.networkPolicy.egress`, which is also limiting access to a metadata server that can be exploited.
+              ```{versionchanged} 2.0.0
+              The default value changed from providing one very permissive rule
+              allowing all egress to providing no rule. The permissive rule is
+              still provided via
+              [`.egressAllowRules`](schema_hub.networkPolicy.egressAllowRules)
+              set to true though.
+              ```
 
-              If you want to restrict egress, you can override this permissive default to be an empty list.
+              As an example, below is a configuration that disables the more
+              broadly permissive `.privateIPs` egress allow rule for the hub
+              pod, and instead provides tightly scoped permissions to access a
+              specific k8s local service as identified by pod labels.
+
+              ```yaml
+              hub:
+                networkPolicy:
+                  egressAllowRules:
+                    privateIPs: false
+                  egress:
+                    - to:
+                        - podSelector:
+                            matchLabels:
+                              app: my-k8s-local-service
+                      ports:
+                        - protocol: TCP
+                          port: 5978
+              ```
           egressAllowRules:
             type: object
             additionalProperties: false

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -607,6 +607,10 @@ properties:
               with the other flags to a reduced set of rules to avoid a
               performance penalty.
               ```
+
+              ```{versionadded} 2.0.0
+              All `egressAllowRules` are new in JupyterHub Helm chart 2.0.0.
+              ```
             properties:
               cloudMetadataServer:
                 type: boolean

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -667,6 +667,12 @@ properties:
                   having this set to false can be a good defence against
                   malicious intent from someone in control of software in these
                   pods.
+
+                  To improve security we recommend only allowing the private IP CIDRs required
+                  <TODO: insert example>
+                  or namespaces
+                  <TODO: insert example>
+                  instead of enabling this.
           interNamespaceAccessLabels:
             enum: [accept, ignore]
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -583,11 +583,86 @@ properties:
           egress:
             type: array
             description: |
-              Additional egress rules to add except those that is known to be needed by  the respective pods in the Helm chart.
+              Additional egress rules to add except those that is known to be needed by the respective pods in the Helm chart.
 
               The default value of this egress is to allow all traffic, except for the `singleuser.networkPolicy.egress`, which is also limiting access to a metadata server that can be exploited.
 
               If you want to restrict egress, you can override this permissive default to be an empty list.
+          egressAllowRules:
+            type: object
+            additionalProperties: false
+            description: |
+              This is a set of predefined rules that when enabled will be added
+              to the NetworkPolicy list of egress rules.
+
+              The resulting egress rules will be a composition of:
+              - rules specific for the respective pod(s) function within the
+                Helm chart
+              - rules based on enabled `egressAllowRules` flags
+              - rules explicitly specified by the user
+
+              ```{note}
+              Each flag under this configuration will not render into a
+              dedicated rule in the NetworkPolicy resource, but instead combine
+              with the other flags to a reduced set of rules to avoid a
+              performance penalty.
+              ```
+            properties:
+              cloudMetadataServer:
+                type: boolean
+                description: |
+                  Defaults to `false` for singleuser servers, but to `true` for
+                  all other network policies.
+
+                  When enabled this rule allows the respective pod(s) to
+                  establish outbound connections to the cloud metadata server.
+
+                  Note that the `nonPrivateIPs` rule is allowing all non Private
+                  IP ranges but makes an exception for the cloud metadata
+                  server, leaving this as the definitive configuration to allow
+                  access to the cloud metadata server.
+              dnsPortsPrivateIPs:
+                type: boolean
+                description: |
+                  Defaults to `true` for all network policies.
+
+                  When enabled this rule allows the respective pod(s) to
+                  establish outbound connections to private IPs via port 53.
+
+                  Note that we can't reliably identify the k8s internal DNS
+                  server due to variations between k8s clusters. Due to that,
+                  this rule which is critical for core functionality, can be
+                  disabled for a more refined custom rule.
+              nonPrivateIPs:
+                type: boolean
+                description: |
+                  Defaults to `true` for all network policies.
+
+                  When enabled this rule allows the respective pod(s) to
+                  establish outbound connections to the non-private IP ranges
+                  with the exception of the cloud metadata server. This means
+                  respective pod(s) can establish connections to the internet
+                  but not (say) an unsecured prometheus server running in the
+                  same cluster.
+              privateIPs:
+                type: boolean
+                description: |
+                  Defaults to `false` for singleuser servers, but to `true` for
+                  all other network policies.
+
+                  Private IPs refer to the IP ranges `10.0.0.0/8`,
+                  `172.16.0.0/12`, `192.168.0.0/16`.
+
+                  When enabled this rule allows the respective pod(s) to
+                  establish outbound connections to the internal k8s cluster.
+                  This means users can access the internet but not (say) an
+                  unsecured prometheus server running in the same cluster.
+
+                  Since not all workloads in the k8s cluster may have
+                  NetworkPolicies setup to restrict their incoming connections,
+                  having this set to false can be a good defence against
+                  malicious intent from someone in control of software in these
+                  pods.
           interNamespaceAccessLabels:
             enum: [accept, ignore]
             description: |

--- a/jupyterhub/templates/_helpers-netpol.tpl
+++ b/jupyterhub/templates/_helpers-netpol.tpl
@@ -1,0 +1,73 @@
+{{- define "jupyterhub.networkPolicy.standardEgressConfiguration" -}}
+{{- include "jupyterhub.networkPolicy.standardEgressConfiguration.withLeadingNewLine" . | trimPrefix "\n" }}
+{{- end }}
+
+{{- define "jupyterhub.networkPolicy.standardEgressConfiguration.withLeadingNewLine" -}}
+{{- $root := index . 0 }}
+{{- $netpol := index . 1 }}
+{{- if and ($netpol.egressAllowRules.dnsPortsPrivateIPs) (not $netpol.egressAllowRules.privateIPs) }}
+# Allow outbound connections to the DNS port in the private IP ranges
+- ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  to:
+    - ipBlock:
+        cidr: 10.0.0.0/8
+    - ipBlock:
+        cidr: 172.16.0.0/12
+    - ipBlock:
+        cidr: 192.168.0.0/16
+{{- end }}
+
+{{- if $netpol.egressAllowRules.nonPrivateIPs }}
+# Allow outbound connections to non-private IP ranges
+{{- if $netpol.egressAllowRules.privateIPs }}
+# Allow outbound connections to private IP ranges (and their DNS ports)
+{{- end }}
+{{- if $netpol.egressAllowRules.cloudMetadataServer }}
+# Allow outbound connections to cloud metadata server
+{{- end }}
+- to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        {{- if or (not $netpol.egressAllowRules.privateIPs) (not $netpol.egressAllowRules.cloudMetadataServer) }}
+        except:
+          {{- if not $netpol.egressAllowRules.privateIPs }}
+          # Don't allow outbound connections to private IP ranges
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
+          {{- end }}
+
+          {{- if not $netpol.egressAllowRules.cloudMetadataServer }}
+          # Don't allow access to the cloud metadata server
+          - {{ $root.Values.singleuser.cloudMetadata.ip }}/32
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- if and ($netpol.egressAllowRules.privateIPs) (not $netpol.egressAllowRules.nonPrivateIPs) }}
+# Allow outbound connections to private IP ranges (and their DNS ports)
+- to:
+    - ipBlock:
+        cidr: 10.0.0.0/8
+    - ipBlock:
+        cidr: 172.16.0.0/12
+    - ipBlock:
+        cidr: 192.168.0.0/16
+{{- end }}
+
+{{- if and ($netpol.egressAllowRules.cloudMetadataServer) (not $netpol.egressAllowRules.nonPrivateIPs) }}
+# Allow outbound connections to cloud metadata server
+- to:
+    - ipBlock:
+        cidr: {{ $root.Values.singleuser.cloudMetadata.ip }}/32
+{{- end }}
+
+{{- with $netpol.egress }}
+# Allow outbound connections based on user specified rules
+{{- . | toYaml }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/_helpers-netpol.tpl
+++ b/jupyterhub/templates/_helpers-netpol.tpl
@@ -3,10 +3,9 @@
   common configuration.
 
   It is rendering based on the `egressAllowRules` and `egress` keys of the
-  passed networkPolicy config object. In practice each flag under
-  egressAllowRules could be a dedicated egress rule, but for potential
-  performance impact we have increased the complexity of this rendering logic
-  and render them in a coalesced form.
+  passed networkPolicy config object. Each flag set to true under
+  `egressAllowRules` is rendered to a egress rule that next to any custom user
+  defined rules from the `egress` config.
 
   This named template needs to render based on a specific networkPolicy
   resource, but also needs access to the root context. Due to that, it
@@ -28,7 +27,7 @@
 {{- define "jupyterhub.networkPolicy.renderEgressRules" -}}
 {{- $root := index . 0 }}
 {{- $netpol := index . 1 }}
-{{- if and ($netpol.egressAllowRules.dnsPortsPrivateIPs) (not $netpol.egressAllowRules.privateIPs) }}
+{{- if $netpol.egressAllowRules.dnsPortsPrivateIPs }}
 # Allow outbound connections to the DNS port in the private IP ranges
 - ports:
     - protocol: UDP
@@ -46,33 +45,21 @@
 
 {{- if $netpol.egressAllowRules.nonPrivateIPs }}
 # Allow outbound connections to non-private IP ranges
-{{- if $netpol.egressAllowRules.privateIPs }}
-# Allow outbound connections to private IP ranges (and their DNS ports)
-{{- end }}
-{{- if $netpol.egressAllowRules.cloudMetadataServer }}
-# Allow outbound connections to cloud metadata server
-{{- end }}
 - to:
     - ipBlock:
         cidr: 0.0.0.0/0
-        {{- if or (not $netpol.egressAllowRules.privateIPs) (not $netpol.egressAllowRules.cloudMetadataServer) }}
         except:
-          {{- if not $netpol.egressAllowRules.privateIPs }}
-          # Don't allow outbound connections to private IP ranges
+          # As part of this rule, don't:
+          # - allow outbound connections to private IP
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
-          {{- end }}
-
-          {{- if not $netpol.egressAllowRules.cloudMetadataServer }}
-          # Don't allow access to the cloud metadata server
+          # - allow outbound connections to the cloud metadata server
           - {{ $root.Values.singleuser.cloudMetadata.ip }}/32
-          {{- end }}
-        {{- end }}
 {{- end }}
 
-{{- if and ($netpol.egressAllowRules.privateIPs) (not $netpol.egressAllowRules.nonPrivateIPs) }}
-# Allow outbound connections to private IP ranges (and their DNS ports)
+{{- if $netpol.egressAllowRules.privateIPs }}
+# Allow outbound connections to private IP ranges
 - to:
     - ipBlock:
         cidr: 10.0.0.0/8
@@ -82,8 +69,8 @@
         cidr: 192.168.0.0/16
 {{- end }}
 
-{{- if and ($netpol.egressAllowRules.cloudMetadataServer) (not $netpol.egressAllowRules.nonPrivateIPs) }}
-# Allow outbound connections to cloud metadata server
+{{- if $netpol.egressAllowRules.cloudMetadataServer }}
+# Allow outbound connections to the cloud metadata server
 - to:
     - ipBlock:
         cidr: {{ $root.Values.singleuser.cloudMetadata.ip }}/32

--- a/jupyterhub/templates/_helpers-netpol.tpl
+++ b/jupyterhub/templates/_helpers-netpol.tpl
@@ -29,7 +29,6 @@
 {{- $root := index . 0 }}
 {{- $netpol := index . 1 }}
 {{- if and ($netpol.egressAllowRules.dnsPortsPrivateIPs) (not $netpol.egressAllowRules.privateIPs) }}
-
 # Allow outbound connections to the DNS port in the private IP ranges
 - ports:
     - protocol: UDP
@@ -46,7 +45,6 @@
 {{- end }}
 
 {{- if $netpol.egressAllowRules.nonPrivateIPs }}
-
 # Allow outbound connections to non-private IP ranges
 {{- if $netpol.egressAllowRules.privateIPs }}
 # Allow outbound connections to private IP ranges (and their DNS ports)
@@ -74,7 +72,6 @@
 {{- end }}
 
 {{- if and ($netpol.egressAllowRules.privateIPs) (not $netpol.egressAllowRules.nonPrivateIPs) }}
-
 # Allow outbound connections to private IP ranges (and their DNS ports)
 - to:
     - ipBlock:
@@ -86,7 +83,6 @@
 {{- end }}
 
 {{- if and ($netpol.egressAllowRules.cloudMetadataServer) (not $netpol.egressAllowRules.nonPrivateIPs) }}
-
 # Allow outbound connections to cloud metadata server
 - to:
     - ipBlock:
@@ -94,8 +90,7 @@
 {{- end }}
 
 {{- with $netpol.egress }}
-
 # Allow outbound connections based on user specified rules
-{{- . | toYaml }}
+{{ . | toYaml }}
 {{- end }}
 {{- end }}

--- a/jupyterhub/templates/_helpers-netpol.tpl
+++ b/jupyterhub/templates/_helpers-netpol.tpl
@@ -1,11 +1,35 @@
-{{- define "jupyterhub.networkPolicy.standardEgressConfiguration" -}}
-{{- include "jupyterhub.networkPolicy.standardEgressConfiguration.withLeadingNewLine" . | trimPrefix "\n" }}
-{{- end }}
+{{- /*
+  This named template renders egress rules for NetworkPolicy resources based on
+  common configuration.
 
-{{- define "jupyterhub.networkPolicy.standardEgressConfiguration.withLeadingNewLine" -}}
+  It is rendering based on the `egressAllowRules` and `egress` keys of the
+  passed networkPolicy config object. In practice each flag under
+  egressAllowRules could be a dedicated egress rule, but for potential
+  performance impact we have increased the complexity of this rendering logic
+  and render them in a coalesced form.
+
+  This named template needs to render based on a specific networkPolicy
+  resource, but also needs access to the root context. Due to that, it
+  accepts a list as its scope, where the first element is supposed to be the
+  root context and the second element is supposed to be the networkPolicy
+  configuration object.
+
+  As an example, this is how you would render this named template from a
+  NetworkPolicy resource under its egress:
+
+    egress:
+      # other rules here...
+
+      {{- with (include "jupyterhub.networkPolicy.renderEgressRules" (list . .Values.hub.networkPolicy)) }}
+      {{- . | nindent 4 }}
+      {{- end }}
+*/}}
+
+{{- define "jupyterhub.networkPolicy.renderEgressRules" -}}
 {{- $root := index . 0 }}
 {{- $netpol := index . 1 }}
 {{- if and ($netpol.egressAllowRules.dnsPortsPrivateIPs) (not $netpol.egressAllowRules.privateIPs) }}
+
 # Allow outbound connections to the DNS port in the private IP ranges
 - ports:
     - protocol: UDP
@@ -22,6 +46,7 @@
 {{- end }}
 
 {{- if $netpol.egressAllowRules.nonPrivateIPs }}
+
 # Allow outbound connections to non-private IP ranges
 {{- if $netpol.egressAllowRules.privateIPs }}
 # Allow outbound connections to private IP ranges (and their DNS ports)
@@ -49,6 +74,7 @@
 {{- end }}
 
 {{- if and ($netpol.egressAllowRules.privateIPs) (not $netpol.egressAllowRules.nonPrivateIPs) }}
+
 # Allow outbound connections to private IP ranges (and their DNS ports)
 - to:
     - ipBlock:
@@ -60,6 +86,7 @@
 {{- end }}
 
 {{- if and ($netpol.egressAllowRules.cloudMetadataServer) (not $netpol.egressAllowRules.nonPrivateIPs) }}
+
 # Allow outbound connections to cloud metadata server
 - to:
     - ipBlock:
@@ -67,6 +94,7 @@
 {{- end }}
 
 {{- with $netpol.egress }}
+
 # Allow outbound connections based on user specified rules
 {{- . | toYaml }}
 {{- end }}

--- a/jupyterhub/templates/_helpers-netpol.tpl
+++ b/jupyterhub/templates/_helpers-netpol.tpl
@@ -22,6 +22,9 @@
       {{- with (include "jupyterhub.networkPolicy.renderEgressRules" (list . .Values.hub.networkPolicy)) }}
       {{- . | nindent 4 }}
       {{- end }}
+
+  Note that the reference to privateIPs and nonPrivateIPs relate to
+  https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses.
 */}}
 
 {{- define "jupyterhub.networkPolicy.renderEgressRules" -}}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -61,31 +61,24 @@ spec:
 
   egress:
     # hub --> proxy
-    - ports:
-        - port: 8001
-      to:
+    - to:
         - podSelector:
             matchLabels:
               {{- $_ := merge (dict "componentLabel" "proxy") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
+      ports:
+        - port: 8001
+
     # hub --> singleuser-server
-    - ports:
-        - port: 8888
-      to:
+    - to:
         - podSelector:
             matchLabels:
               {{- $_ := merge (dict "componentLabel" "singleuser-server") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
+      ports:
+        - port: 8888
 
-    # hub --> Kubernetes internal DNS
-    - ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-
-    {{- with .Values.hub.networkPolicy.egress }}
-    # hub --> depends, but the default is everything
-    {{- . | toYaml | nindent 4 }}
+    {{- with (include "jupyterhub.networkPolicy.standardEgressConfiguration" (list . .Values.hub.networkPolicy)) }}
+    {{- . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/hub/netpol.yaml
+++ b/jupyterhub/templates/hub/netpol.yaml
@@ -78,7 +78,7 @@ spec:
       ports:
         - port: 8888
 
-    {{- with (include "jupyterhub.networkPolicy.standardEgressConfiguration" (list . .Values.hub.networkPolicy)) }}
+    {{- with (include "jupyterhub.networkPolicy.renderEgressRules" (list . .Values.hub.networkPolicy)) }}
     {{- . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -64,23 +64,15 @@ spec:
 
   egress:
     # autohttps --> proxy (http port)
-    - ports:
-        - port: 8000
-      to:
+    - to:
         - podSelector:
             matchLabels:
               {{- $_ := merge (dict "componentLabel" "proxy") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
+      ports:
+        - port: 8000
 
-    # autohttps --> Kubernetes internal DNS
-    - ports:
-      - protocol: UDP
-        port: 53
-      - protocol: TCP
-        port: 53
-
-    {{- with .Values.proxy.traefik.networkPolicy.egress }}
-    # autohttps --> depends, but the default is everything
-    {{- . | toYaml | nindent 4 }}
+    {{- with (include "jupyterhub.networkPolicy.standardEgressConfiguration" (list . .Values.proxy.traefik.networkPolicy)) }}
+    {{- . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/netpol.yaml
+++ b/jupyterhub/templates/proxy/autohttps/netpol.yaml
@@ -72,7 +72,7 @@ spec:
       ports:
         - port: 8000
 
-    {{- with (include "jupyterhub.networkPolicy.standardEgressConfiguration" (list . .Values.proxy.traefik.networkPolicy)) }}
+    {{- with (include "jupyterhub.networkPolicy.renderEgressRules" (list . .Values.proxy.traefik.networkPolicy)) }}
     {{- . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -85,32 +85,24 @@ spec:
 
   egress:
     # proxy --> hub
-    - ports:
-        - port: 8081
-      to:
+    - to:
         - podSelector:
             matchLabels:
               {{- $_ := merge (dict "componentLabel" "hub") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
+      ports:
+        - port: 8081
 
     # proxy --> singleuser-server
-    - ports:
-        - port: 8888
-      to:
+    - to:
         - podSelector:
             matchLabels:
               {{- $_ := merge (dict "componentLabel" "singleuser-server") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
+      ports:
+        - port: 8888
 
-    # proxy --> Kubernetes internal DNS
-    - ports:
-      - protocol: UDP
-        port: 53
-      - protocol: TCP
-        port: 53
-
-    {{- with .Values.proxy.chp.networkPolicy.egress }}
-    # proxy --> depends, but the default is everything
-    {{- . | toYaml | nindent 4 }}
+    {{- with (include "jupyterhub.networkPolicy.standardEgressConfiguration" (list . .Values.proxy.chp.networkPolicy)) }}
+    {{- . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -102,7 +102,7 @@ spec:
       ports:
         - port: 8888
 
-    {{- with (include "jupyterhub.networkPolicy.standardEgressConfiguration" (list . .Values.proxy.chp.networkPolicy)) }}
+    {{- with (include "jupyterhub.networkPolicy.renderEgressRules" (list . .Values.proxy.chp.networkPolicy)) }}
     {{- . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -62,50 +62,69 @@ spec:
 
   egress:
     # singleuser-server --> hub
-    - ports:
-        - port: 8081
-      to:
+    - to:
         - podSelector:
             matchLabels:
               {{- $_ := merge (dict "componentLabel" "hub") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
+      ports:
+        - port: 8081
 
-    # singleuser-server --> Kubernetes internal DNS
-    - ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-
-    # User code should *always* be able to access the public facing URL
-    # of the hub. When internal network access is blocked, NetworkPolicy
-    # will not allow code to request https://<hub-externaal-url> from
-    # user code. This can break hub services.
-    # We explicitly allow this outbound access regardless of wether
-    # we are using autohttps to provide HTTPS or not.
+    # singleuser-server --> proxy
+    # singleuser-server --> autohttps
+    #
+    # While not critical for core functionality, a user or library code may rely
+    # on communicating with the proxy or autohttps pods via a k8s Service it can
+    # detected from well known environment variables.
+    #
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- $_ := merge (dict "componentLabel" "proxy") . }}
+              {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
+      ports:
+        - port: 8000
     - to:
         - podSelector:
             matchLabels:
               {{- $_ := merge (dict "componentLabel" "autohttps") . }}
               {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
-        # Library code (such as dask-gateway) often wants a way to refer
-        # to hub services without the user having to supply the domain the
-        # hub is hosted at. Since the CHP proxy pod will always be running
-        # and routing hub services, they use http://proxy-public as a URL
-        # to route to hub services. This NetworkPolicy rule explicitly
-        # allows that.
-        - podSelector:
-            matchLabels:
-              {{- $_ := merge (dict "componentLabel" "proxy") . }}
-              {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
+      ports:
+        - port: 8080
+        - port: 8443
 
-    {{- if .Values.singleuser.networkPolicy.noPrivateIPAccess }}
-    # Allow broad access to the external internet, but block all
-    # access to private IPs. This means users can access the internet but not
-    # (say) an unsecured prometheus server running in the same cluster. Given
-    # that not all charts have proper NetworkPolicies setup, this is a defense
-    # in depth measure that restricts the amount of damage someone could do if
-    # they get an unauthorized login into the hub system.
+    {{- if .Values.singleuser.networkPolicy.egressAllowRules.dnsPorts }}
+    # singleuser-server --> DNS ports
+    #
+    # We can't reliably identify the Kubernetes internal DNS server because that
+    # varies too much between k8s clusters. Due to that, we allow all
+    # connections to port 53.
+    #
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+
+    {{- if .Values.singleuser.networkPolicy.egressAllowRules.cloudMetadataServer }}
+    # singleuser-server --> cloud metadata server
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.cloudMetadata.ip }}/32
+    {{- end }}
+
+    {{- if .Values.singleuser.networkPolicy.egressAllowRules.publicIPs }}
+    # singleuser-server --> public IPs (but not the cloud metadata server)
+    #
+    # Allow access to the external internet, but don't allow access to private
+    # IPs or the cloud metadata server. This means users can access the internet
+    # but not (say) an unsecured prometheus server running in the same cluster.
+    #
+    # Given that not all charts have proper NetworkPolicies setup, this is a
+    # defense in depth measure that restricts the amount of damage someone could
+    # do if they get an unauthorized login into the hub system.
+    #
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -115,6 +134,8 @@ spec:
               - 10.0.0.0/8
               - 172.16.0.0/12
               - 192.168.0.0/16
+              # Don't allow access to the cloud metadata server
+              - {{ .Values.cloudMetadata.ip }}/32
     {{- end }}
 
     {{- with .Values.singleuser.networkPolicy.egress }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -86,9 +86,8 @@ spec:
     - to:
         - podSelector:
             matchLabels:
-              app: jupyterhub
-              component: autohttps
-
+              {{- $_ := merge (dict "componentLabel" "autohttps") . }}
+              {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
         # Library code (such as dask-gateway) often wants a way to refer
         # to hub services without the user having to supply the domain the
         # hub is hosted at. Since the CHP proxy pod will always be running
@@ -97,8 +96,8 @@ spec:
         # allows that.
         - podSelector:
             matchLabels:
-              app: jupyterhub
-              component: proxy
+              {{- $_ := merge (dict "componentLabel" "proxy") . }}
+              {{- include "jupyterhub.matchLabels" $_ | nindent 14 }}
 
     {{- if .Values.singleuser.networkPolicy.noPrivateIPAccess }}
     # Allow broad access to the external internet, but block all

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -77,6 +77,24 @@ spec:
         - protocol: TCP
           port: 53
 
+    {{- if .Values.singleuser.networkPolicy.noPrivateIPAccess }}
+    # Allow broad access to the external internet, but block all
+    # access to private IPs. This means users can access the internet but not
+    # (say) an unsecured prometheus server running in the same cluster. Given
+    # that not all charts have proper NetworkPolicies setup, this is a defense
+    # in depth measure that restricts the amount of damage someone could do if
+    # they get an unauthorized login into the hub system.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              # Don't allow network access to private IP ranges
+              # Listed in https://datatracker.ietf.org/doc/html/rfc1918
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+    {{- end }}
+
     {{- with .Values.singleuser.networkPolicy.egress }}
     # singleuser-server --> depends, but the default is everything
     {{- . | toYaml | nindent 4 }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -93,53 +93,7 @@ spec:
         - port: 8080
         - port: 8443
 
-    {{- if .Values.singleuser.networkPolicy.egressAllowRules.dnsPorts }}
-    # singleuser-server --> DNS ports
-    #
-    # We can't reliably identify the Kubernetes internal DNS server because that
-    # varies too much between k8s clusters. Due to that, we allow all
-    # connections to port 53.
-    #
-    - ports:
-        - protocol: UDP
-          port: 53
-        - protocol: TCP
-          port: 53
-    {{- end }}
-
-    {{- if .Values.singleuser.networkPolicy.egressAllowRules.cloudMetadataServer }}
-    # singleuser-server --> cloud metadata server
-    - to:
-        - ipBlock:
-            cidr: {{ .Values.cloudMetadata.ip }}/32
-    {{- end }}
-
-    {{- if .Values.singleuser.networkPolicy.egressAllowRules.publicIPs }}
-    # singleuser-server --> public IPs (but not the cloud metadata server)
-    #
-    # Allow access to the external internet, but don't allow access to private
-    # IPs or the cloud metadata server. This means users can access the internet
-    # but not (say) an unsecured prometheus server running in the same cluster.
-    #
-    # Given that not all charts have proper NetworkPolicies setup, this is a
-    # defense in depth measure that restricts the amount of damage someone could
-    # do if they get an unauthorized login into the hub system.
-    #
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-            except:
-              # Don't allow network access to private IP ranges
-              # Listed in https://datatracker.ietf.org/doc/html/rfc1918
-              - 10.0.0.0/8
-              - 172.16.0.0/12
-              - 192.168.0.0/16
-              # Don't allow access to the cloud metadata server
-              - {{ .Values.cloudMetadata.ip }}/32
-    {{- end }}
-
-    {{- with .Values.singleuser.networkPolicy.egress }}
-    # singleuser-server --> depends, but the default is everything
-    {{- . | toYaml | nindent 4 }}
+    {{- with (include "jupyterhub.networkPolicy.standardEgressConfiguration" (list . .Values.singleuser.networkPolicy)) }}
+    {{ . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -94,6 +94,6 @@ spec:
         - port: 8443
 
     {{- with (include "jupyterhub.networkPolicy.renderEgressRules" (list . .Values.singleuser.networkPolicy)) }}
-    {{ . | nindent 4 }}
+    {{- . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -77,6 +77,29 @@ spec:
         - protocol: TCP
           port: 53
 
+    # User code should *always* be able to access the public facing URL
+    # of the hub. When internal network access is blocked, NetworkPolicy
+    # will not allow code to request https://<hub-externaal-url> from
+    # user code. This can break hub services.
+    # We explicitly allow this outbound access regardless of wether
+    # we are using autohttps to provide HTTPS or not.
+    - to:
+        - podSelector:
+            matchLabels:
+              app: jupyterhub
+              component: autohttps
+
+        # Library code (such as dask-gateway) often wants a way to refer
+        # to hub services without the user having to supply the domain the
+        # hub is hosted at. Since the CHP proxy pod will always be running
+        # and routing hub services, they use http://proxy-public as a URL
+        # to route to hub services. This NetworkPolicy rule explicitly
+        # allows that.
+        - podSelector:
+            matchLabels:
+              app: jupyterhub
+              component: proxy
+
     {{- if .Values.singleuser.networkPolicy.noPrivateIPAccess }}
     # Allow broad access to the external internet, but block all
     # access to private IPs. This means users can access the internet but not

--- a/jupyterhub/templates/singleuser/netpol.yaml
+++ b/jupyterhub/templates/singleuser/netpol.yaml
@@ -93,7 +93,7 @@ spec:
         - port: 8080
         - port: 8443
 
-    {{- with (include "jupyterhub.networkPolicy.standardEgressConfiguration" (list . .Values.singleuser.networkPolicy)) }}
+    {{- with (include "jupyterhub.networkPolicy.renderEgressRules" (list . .Values.singleuser.networkPolicy)) }}
     {{ . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -97,16 +97,12 @@ hub:
   networkPolicy:
     enabled: true
     ingress: []
-    ## egress for JupyterHub already includes Kubernetes internal DNS and
-    ## access to the proxy, but can be restricted further, but ensure to allow
-    ## access to the Kubernetes API server that couldn't be pinned ahead of
-    ## time.
-    ##
-    ## ref: https://stackoverflow.com/a/59016417/2220152
-    egress:
-      - to:
-          - ipBlock:
-              cidr: 0.0.0.0/0
+    egress: []
+    egressAllowRules:
+      cloudMetadataServer: true
+      dnsPortsPrivateIPs: true
+      nonPrivateIPs: true
+      privateIPs: true
     interNamespaceAccessLabels: ignore
     allowedIngressPorts: []
   allowNamedServers: false
@@ -219,10 +215,12 @@ proxy:
     networkPolicy:
       enabled: true
       ingress: []
-      egress:
-        - to:
-            - ipBlock:
-                cidr: 0.0.0.0/0
+      egress: []
+      egressAllowRules:
+        cloudMetadataServer: true
+        dnsPortsPrivateIPs: true
+        nonPrivateIPs: true
+        privateIPs: true
       interNamespaceAccessLabels: ignore
       allowedIngressPorts: [http, https]
     pdb:
@@ -259,10 +257,12 @@ proxy:
     networkPolicy:
       enabled: true
       ingress: []
-      egress:
-        - to:
-            - ipBlock:
-                cidr: 0.0.0.0/0
+      egress: []
+      egressAllowRules:
+        cloudMetadataServer: true
+        dnsPortsPrivateIPs: true
+        nonPrivateIPs: true
+        privateIPs: true
       interNamespaceAccessLabels: ignore
       allowedIngressPorts: [http, https]
     pdb:
@@ -333,8 +333,9 @@ singleuser:
     ingress: []
     egressAllowRules:
       cloudMetadataServer: false
-      dnsPorts: true
-      publicIPs: true
+      dnsPortsPrivateIPs: true
+      nonPrivateIPs: true
+      privateIPs: false
     egress: []
     interNamespaceAccessLabels: ignore
     allowedIngressPorts: []

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -331,12 +331,12 @@ singleuser:
   networkPolicy:
     enabled: true
     ingress: []
+    egress: []
     egressAllowRules:
       cloudMetadataServer: false
       dnsPortsPrivateIPs: true
       nonPrivateIPs: true
       privateIPs: false
-    egress: []
     interNamespaceAccessLabels: ignore
     allowedIngressPorts: []
   events: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -331,19 +331,11 @@ singleuser:
   networkPolicy:
     enabled: true
     ingress: []
-    noPrivateIPAccess: true
-    egress:
-      # Required egress to communicate with the hub and DNS servers will be
-      # augmented to these egress rules.
-      #
-      # This default rule explicitly allows all outbound traffic from singleuser
-      # pods, except to a typical IP used to return metadata that can be used by
-      # someone with malicious intent.
-      - to:
-          - ipBlock:
-              cidr: 0.0.0.0/0
-              except:
-                - 169.254.169.254/32
+    egressAllowRules:
+      cloudMetadataServer: false
+      dnsPorts: true
+      publicIPs: true
+    egress: []
     interNamespaceAccessLabels: ignore
     allowedIngressPorts: []
   events: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -331,6 +331,7 @@ singleuser:
   networkPolicy:
     enabled: true
     ingress: []
+    noPrivateIPAccess: true
     egress:
       # Required egress to communicate with the hub and DNS servers will be
       # augmented to these egress rules.

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -181,8 +181,12 @@ hub:
       privateIPs: false
     egress:
       - to:
-          - ipBlock:
-              cidr: 0.0.0.0/0
+          - podSelector:
+              matchLabels:
+                app: my-k8s-local-service
+        ports:
+          - protocol: TCP
+            port: 5978
     interNamespaceAccessLabels: ignore
     allowedIngressPorts: []
   allowNamedServers: true

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -174,6 +174,11 @@ hub:
     minAvailable: null
   networkPolicy:
     enabled: true
+    egressAllowRules:
+      cloudMetadataServer: true
+      dnsPortsPrivateIPs: true
+      nonPrivateIPs: true
+      privateIPs: false
     egress:
       - to:
           - ipBlock:
@@ -233,6 +238,11 @@ proxy:
         effect: NoSchedule
     networkPolicy:
       enabled: true
+      egressAllowRules:
+        cloudMetadataServer: false
+        dnsPortsPrivateIPs: false
+        nonPrivateIPs: false
+        privateIPs: true
       egress:
         - to:
             - ipBlock:
@@ -257,6 +267,11 @@ proxy:
         effect: NoSchedule
     networkPolicy:
       enabled: true
+      egressAllowRules:
+        cloudMetadataServer: false
+        dnsPortsPrivateIPs: false
+        nonPrivateIPs: true
+        privateIPs: true
       egress:
         - to:
             - ipBlock:
@@ -377,6 +392,11 @@ singleuser:
     ip: 169.254.169.254
   networkPolicy:
     enabled: true
+    egressAllowRules:
+      cloudMetadataServer: true
+      dnsPortsPrivateIPs: true
+      nonPrivateIPs: false
+      privateIPs: false
     egress:
       - to:
           - ipBlock:


### PR DESCRIPTION
## Updated technical change summary by Erik

`<hub|proxy.chp|proxy.traefik|singleuser>.networkPolicy.egressAllowRules` is introduced. They are meant to help adjust the created NetworkPolicy resource rules with a few convenient true/false values. They are all set to true by default besides for the singleuser NetworkPolicy governing the user pods. Using the default configuration, user pods are no longer granted access to [PrivateIPv4 addresses](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses).

Also note that with the introduction of the `egressAllowRules`, the configuration to allow outbound network connections moved from `.egress` to `.egressAllowRules`. This means that if users have configured `.egress` previously to not be as permissive, they may experience a permission escalation by having `.egressAllowRules` introduced. So, for anyone configuring `.egress` and upgrading to version 2 of this chart can set all .egressAllowRules to false.

## Original PR description

This PR enables all traffic to the *internet* from user pods,
but stops allowing access to the private network where other
kubernetes pods or services may be running. Meant to be a
minimally intrusive defense in depth mechanism that prevents
access to unsecured endpoints running on VMs, in the kubernetes
cluster, etc. For example, users often run Prometheus without
any kind of network protection in the same cluster as the
users, and access to prometheus can leak a lot of sensitive
user data.

https://www.wiz.io/blog/chaosdb-explained-azures-cosmos-db-vulnerability-walkthrough
shows the immense security value of restricting access to internal
network from user written code. Most software projects do not have
their authz/authn layers, and rely on network segmentation for
protection. When network segmentation fails like it does in the Azure security incident,
there is often no secondary line of defense.

Most JupyterHub users talk to the internet, but by default I think
nobody really talks to the *internal network*. This also only affects
network connections from user code - stuff like mounting NFS shares
are done by the kubelet, and hence are not affected. Connections
to hub infrastructure (proxy, hub, etc) are also not affected,
as they are separately allowed by other NetworkPolicy rules.
Access to `http://proxy-public` for user code to talk in a hub agnostic
way to services, as well as access to the full hub URL when autohttps
is used are also added in this PR.