### PR TITLE
Bump kube-scheduler binary version from 1.19 to 1.22

### DIFF
--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -19,13 +19,20 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 rules:
   # Copied from the system:kube-scheduler ClusterRole of the k8s version
-  # matching the kube-scheduler binary we use. A modification of two resource
-  # name references from kube-scheduler to user-scheduler-lock was made.
+  # matching the kube-scheduler binary we use. A modification has been made to
+  # resourceName fields to remain relevant for how we have named our resources
+  # in this Helm chart.
   #
-  # NOTE: These rules have been unchanged between 1.12 and 1.15, then changed in
-  #       1.16 and in 1.17, but unchanged in 1.18 and 1.19.
+  # NOTE: These rules have been:
+  #       - unchanged between 1.12 and 1.15
+  #       - changed in 1.16
+  #       - changed in 1.17
+  #       - unchanged between 1.18 and 1.20
+  #       - changed in 1.21: get/list/watch permission for namespace,
+  #                          csidrivers, csistoragecapacities was added.
+  #       - unchanged between 1.22 and 1.23
   #
-  # ref: https://github.com/kubernetes/kubernetes/blob/v1.19.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L696-L829
+  # ref: https://github.com/kubernetes/kubernetes/blob/v1.23.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L705-L861
   - apiGroups:
     - ""
     - events.k8s.io
@@ -159,13 +166,37 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - csidrivers
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - csistoragecapacities
+    verbs:
+    - get
+    - list
+    - watch
 
   # Copied from the system:volume-scheduler ClusterRole of the k8s version
   # matching the kube-scheduler binary we use.
   #
-  # NOTE: These rules have not changed between 1.12 and 1.19.
+  # NOTE: These rules have not changed between 1.12 and 1.23.
   #
-  # ref: https://github.com/kubernetes/kubernetes/blob/v1.19.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1213-L1240
+  # ref: https://github.com/kubernetes/kubernetes/blob/v1.23.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1280-L1307
   - apiGroups:
     - ""
     resources:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -431,9 +431,22 @@ scheduling:
     image:
       # IMPORTANT: Bumping the minor version of this binary should go hand in
       #            hand with an inspection of the user-scheduelrs RBAC resources
-      #            that we have forked.
+      #            that we have forked in
+      #            templates/scheduling/user-scheduler/rbac.yaml.
+      #
+      #            If failures are observed, it may also be that our
+      #            configuration of kube-scheduler is broken in
+      #            templates/scheduling/user-scheduler/configmap.yaml.
+      #
+      #            If failures are observed, it could also be that we are
+      #            stretching the kube-scheduler binary's compatebility to work
+      #            against a k8s api-server that is too new or too old.
+      #
+      #            Inspecting the user-scheduler pod's logs with a semi-high log
+      #            level is a good strategy to debug.
+      #
       name: k8s.gcr.io/kube-scheduler
-      tag: v1.19.16 # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
+      tag: v1.22.7 # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
       pullPolicy:
       pullSecrets: []
     nodeSelector: {}


### PR DESCRIPTION
As k8s versions increase, we should try ensure user-scheduler that relies on a k8s official kube-scheduler binary is updated as well. This PR bumps the kube-scheduler binary version we rely on from 1.19 to 1.22.