### PR TITLE
Fix failure to respect proxy.secretSync.resources configuration

### DIFF
--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -118,6 +118,10 @@ spec:
           {{- with .Values.proxy.secretSync.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
+          {{- with .Values.proxy.secretSync.resources }}
+          resources:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           args:
             - watch-save
             - --label=app={{ include "jupyterhub.appLabel" . }}


### PR DESCRIPTION
The `resources` property was not being set in the secret-sync container configuration. This is a configurable property that is described in the zero-to-jupyterhub configuration docs.