### PR TITLE
docs: document `singleuser.someConfig` by linking to `KubeSpawner.some_config` docs

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1788,10 +1788,9 @@ properties:
       networkPolicy: *networkPolicy-spec
       podNameTemplate:
         type: [string, "null"]
-        description: &kubespawner-native-config-description |
-          KubeSpawner native configuration, see the [KubeSpawner
-          documentation](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html)
-          for more information.
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.pod_name_template](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.pod_name_template).
       cpu:
         type: object
         additionalProperties: false
@@ -1979,31 +1978,45 @@ properties:
 
       cmd:
         type: [array, string, "null"]
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.cmd](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.cmd).
       defaultUrl:
         type: [string, "null"]
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.default_url](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.default_url).
       # FIXME: name mismatch, named events_enabled in kubespawner
       events:
         type: [boolean, "null"]
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.events_enabled](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.events_enabled).
       extraAnnotations:
         type: object
         additionalProperties: false
         patternProperties: *labels-and-annotations-patternProperties
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.extra_annotations](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.extra_annotations).
       extraContainers:
         type: array
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.extra_containers](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.extra_containers).
       extraLabels:
         type: object
         additionalProperties: false
         patternProperties: *labels-and-annotations-patternProperties
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.extra_labels](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.extra_labels).
       extraPodConfig:
         type: object
         additionalProperties: true
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.extra_pod_config](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.extra_pod_config).
       extraResource:
         type: object
         additionalProperties: false
@@ -2012,19 +2025,27 @@ properties:
           guarantees:
             type: object
             additionalProperties: true
-            description: *kubespawner-native-config-description
+            description: |
+              Passthrough configuration for
+              [KubeSpawner.extra_resource_guarantees](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.extra_resource_guarantees).
           # FIXME: name mismatch, named extra_resource_limits in kubespawner
           limits:
             type: object
             additionalProperties: true
-            description: *kubespawner-native-config-description
+            description: |
+              Passthrough configuration for
+              [KubeSpawner.extra_resource_limits](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.extra_resource_limits).
       fsGid:
         type: [integer, "null"]
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.fs_gid](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.fs_gid).
       lifecycleHooks:
         type: object
         additionalProperties: false
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.lifecycle_hooks](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.lifecycle_hooks).
         properties:
           postStart:
             type: object
@@ -2049,10 +2070,14 @@ properties:
       # FIXME: name mismatch, named service_account in kubespawner
       serviceAccountName:
         type: [string, "null"]
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.service_account](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.service_account).
       startTimeout:
         type: [integer, "null"]
-        description: *kubespawner-native-config-description
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.start_timeout](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.start_timeout).
       storage:
         type: object
         additionalProperties: false

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2020,11 +2020,7 @@ properties:
             description: *kubespawner-native-config-description
       fsGid:
         type: [integer, "null"]
-        description: |
-          The GID of the group that should own any volumes that are created and mounted.
-          You’ll have to set this if you are using auto-provisioned volumes with most cloud providers.
-          See `fs_gid` in the [KubeSpawner
-          documentation](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html).
+        description: *kubespawner-native-config-description
       lifecycleHooks:
         type: object
         additionalProperties: false

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2020,7 +2020,11 @@ properties:
             description: *kubespawner-native-config-description
       fsGid:
         type: [integer, "null"]
-        description: *kubespawner-native-config-description
+        description: |
+          The GID of the group that should own any volumes that are created and mounted.
+          You’ll have to set this if you are using auto-provisioned volumes with most cloud providers.
+          See `fs_gid` in the [KubeSpawner
+          documentation](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html).
       lifecycleHooks:
         type: object
         additionalProperties: false


### PR DESCRIPTION
When responding to https://discourse.jupyter.org/t/sql-operationalerror-with-jh-default-config/12207/3 I realised the Z2JH docs on setting the storage group ID are a bit unclear.

- [`singleuser.fsGid`](https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#singleuser-fsgid) links to https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html
- https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html doesn't contain `fsGid` so searching for it doesn't work, the property is called `fs_gid`.
- `fs_gid` maps to the K8S property `fsGroup` which is relevant when investigation cloud storage volume permissions.

It'd be nice if we could link directly to `fs_gid` in https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html but it doesn't have any in-page anchors.