### PR TITLE
kubespawner: pass "allow_privilege_escalation"

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -166,6 +166,7 @@ for trait, cfg_key in (
     ("environment", "extraEnv"),
     ("profile_list", None),
     ("extra_pod_config", None),
+    ("allow_privilege_escalation", None),
 ):
     if cfg_key is None:
         cfg_key = camelCaseify(trait)


### PR DESCRIPTION
In order to address https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2429#issuecomment-1096060016 and permit `sudo` on z2jh installations without jupyterhub_config level changes, I believe we'll need to be able to override the `allow_privilege_escalation` from values.yaml