### PR TITLE
Fix broken internal references in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,11 @@
-# Order matters:
-# - myst-parser depends on "sphinx>=2,<4"
-# - pydata-sphinx-theme depends on "sphinx"
-# - sphinx-copybutton depends on "sphinx>=1.8"
+# The ordering of these requirements can matter. It matters if we install them
+# in an environment where a dependency to them (such as sphinx) is
+# pre-installed, such as it can be on RTD. For example, if a top-ordered package
+# declares it needs sphinx>=1 and then a later package declares it needs
+# sphinx<4 - the latter may be ignored.
 #
-# Listing either pydata-sphinx-theme or sphinx-copybutton first will make the
-# myst-parser constraints on sphinx be ignored, so myst-parser should go
-# first. This is only relevant if sphinx==1.* is already installed in the
-# environment, which it is on ReadTheDocs.
+# As long as we have myst-parser ordered before other sphinx depending packages,
+# we should be good.
 #
 chartpress
 myst-parser

--- a/docs/source/administrator/optimization.md
+++ b/docs/source/administrator/optimization.md
@@ -120,7 +120,7 @@ situations:
    generally fail to do so. This is because it will only add a node if one or
    more pods won't fit on the current nodes but would fit more if a node is
    added, but at that point users are already waiting. To scale up nodes ahead
-   of time we can use [user-placeholders](#scaling-up-in-time-user-placeholders).
+   of time we can use [user-placeholders](scaling-up-in-time-user-placeholders).
 
 (images-that-will-be-pulled)=
 
@@ -178,6 +178,8 @@ Autoscaler_](https://github.com/kubernetes/autoscaler/tree/HEAD/cluster-autoscal
 (CA) will help you add and remove nodes from the cluster. But the CA needs some
 help to function well. Without help, it will both fail to scale up before users
 arrive and scale down nodes aggressively enough without disrupting users.
+
+(scaling-up-in-time-user-placeholders)=
 
 ### Scaling up in time (user placeholders)
 

--- a/docs/source/administrator/upgrading.md
+++ b/docs/source/administrator/upgrading.md
@@ -48,6 +48,8 @@ This section covers upgrade information specific to the following:
 - RBAC (Role Based Access Control)
 - Custom Docker images
 
+(helm-upgrade-command)=
+
 ### `helm upgrade` command
 
 After modifying your `config.yaml` file according to the CHANGELOG, you will need
@@ -79,7 +81,7 @@ you are using the default database provider (SQLite), then the required db upgra
 will be performed automatically when you do a `helm upgrade`.
 
 **Default (SQLite)**: The database upgrade will be performed automatically when you
-[perform the upgrade](#upgrade-command)
+[perform the upgrade](helm-upgrade-command)
 
 **MySQL / PostgreSQL**: You will execute the following steps, which includes a manual update of your database:
 
@@ -94,8 +96,8 @@ will be performed automatically when you do a `helm upgrade`.
        upgrade: true
    ```
 
-4. Do a [`helm upgrade`](#upgrade-command). This should perform the database upgrade needed.
-5. Remove the lines added in step 3, and do another [`helm upgrade`](#upgrade-command).
+4. Do a [`helm upgrade`](helm-upgrade-command). This should perform the database upgrade needed.
+5. Remove the lines added in step 3, and do another [`helm upgrade`](helm-upgrade-command).
 
 ### Custom Docker Images: JupyterHub version match
 

--- a/docs/source/resources/community.md
+++ b/docs/source/resources/community.md
@@ -19,7 +19,7 @@ JupyterHub guide, please see the [issues page](https://github.com/jupyterhub/zer
 
 We hope that you will use this section to share deployments with on a variety
 of infrastructure and for different use cases.
-There is also a [community maintained list](#users-list) of users of this
+There is also a [community maintained list](users-list) of users of this
 Guide and the JupyterHub Helm Chart.
 
 Please submit an [issue/pull request](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues) to add to this section. Thanks.


### PR DESCRIPTION
Sphinx 4 has made the linkcheck emit a warning about broken internal references. This PR fixes those.

It also updated an outdated comment in the docs requirements.txt file.