### PR TITLE
Remove workaround to have PriorityClass resources as helm hooks

### DIFF
--- a/jupyterhub/templates/scheduling/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/priorityclass.yaml
@@ -4,22 +4,9 @@ kind: PriorityClass
 metadata:
   name: {{ include "jupyterhub.priority.fullname" . }}
   annotations:
-    # FIXME: PriorityClasses must be added before the other resources reference
-    #        them, and in the past a workaround was needed to accomplish this:
-    #        to make the resource a Helm hook.
-    #
-    #        To transition this resource to no longer be a Helm hook resource,
-    #        we explicitly add ownership annotations/labels (in 1.0.0) which
-    #        will allow a future upgrade (in 2.0.0) to remove all hook and
-    #        ownership annotations/labels.
-    #
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "-100"
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
-    app.kubernetes.io/managed-by: Helm
     {{- $_ := merge (dict "componentLabel" "default-priority") . }}
     {{- include "jupyterhub.labels" $_ | nindent 4 }}
 value: {{ .Values.scheduling.podPriority.defaultPriority }}

--- a/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/priorityclass.yaml
@@ -5,22 +5,9 @@ kind: PriorityClass
 metadata:
   name: {{ include "jupyterhub.user-placeholder-priority.fullname" . }}
   annotations:
-    # FIXME: PriorityClasses must be added before the other resources reference
-    #        them, and in the past a workaround was needed to accomplish this:
-    #        to make the resource a Helm hook.
-    #
-    #        To transition this resource to no longer be a Helm hook resource,
-    #        we explicitly add ownership annotations/labels (in 1.0.0) which
-    #        will allow a future upgrade (in 2.0.0) to remove all hook and
-    #        ownership annotations/labels.
-    #
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "-100"
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:
-    app.kubernetes.io/managed-by: Helm
     {{- include "jupyterhub.labels" . | nindent 4 }}
 value: {{ .Values.scheduling.podPriority.userPlaceholderPriority }}
 globalDefault: false


### PR DESCRIPTION
Thanks to preparing for this in 1.0.0, assuming all users will stop-gap upgrades to the Helm chart 2.0.0 by first upgrading to 1.0.0, we can stop using a workaround needed because `helm` didn't handle PriorityClass resources correctly in the past.

The workaround was that the PriorityClass resources managed by this Helm chart was installed as a "helm hook", which means that they were not really managed by Helm as one would expect. For example, without this fix, uninstalling the helm chart would mean that the priorityclass resources would remain.

---

Since this is tested reliably in the upgrade tests, I'll go for a quick self-merge and update the changelog for 2.0.0 i'm writing.