### PR TITLE
 Fix Ingress API check

### DIFF
--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -22,7 +22,7 @@ spec:
     - http:
         paths:
           - path: {{ $.Values.hub.baseUrl | trimSuffix "/" }}/{{ $.Values.ingress.pathSuffix }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
             pathType: {{ $.Values.ingress.pathType }}
             backend:
               service:


### PR DESCRIPTION
If the full API resource is given, Helm on ArgoCD produces wrong answer for the ".Capabilities.APIVersions.Has" template.
Checking for "networking.k8s.io/v1" is enough, and works well.