### PR TITLE
Improved nodeSelector formatting in template

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -33,7 +33,10 @@ spec:
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
-      nodeSelector: {{ toJson .Values.hub.nodeSelector }}
+      {{- with .Values.hub.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with concat .Values.scheduling.corePods.tolerations .Values.hub.tolerations }}
       tolerations:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -50,7 +50,10 @@ spec:
       {{- if and (not .hook) .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.user-placeholder-priority.fullname" . }}
       {{- end }}
-      nodeSelector: {{ toJson .Values.singleuser.nodeSelector }}
+      {{- with .Values.singleuser.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with concat .Values.scheduling.userPods.tolerations .Values.singleuser.extraTolerations .Values.prePuller.extraTolerations }}
       tolerations:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -37,7 +37,10 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
       {{- end }}
-      nodeSelector: {{ toJson .Values.prePuller.hook.nodeSelector }}
+      {{- with .Values.prePuller.hook.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with concat .Values.scheduling.corePods.tolerations .Values.prePuller.hook.tolerations }}
       tolerations:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -33,7 +33,10 @@ spec:
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
-      nodeSelector: {{ toJson .Values.proxy.traefik.nodeSelector }}
+      {{- with .Values.proxy.traefik.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with concat .Values.scheduling.corePods.tolerations .Values.proxy.traefik.tolerations }}
       tolerations:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -44,7 +44,10 @@ spec:
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
-      nodeSelector: {{ toJson .Values.proxy.chp.nodeSelector }}
+      {{- with .Values.proxy.chp.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with concat .Values.scheduling.corePods.tolerations .Values.proxy.chp.tolerations }}
       tolerations:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -33,7 +33,10 @@ spec:
       {{- if .Values.scheduling.userScheduler.enabled }}
       schedulerName: {{ include "jupyterhub.user-scheduler.fullname" . }}
       {{- end }}
-      nodeSelector: {{ toJson .Values.singleuser.nodeSelector }}
+      {{- with .Values.singleuser.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with concat .Values.scheduling.userPods.tolerations .Values.singleuser.extraTolerations }}
       tolerations:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -23,7 +23,10 @@ spec:
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}
-      nodeSelector: {{ toJson .Values.scheduling.userScheduler.nodeSelector }}
+      {{- with .Values.scheduling.userScheduler.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       {{- with concat .Values.scheduling.corePods.tolerations .Values.scheduling.userScheduler.tolerations }}
       tolerations:
         {{- . | toYaml | nindent 8 }}


### PR DESCRIPTION
**Improves** a formatting in the **nodeSelector** section in the final template.

**Previous behavior:**
When generating a helm template, the **toJson** function is applied to all nodeSelectors. The final template looks like this:
```
bash:
    helm template . | grep nodeSelector
result:
    nodeSelector: {"key1":"singleuser"}
    nodeSelector: {"key1":"hub"}
    nodeSelector: {"key1":"proxy.chp"}
    nodeSelector: {"key1":"scheduling.userScheduler"}
    nodeSelector: {"key1":"singleuser"}
    nodeSelector: {"key1":"singleuser"}
    nodeSelector: {"key1":"prePuller.hook"}
```

**Behavior after PR:**
After applying the changes, the fragment of the final template will look like this:
```
bash:
    helm template . | grep -A 1 nodeSelector
result:
      nodeSelector:
        key1: singleuser
--
      nodeSelector:
        key1: hub
--
      nodeSelector:
        key1: proxy.chp
--
      nodeSelector:
        key1: scheduling.userScheduler
--
      nodeSelector:
        key1: singleuser
--
      nodeSelector:
        key1: singleuser
--
      nodeSelector:
        key1: prePuller.hook
```

**Reason for change:**
Tried to find **all** occurrences of **toJson** in yaml files:
```
grep -r --include='*.yaml' -F 'toJson' | cut -d' ' -f2-
```
As a result, occurrences were found only in nodeSelector:
```
nodeSelector: {{ toJson .Values.hub.nodeSelector }}
nodeSelector: {{ toJson .Values.prePuller.hook.nodeSelector }}
nodeSelector: {{ toJson .Values.proxy.traefik.nodeSelector }}
nodeSelector: {{ toJson .Values.proxy.chp.nodeSelector }}
nodeSelector: {{ toJson .Values.singleuser.nodeSelector }}
nodeSelector: {{ toJson .Values.scheduling.userScheduler.nodeSelector }}
```