### PR TITLE
Enable parent chart's (binderhub etc) to use imagePullSecrets helper

### DIFF
--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -201,30 +201,30 @@ component: {{ include "jupyterhub.componentLabel" . }}
         {{- end }}
     {{- end }}
 
-{{- /* Populate $_.list with all relevant entries */}}
-{{- $_ := dict "list" (concat .image.pullSecrets $jupyterhub_values.imagePullSecrets | uniq) }}
-{{- if and $jupyterhub_values.imagePullSecret.create $jupyterhub_values.imagePullSecret.automaticReferenceInjection }}
-{{- $__ := set $_ "list" (append $_.list (include "jupyterhub.image-pull-secret.fullname" .root) | uniq) }}
-{{- end }}
+    {{- /* Populate $_.list with all relevant entries */}}
+    {{- $_ := dict "list" (concat .image.pullSecrets $jupyterhub_values.imagePullSecrets | uniq) }}
+    {{- if and $jupyterhub_values.imagePullSecret.create $jupyterhub_values.imagePullSecret.automaticReferenceInjection }}
+        {{- $__ := set $_ "list" (append $_.list (include "jupyterhub.image-pull-secret.fullname" .root) | uniq) }}
+    {{- end }}
 
-{{- /* Decide if something should be written */}}
-{{- if not (eq ($_.list | toJson) "[]") }}
+    {{- /* Decide if something should be written */}}
+    {{- if not (eq ($_.list | toJson) "[]") }}
 
-{{- /* Process the $_.list where strings become dicts with a name key and the
-strings become the name keys' values into $_.res */}}
-{{- $_ := set $_ "res" list }}
-{{- range $_.list }}
-{{- if eq (typeOf .) "string" }}
-{{- $__ := set $_ "res" (append $_.res (dict "name" .)) }}
-{{- else }}
-{{- $__ := set $_ "res" (append $_.res .) }}
-{{- end }}
-{{- end }}
+        {{- /* Process the $_.list where strings become dicts with a name key and the
+        strings become the name keys' values into $_.res */}}
+        {{- $_ := set $_ "res" list }}
+        {{- range $_.list }}
+            {{- if eq (typeOf .) "string" }}
+                {{- $__ := set $_ "res" (append $_.res (dict "name" .)) }}
+            {{- else }}
+                {{- $__ := set $_ "res" (append $_.res .) }}
+            {{- end }}
+        {{- end }}
 
-{{- /* Write the results */}}
-{{- $_.res | toJson }}
+        {{- /* Write the results */}}
+        {{- $_.res | toJson }}
 
-{{- end }}
+    {{- end }}
 {{- end }}
 
 {{- /*


### PR DESCRIPTION
I saw https://github.com/jupyterhub/binderhub/pull/1444 and figured reusing the helper template in this helm chart was the way to do it, because then binderhub could make use of the functionality defined in this Helm chart to both create and reference a k8s Secret with image registry credentials for the various pods.

I think https://github.com/jupyterhub/binderhub/pull/1444 can be merged as it is, but think of this as the long term solution rather than a short term fix. BinderHub would need to make a version bump of the jupyterhub helm chart to include a release with this PR merged.

### Review notes

Note that most lines changed are indentation changes, focus your attention on 98df189c5c46e6f99b4ef10aed3c59d67b547f38 instead of the other commit.

### Related

- About using this Helm chart to create a k8s Secret with image pulling credentials: https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#imagepullsecret
- About using this Helm chart's named template ("jupyterhub.imagePullSecrets") to render a combination of what is specified under `<something>.image.pullSecrets` and what is declared in this Helm chart's `.Values.imagePullSecret` and `.Values.imagePullSecrets` fields: https://zero-to-jupyterhub.readthedocs.io/en/latest/resources/reference.html#imagepullsecrets