### PR TITLE
Remove typo " in schema.yaml

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -11,7 +11,7 @@
 #
 # ref: https://json-schema.org/learn/getting-started-step-by-step.html
 #
-$schema": http://json-schema.org/draft-07/schema#
+$schema: http://json-schema.org/draft-07/schema#
 type: object
 additionalProperties: false
 required:


### PR DESCRIPTION
The `$schema"` key has a random `"`