### PR TITLE
Require k8s 1.20+ and small cleanups based on assuming it

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -124,32 +124,22 @@ jobs:
         # k3s-version: https://github.com/rancher/k3s/tags
         # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
-          - k3s-channel: v1.23
+          - k3s-channel: latest
             test: install
-          - k3s-channel: v1.22
+          - k3s-channel: stable
             test: install
-          - k3s-channel: v1.21
-            test: install
-          - k3s-channel: v1.20
-            test: install
-          - k3s-channel: v1.19
-            test: install
-          - k3s-channel: v1.18 # also test prePuller.hook
+          - k3s-channel: v1.21 # also test prePuller.hook
             test: install
             local-chart-extra-args: >-
               --set prePuller.hook.enabled=true
               --set prePuller.hook.pullOnlyOnChanges=true
-          - k3s-channel: v1.17 # also test hub.existingSecret
+          - k3s-channel: v1.20 # also test hub.existingSecret
             test: install
             local-chart-extra-args: >-
               --set hub.existingSecret=test-hub-existing-secret
               --set proxy.secretToken=aaaa1111
               --set hub.cookieSecret=bbbb2222
               --set hub.config.CryptKeeper.keys[0]=cccc3333
-            # ingress.ingressClassName requires k8s 1.18 and above, don't
-            # validate setting it against the k8s api-server on k8s 1.17.
-            helm-template-validate-extra-args: >-
-              --set ingress.ingressClassName=""
             create-k8s-test-resources: true
 
           # We run two upgrade tests where we first install an already released
@@ -164,7 +154,7 @@ jobs:
           # The upgrade-from input should match the version information from
           # https://jupyterhub.github.io/helm-chart/info.json
           #
-          - k3s-channel: v1.19
+          - k3s-channel: v1.23
             test: upgrade
             upgrade-from: stable
             upgrade-from-extra-args: >-
@@ -177,7 +167,7 @@ jobs:
               --set hub.db.type=sqlite-pvc
               --set singleuser.storage.type=dynamic
             create-k8s-test-resources: true
-          - k3s-channel: v1.19
+          - k3s-channel: v1.23
             test: upgrade
             upgrade-from: dev
             upgrade-from-extra-args: >-

--- a/docs/source/administrator/advanced.md
+++ b/docs/source/administrator/advanced.md
@@ -183,7 +183,7 @@ in kubernetes that as a long list of cool use cases. Some example use cases are:
 2. Servers / other daemons that are used by code in your `hub.customConfig`
 
 The items in this list must be valid kubernetes
-[container specifications](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core).
+[container specifications](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#container-v1-core).
 
 ### Specifying suitable hub storage
 

--- a/docs/source/resources/glossary.md
+++ b/docs/source/resources/glossary.md
@@ -126,5 +126,5 @@ Additions to the glossary are welcomed. Please add in alphabetical order.
       A spawner is a separate process created for each active user by
       JupyterHub. They are each responsible for one user. This Helm chart relies
       on `KubeSpawner
-      <https://jupyterhub-kubespawner.readthedocs.io/en/latest/overview.html>`_.
+      <https://jupyterhub-kubespawner.readthedocs.io/en/latest/>`_.
 ```

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org
 sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
 icon: https://jupyterhub.github.io/helm-chart/images/hublogo.svg
-kubeVersion: ">=1.17.0-0"
+kubeVersion: ">=1.20.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -824,7 +824,7 @@ properties:
           ```
 
           For more information, see the [Kubernetes EnvVar
-          specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
+          specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envvar-v1-core).
       extraConfig:
         type: object
         additionalProperties: true
@@ -1005,7 +1005,7 @@ properties:
           [scheduling.userPods.tolerations](schema_scheduling.userPods.tolerations)).
 
           Pass this field an array of
-          [`Toleration`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core)
+          [`Toleration`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core)
           objects.
 
           See the [Kubernetes
@@ -1040,7 +1040,7 @@ properties:
         additionalProperties: true
         description: |
           A k8s native specification of the container's security context, see [the
-          documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#securitycontext-v1-core)
+          documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core)
           for details.
       deploymentStrategy:
         type: object
@@ -1080,7 +1080,7 @@ properties:
             flag.
 
             See [the k8s
-            documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#probe-v1-core)
+            documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#probe-v1-core)
             for more details.
       readinessProbe: *probe-spec
       namedServerLimitPerUser:
@@ -1094,13 +1094,13 @@ properties:
         additionalProperties: true
         description: |
           A k8s native specification of resources, see [the
-          documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#resourcerequirements-v1-core).
+          documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core).
       lifecycle: &lifecycle-spec
         type: object
         additionalProperties: false
         description: |
           A k8s native specification of lifecycle hooks on the container, see [the
-          documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#lifecycle-v1-core).
+          documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#lifecycle-v1-core).
         properties:
           postStart:
             type: object
@@ -1378,7 +1378,7 @@ properties:
               ```
 
               For more information, see the [Kubernetes EnvVar
-              specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
+              specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envvar-v1-core).
           pdb: *pdb-spec
           nodeSelector: *nodeSelector-spec
           tolerations: *tolerations-spec
@@ -1498,7 +1498,7 @@ properties:
               or the `proxy` pod (chp).
 
               See [the Kubernetes
-              documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#serviceport-v1-core)
+              documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#serviceport-v1-core)
               for the structure of the items in this list.
           loadBalancerIP:
             type: [string, "null"]
@@ -1664,7 +1664,7 @@ properties:
               ```
 
               For more information, see the [Kubernetes EnvVar
-              specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
+              specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envvar-v1-core).
           pdb: *pdb-spec
           nodeSelector: *nodeSelector-spec
           tolerations: *tolerations-spec
@@ -1899,7 +1899,7 @@ properties:
           ```
 
           For more information, see the [Kubernetes EnvVar
-          specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core).
+          specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envvar-v1-core).
       nodeSelector: *nodeSelector-spec
       extraTolerations: *tolerations-spec
       extraNodeAffinity:
@@ -1920,13 +1920,13 @@ properties:
             type: array
             description: |
               Pass this field an array of
-              [`NodeSelectorTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#nodeselectorterm-v1-core)
+              [`NodeSelectorTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#nodeselectorterm-v1-core)
               objects.
           preferred:
             type: array
             description: |
               Pass this field an array of
-              [`PreferredSchedulingTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#preferredschedulingterm-v1-core)
+              [`PreferredSchedulingTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#preferredschedulingterm-v1-core)
               objects.
       extraPodAffinity:
         type: object
@@ -1938,13 +1938,13 @@ properties:
             type: array
             description: |
               Pass this field an array of
-              [`PodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podaffinityterm-v1-core)
+              [`PodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podaffinityterm-v1-core)
               objects.
           preferred:
             type: array
             description: |
               Pass this field an array of
-              [`WeightedPodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#weightedpodaffinityterm-v1-core)
+              [`WeightedPodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#weightedpodaffinityterm-v1-core)
               objects.
       extraPodAntiAffinity:
         type: object
@@ -1956,13 +1956,13 @@ properties:
             type: array
             description: |
               Pass this field an array of
-              [`PodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podaffinityterm-v1-core)
+              [`PodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podaffinityterm-v1-core)
               objects.
           preferred:
             type: array
             description: |
               Pass this field an array of
-              [`WeightedPodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#weightedpodaffinityterm-v1-core)
+              [`WeightedPodAffinityTerm`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#weightedpodaffinityterm-v1-core)
               objects.
       cloudMetadata:
         type: object
@@ -2421,8 +2421,7 @@ properties:
       ingressClassName:
         type: [string, "null"]
         description: |
-          Maps directly to the Ingress resource's spec.ingressClassName. To
-          configure this, your k8s cluster must have version 1.18+ or above.
+          Maps directly to the Ingress resource's `spec.ingressClassName``.
 
           See [the Kubernetes
           documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class)
@@ -2440,7 +2439,7 @@ properties:
       pathType:
         enum: [Prefix, Exact, ImplementationSpecific]
         description: |
-          The path type to use. The default value is 'Prefix'. Only applies on Kubernetes v1.18+.
+          The path type to use. The default value is 'Prefix'.
 
           See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) 
           for more details about path types.

--- a/jupyterhub/templates/hub/pdb.yaml
+++ b/jupyterhub/templates/hub/pdb.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.hub.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "jupyterhub.ingress.fullname" . }}
@@ -22,18 +18,12 @@ spec:
     - http:
         paths:
           - path: {{ $.Values.hub.baseUrl | trimSuffix "/" }}/{{ $.Values.ingress.pathSuffix }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: {{ $.Values.ingress.pathType }}
             backend:
               service:
                 name: {{ include "jupyterhub.proxy-public.fullname" $ }}
                 port:
                   name: http
-            {{- else }}
-            backend:
-              serviceName: {{ include "jupyterhub.proxy-public.fullname" $ }}
-              servicePort: 80
-            {{- end }}
       {{- if $host }}
       host: {{ $host | quote }}
       {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/pdb.yaml
+++ b/jupyterhub/templates/proxy/autohttps/pdb.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.proxy.traefik.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.proxy.chp.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/jupyterhub/templates/scheduling/user-placeholder/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/pdb.yaml
@@ -3,7 +3,8 @@ The cluster autoscaler should be allowed to evict and reschedule these pods if
 it would help in order to scale down a node.
 */}}
 {{- if .Values.scheduling.userPlaceholder.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.scheduling.userScheduler.enabled .Values.scheduling.userScheduler.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
This PR closes #2591 by requiring k8s 1.20+ and dropping support for k8s 1.17-1.19 that are no longer supported by the major cloud providers.

As part of this, I also do some cleanup to not test against old versions, remove misc conditionals to support old versions, and updates misc documentation references found to old versions.