### PR TITLE
Update user-scheduler's kube-scheduler binary and config when in k8s clusters versioned >=1.21

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -126,7 +126,6 @@ jobs:
         include:
           - k3s-channel: v1.23
             test: install
-            debuggable: debuggable
           - k3s-channel: v1.22
             test: install
           - k3s-channel: v1.21

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2162,7 +2162,7 @@ properties:
       userScheduler:
         type: object
         additionalProperties: false
-        required: [enabled, plugins, logLevel]
+        required: [enabled, plugins, pluginConfig, logLevel]
         description: |
           The user scheduler is making sure that user pods are scheduled
           tight on nodes, this is useful for autoscaling of user node pools.
@@ -2219,6 +2219,10 @@ properties:
                           type: string
                         weight:
                           type: integer
+          pluginConfig:
+            type: array
+            description: |
+              Individually activated plugins can be configured further.
           resources: *resources-spec
           serviceAccount: *serviceAccount
           extraPodSpec: *extraPodSpec-spec

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -6,8 +6,51 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 data:
-  # ref: https://kubernetes.io/docs/reference/scheduling/config/
+  {{- /*
+    This is configuration of a k8s official kube-scheduler binary running in the
+    user-scheduler pod.
+
+    ref: https://kubernetes.io/docs/reference/scheduling/config/
+    ref: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta2/
+    ref: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta3/
+
+    v1beta1 can be used with kube-scheduler binary version <=1.21
+    v1beta2 requires kube-scheduler binary version >=1.22
+    v1beta3 requires kube-scheduler binary version >=1.23
+
+    kube-scheduler binaries versioned >=1.21 will error in k8s clusters
+    versioned <=1.20. To support a modern version of kube-scheduler and k8s
+    versions <=1.20 upwards, we provide two scenarios:
+
+    1. For k8s >= 1.21 we use a modern version of kube-scheduler and Helm chart
+       configuration works as expected.
+    2. For k8s <= 1.20 we use a hardcoded version of kube-scheduler (v1.20.15)
+       and configuration (v1beta1) of kube-scheduler.
+  */}}
   config.yaml: |
+    {{- if ge (atoi .Capabilities.KubeVersion.Minor) 21 }}
+    apiVersion: kubescheduler.config.k8s.io/v1beta3
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      resourceLock: endpoints
+      resourceName: {{ include "jupyterhub.user-scheduler-lock.fullname" . }}
+      resourceNamespace: "{{ .Release.Namespace }}"
+    profiles:
+      - schedulerName: {{ include "jupyterhub.user-scheduler.fullname" . }}
+        {{- with .Values.scheduling.userScheduler.plugins }}
+        plugins:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
+        {{- with .Values.scheduling.userScheduler.pluginConfig }}
+        pluginConfig:
+          {{- . | toYaml | nindent 10 }}
+        {{- end }}
+    {{- else }}
+    # WARNING: The tag of this image is hardcoded, and the
+    #          "scheduling.userScheduler.plugins" configuration of the Helm
+    #          chart that generated this resource manifest wasn't respected. If
+    #          you install the Helm chart in a k8s cluster versioned 1.21 or
+    #          higher, your configuration will be respected.
     apiVersion: kubescheduler.config.k8s.io/v1beta1
     kind: KubeSchedulerConfiguration
     leaderElection:
@@ -17,5 +60,29 @@ data:
     profiles:
       - schedulerName: {{ include "jupyterhub.user-scheduler.fullname" . }}
         plugins:
-          {{- .Values.scheduling.userScheduler.plugins | toYaml | nindent 10 }}
+          score:
+            disabled:
+              - name: SelectorSpread
+              - name: TaintToleration
+              - name: PodTopologySpread
+              - name: NodeResourcesBalancedAllocation
+              - name: NodeResourcesLeastAllocated
+              # Disable plugins to be allowed to enable them again with a
+              # different weight and avoid an error.
+              - name: NodePreferAvoidPods
+              - name: NodeAffinity
+              - name: InterPodAffinity
+              - name: ImageLocality
+            enabled:
+              - name: NodePreferAvoidPods
+                weight: 161051
+              - name: NodeAffinity
+                weight: 14631
+              - name: InterPodAffinity
+                weight: 1331
+              - name: NodeResourcesMostAllocated
+                weight: 121
+              - name: ImageLocality
+                weight: 11
+    {{- end }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           {{- else }}
           # WARNING: The tag of this image is hardcoded, and the
           #          "scheduling.userScheduler.image.tag" configuration of the
-          #          Helm chart that generated this resource manifest wasn't
+          #          Helm chart that generated this resource manifest isn't
           #          respected. If you install the Helm chart in a k8s cluster
           #          versioned 1.21 or higher, your configuration will be
           #          respected.

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -47,13 +47,6 @@ spec:
           {{- end }}
           command:
             - /usr/local/bin/kube-scheduler
-            # NOTE: --leader-elect-... (new) and --lock-object-... (deprecated)
-            #       flags are silently ignored in favor of whats defined in the
-            #       passed KubeSchedulerConfiguration whenever --config is
-            #       passed.
-            #
-            # ref: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/
-            #
             # NOTE: --authentication-skip-lookup=true is used to avoid a
             #       seemingly harmless error, if we need to not skip
             #       "authentication lookup" in the future, see the linked issue.

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -61,12 +61,14 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 10251
+              scheme: HTTPS
+              port: 10259
             initialDelaySeconds: 15
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 10251
+              scheme: HTTPS
+              port: 10259
           {{- with .Values.scheduling.userScheduler.resources }}
           resources:
             {{- . | toYaml | nindent 12 }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -41,7 +41,17 @@ spec:
       {{- end }}
       containers:
         - name: kube-scheduler
+          {{- if ge (atoi .Capabilities.KubeVersion.Minor) 21 }}
           image: {{ .Values.scheduling.userScheduler.image.name }}:{{ .Values.scheduling.userScheduler.image.tag }}
+          {{- else }}
+          # WARNING: The tag of this image is hardcoded, and the
+          #          "scheduling.userScheduler.image.tag" configuration of the
+          #          Helm chart that generated this resource manifest wasn't
+          #          respected. If you install the Helm chart in a k8s cluster
+          #          versioned 1.21 or higher, your configuration will be
+          #          respected.
+          image: {{ .Values.scheduling.userScheduler.image.name }}:v1.20.15
+          {{- end }}
           {{- with .Values.scheduling.userScheduler.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -19,13 +19,20 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 rules:
   # Copied from the system:kube-scheduler ClusterRole of the k8s version
-  # matching the kube-scheduler binary we use. A modification of two resource
-  # name references from kube-scheduler to user-scheduler-lock was made.
+  # matching the kube-scheduler binary we use. A modification has been made to
+  # resourceName fields to remain relevant for how we have named our resources
+  # in this Helm chart.
   #
-  # NOTE: These rules have been unchanged between 1.12 and 1.15, then changed in
-  #       1.16 and in 1.17, but unchanged in 1.18 and 1.19.
+  # NOTE: These rules have been:
+  #       - unchanged between 1.12 and 1.15
+  #       - changed in 1.16
+  #       - changed in 1.17
+  #       - unchanged between 1.18 and 1.20
+  #       - changed in 1.21: get/list/watch permission for namespace,
+  #                          csidrivers, csistoragecapacities was added.
+  #       - unchanged between 1.22 and 1.23
   #
-  # ref: https://github.com/kubernetes/kubernetes/blob/v1.19.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L696-L829
+  # ref: https://github.com/kubernetes/kubernetes/blob/v1.23.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L705-L861
   - apiGroups:
     - ""
     - events.k8s.io
@@ -159,13 +166,37 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - csidrivers
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - storage.k8s.io
+    resources:
+    - csistoragecapacities
+    verbs:
+    - get
+    - list
+    - watch
 
   # Copied from the system:volume-scheduler ClusterRole of the k8s version
   # matching the kube-scheduler binary we use.
   #
-  # NOTE: These rules have not changed between 1.12 and 1.19.
+  # NOTE: These rules have not changed between 1.12 and 1.23.
   #
-  # ref: https://github.com/kubernetes/kubernetes/blob/v1.19.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1213-L1240
+  # ref: https://github.com/kubernetes/kubernetes/blob/v1.23.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1280-L1307
   - apiGroups:
     - ""
     resources:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -398,32 +398,63 @@ scheduling:
     enabled: true
     replicas: 2
     logLevel: 4
+    # plugins are configured on the user-scheduler to make us score how we
+    # schedule user pods in a way to help us schedule on the most busy node. By
+    # doing this, we help scale down more effectively. It isn't obvious how to
+    # enable/disable scoring plugins, and configure them, to accomplish this.
+    #
     # plugins ref: https://kubernetes.io/docs/reference/scheduling/config/#scheduling-plugins-1
+    # migration ref: https://kubernetes.io/docs/reference/scheduling/config/#scheduler-configuration-migrations
+    #
     plugins:
       score:
+        # These scoring plugins are enabled by default according to
+        # https://kubernetes.io/docs/reference/scheduling/config/#scheduling-plugins
+        # 2022-02-22.
+        #
+        # Enabled with high priority:
+        # - NodeAffinity
+        # - InterPodAffinity
+        # - NodeResourcesFit
+        # - ImageLocality
+        # Remains enabled with low default priority:
+        # - TaintToleration
+        # - PodTopologySpread
+        # - VolumeBinding
+        # Disabled for scoring:
+        # - NodeResourcesBalancedAllocation
+        #
         disabled:
-          - name: SelectorSpread
-          - name: TaintToleration
-          - name: PodTopologySpread
+          # We disable these plugins (with regards to scoring) to not interfere
+          # or complicate our use of NodeResourcesFit.
           - name: NodeResourcesBalancedAllocation
-          - name: NodeResourcesLeastAllocated
           # Disable plugins to be allowed to enable them again with a different
           # weight and avoid an error.
-          - name: NodePreferAvoidPods
           - name: NodeAffinity
           - name: InterPodAffinity
+          - name: NodeResourcesFit
           - name: ImageLocality
         enabled:
-          - name: NodePreferAvoidPods
-            weight: 161051
           - name: NodeAffinity
             weight: 14631
           - name: InterPodAffinity
             weight: 1331
-          - name: NodeResourcesMostAllocated
+          - name: NodeResourcesFit
             weight: 121
           - name: ImageLocality
             weight: 11
+    pluginConfig:
+      # Here we declare that we should optimize pods to fit based on a
+      # MostAllocated strategy instead of the default LeastAllocated.
+      - name: NodeResourcesFit
+        args:
+          scoringStrategy:
+            resources:
+              - name: cpu
+                weight: 1
+              - name: memory
+                weight: 1
+            type: MostAllocated
     containerSecurityContext:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
@@ -431,9 +462,34 @@ scheduling:
     image:
       # IMPORTANT: Bumping the minor version of this binary should go hand in
       #            hand with an inspection of the user-scheduelrs RBAC resources
-      #            that we have forked.
+      #            that we have forked in
+      #            templates/scheduling/user-scheduler/rbac.yaml.
+      #
+      #            Debugging advice:
+      #
+      #            - Is configuration of kube-scheduler broken in
+      #              templates/scheduling/user-scheduler/configmap.yaml?
+      #
+      #            - Is the kube-scheduler binary's compatebility to work
+      #              against a k8s api-server that is too new or too old?
+      #
+      #            - You can update the GitHub workflow that runs tests to
+      #              include "deploy/user-scheduler" in the k8s namespace report
+      #              and reduce the user-scheduler deployments replicas to 1 in
+      #              dev-config.yaml to get relevant logs from the user-scheduler
+      #              pods. Inspect the "Kubernetes namespace report" action!
+      #
+      #            - Typical failures are that kube-scheduler fail to search for
+      #              resources via its "informers", and won't start trying to
+      #              schedule pods before they succeed which may require
+      #              additional RBAC permissions or that the k8s api-server is
+      #              aware of the resources.
+      #
+      #            - If "successfully acquired lease" can be seen in the logs, it
+      #              is a good sign kube-scheduler is ready to schedule pods.
+      #
       name: k8s.gcr.io/kube-scheduler
-      tag: v1.19.16 # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
+      tag: v1.23.4 # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
       pullPolicy:
       pullSecrets: []
     nodeSelector: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -470,7 +470,7 @@ scheduling:
       #            - Is configuration of kube-scheduler broken in
       #              templates/scheduling/user-scheduler/configmap.yaml?
       #
-      #            - Is the kube-scheduler binary's compatebility to work
+      #            - Is the kube-scheduler binary's compatibility to work
       #              against a k8s api-server that is too new or too old?
       #
       #            - You can update the GitHub workflow that runs tests to
@@ -479,7 +479,7 @@ scheduling:
       #              dev-config.yaml to get relevant logs from the user-scheduler
       #              pods. Inspect the "Kubernetes namespace report" action!
       #
-      #            - Typical failures are that kube-scheduler fail to search for
+      #            - Typical failures are that kube-scheduler fails to search for
       #              resources via its "informers", and won't start trying to
       #              schedule pods before they succeed which may require
       #              additional RBAC permissions or that the k8s api-server is

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -451,6 +451,14 @@ scheduling:
           - name: NodePreferAvoidPods
             weight: 161051
           - name: NodeAffinity
+    pluginConfig:
+      - name: NodeResourcesFit
+        args:
+          scoringStrategy:
+            resources:
+              - name: cpu
+                weight: 1
+            type: MostAllocated
     serviceAccount: *serviceAccount
     extraPodSpec: *extraPodSpec
   podPriority:


### PR DESCRIPTION
## Description of breaking changes

If you have configured `scheduling.userScheduler.plugins`, this is a breaking change.

- When k8s <=1.20 is used, you can no longer influence the configuration via `scheduling.userScheduler.plugins`. The previous default configuration is now hardcoded for this scenario.
- When k8s >=1.21 is used, `scheduling.userScheduler.plugins` configuration should be updated to be compatible with a KubeSchedulerConfiguration of kind `v1beta3`.

## Original PR description

As new k8s versions arrive, we should try ensure that our user-scheduler that schedules some of our pods, that relies on a k8s official kube-scheduler binary - is updated as well.

This PR bumps the kube-scheduler binary version we rely on in k8s clusters versioned 1.21 or higher to the kube-scheduler binary v1.23.4, and the associated configuration to be of a modern kind (v1beta3) incompatible with the previous kind (v1beta1). Since I learned that kube-scheduler verionsed >=1.21 also couldn't be used in k8s clusters verionsed <=1.20, I had to introduce some complexity.

I made the configuration this Helm chart provides under `scheduling.userScheduler.plugins` be updated and respected in k8s k8s clusters >=1.21, but adopted a hardcoded user-scheduler configuration in k8s clusters <=1.20 that relied on the latest known function kube-scheduler binary (1.20.15).