### PR TITLE
Images without tags

### DIFF
--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -400,3 +400,19 @@ limits:
 {{- define "jupyterhub.chart-version-to-git-ref" -}}
 {{- regexReplaceAll ".*[.-]n\\d+[.]h(.*)" . "${1}" }}
 {{- end }}
+
+{{- /*
+  jupyterhub.image.fullname:
+    Used to generate image names even with a missing tag.
+    The delimiter is a semicolon.
+
+    - Allows to transfer custom images to the chart using werf, see
+      https://werf.io/documentation/v1.2/advanced/helm/configuration/chart_dependencies.html.
+*/}}
+{{- define "jupyterhub.image.fullname" -}}
+    {{- if .tag }}
+        {{- printf "%s:%s" .name .tag }}
+    {{- else }}
+        {{- .name }}
+    {{- end }}
+{{- end }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -89,7 +89,7 @@ spec:
         {{- . | toYaml | nindent 8 }}
         {{- end }}
         - name: hub
-          image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
+          image: {{ include "jupyterhub.image.fullname" .Values.hub.image }}
           {{- with .Values.hub.command }}
           command:
             {{- range . }}

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -72,7 +72,7 @@ spec:
         {{- $blockWithIptables := hasKey .Values.singleuser.cloudMetadata "enabled" | ternary (not .Values.singleuser.cloudMetadata.enabled) .Values.singleuser.cloudMetadata.blockWithIptables }}
         {{- if $blockWithIptables }}
         - name: image-pull-metadata-block
-          image: {{ .Values.singleuser.networkTools.image.name }}:{{ .Values.singleuser.networkTools.image.tag }}
+          image: {{ include "jupyterhub.image.fullname" .Values.singleuser.networkTools.image }}
           {{- with .Values.singleuser.networkTools.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
@@ -92,7 +92,7 @@ spec:
 
         {{- /* --- Pull default image --- */}}
         - name: image-pull-singleuser
-          image: {{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}
+          image: {{ include "jupyterhub.image.fullname" .Values.singleuser.image }}
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
This PR **allows not to specify image tags** in values.yaml sections. Implemented for _hub_ and  _singleuser_ sections.

**Previous behavior:**
Tag omission error: YAML parse error.

**Behavior after PR:**
For images from _hub_ and _singleuser_ sections without specifying _.image.tag_. The name of the image in the deployment will consist of only the name.

**Reason for change:**
This change will make it easier to use the subject with [Werf version 1.2](https://werf.io/documentation/v1.2/advanced/helm/configuration/chart_dependencies.html), which builds a "\<name\>:\<tag\>" image available as a single string.