### PR TITLE
Link to Discourse instead of the mailing list

### DIFF
--- a/doc/source/administrator/upgrading.md
+++ b/doc/source/administrator/upgrading.md
@@ -9,7 +9,7 @@ changes to your deployment. Check the [CHANGELOG](https://github.com/jupyterhub/
 for each release to find out if there are any breaking changes in the newest version.
 
 For additional help, feel free to reach out to us on [gitter](https://gitter.im/jupyterhub/jupyterhub)
-or the [mailing list](https://groups.google.com/forum/#!forum/jupyter)!
+or the [Discourse forum](https://discourse.jupyter.org/).
 
 ## Major helm-chart upgrades
 


### PR DESCRIPTION
This should also fix the failing linkcheck.