### PR TITLE
`proxy.service.type`: link directly to k8s docs

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1446,7 +1446,9 @@ properties:
           type:
             enum: [ClusterIP, NodePort, LoadBalancer, ExternalName]
             description: |
-              Default `LoadBalancer`. See `hub.service.type` for supported values.
+              Default `LoadBalancer`.
+              See the [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
+              to learn more about service types.
           labels:
             type: object
             additionalProperties: false


### PR DESCRIPTION
The help text refers to `hub.service.type`, but this isn't hyperlinked:
![image](https://user-images.githubusercontent.com/1644105/164999435-11ec4a7b-ceff-4152-a587-a62c07965d28.png)

When you find `hub.service.type` there's no information, you're directed to the k8s docs.