### PR TITLE
Adding in the ability to use the https proxy port on ingress if http is disabled

### DIFF
--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -23,7 +23,11 @@ spec:
               service:
                 name: {{ include "jupyterhub.proxy-public.fullname" $ }}
                 port:
+                  {{- if ne .Values.proxy.service.disableHttpPort true }}
                   name: http
+                  {{ else }}
+                  name: https
+                  {{ end }}
       {{- if $host }}
       host: {{ $host | quote }}
       {{- end }}


### PR DESCRIPTION
In relation to #2652 - this is a PR to try and correct the issue in the next release