### PR TITLE
Implement continuous image puller priority for better pod scheduling

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2237,6 +2237,11 @@ properties:
           4. Normal user pods have a higher priority than the user-placeholder
              pods
 
+          Additionally, continuous image puller pods should get a priority
+          between normal user pods and placeholder pods. Otherwise, continuous
+          image puller pods may block normal user pods to spawn, and placeholder
+          pods may block continuous image puller pods.
+
           Note that if the default priority cutoff if not configured on cluster
           autoscaler, it will currently default to 0, and that in the future
           this is meant to be lowered. If your cloud provider is installing the
@@ -2251,6 +2256,7 @@ properties:
             enabled: true
             globalDefault: false
             defaultPriority: 0
+            continuousImagePullerPriority: -5
             userPlaceholderPriority: -10
           ```
 
@@ -2261,6 +2267,7 @@ properties:
             enabled: true
             globalDefault: true
             defaultPriority: 10
+            continuousImagePullerPriority: 5
             userPlaceholderPriority: 0
           ```
         properties:
@@ -2279,6 +2286,10 @@ properties:
             type: integer
             description: |
               The actual value for the default pod priority.
+          continuousImagePullerPriority:
+            type: integer
+            description: |
+              The actual value for the continuous-image-puller pods' priority.
           userPlaceholderPriority:
             type: integer
             description: |

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -210,6 +210,15 @@
     {{- end }}
 {{- end }}
 
+{{- /* continuous-image-puller.fullname Priority */}}
+{{- define "jupyterhub.continuous-image-puller-priority.fullname" -}}
+    {{- if (include "jupyterhub.fullname" .) }}
+        {{- include "jupyterhub.continuous-image-puller.fullname" . }}
+    {{- else }}
+        {{- .Release.Name }}-continuous-image-puller-priority
+    {{- end }}
+{{- end }}
+
 {{- /* user-scheduler's registered name */}}
 {{- define "jupyterhub.user-scheduler.fullname" -}}
     {{- if (include "jupyterhub.fullname" .) }}

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -48,7 +48,7 @@ spec:
         per node limit all k8s clusters have.
       */}}
       {{- if and (not .hook) .Values.scheduling.podPriority.enabled }}
-      priorityClassName: {{ include "jupyterhub.user-placeholder-priority.fullname" . }}
+      priorityClassName: {{ include "jupyterhub.continuous-image-puller-priority.fullname" . }}
       {{- end }}
       {{- with .Values.singleuser.nodeSelector }}
       nodeSelector:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -450,6 +450,7 @@ scheduling:
     enabled: false
     globalDefault: false
     defaultPriority: 0
+    continuousImagePullerPriority: -5
     userPlaceholderPriority: -10
   userPlaceholder:
     enabled: true


### PR DESCRIPTION
### Changes
- Introduce `scheduling.podPriority.podPriority.continuousImagePullerPriority` in `values.yaml`
- Modify `schema.yaml` accordingly.
- Define `jupyterhub.continuous-image-puller-priority.fullname`
- Let continuous image puller demonset create pods with "continuous image puller priority"

### Purpose
- Sometimes, placeholder pods block continuous image puller pods to spawn.
![image](https://user-images.githubusercontent.com/4434752/153347783-51a2abef-d365-4358-8c6b-b72e36d0a67e.png)
![image](https://user-images.githubusercontent.com/4434752/153348163-0c2046de-7351-486d-ab62-8e6c3dafb35f.png)

- This situation can occur after increasing the number of user placeholder pods a lot(in my case, it is 100).

### Alternatives
- Set "continuous imager puller priority" as `(defaultPriority+userPlaceholderPriority)/2` automatically.

### Related Issues
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1760