### PR TITLE
image-awaiter: fix known vulns. by updating to golang:1.17 in image build stage

### DIFF
--- a/images/image-awaiter/Dockerfile
+++ b/images/image-awaiter/Dockerfile
@@ -1,5 +1,5 @@
 # compile the code to an executable using an intermediary image
-FROM golang:1.15
+FROM golang:1.17
 
 # VULN_SCAN_TIME=
 


### PR DESCRIPTION
Update to golang:1.17 base image to patch 1 critical and 5 high vulnerabilities


![image](https://user-images.githubusercontent.com/6225521/152271061-15eb784a-7563-4250-9ad6-2c15e6e4f647.png)
