### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ on:
     tags:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   # Builds and pushes docker images to DockerHub and package the Helm chart and
   # pushes it to jupyterhub/helm-chart@gh-pages where index.yaml represents the

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -22,6 +22,9 @@ on:
       - "pre-commit-ci-update-config"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # This is a quick test to check the arm64 docker images based on:
   # - https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/local-registry.md

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -21,6 +21,9 @@ on:
       - "pre-commit-ci-update-config"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   linkcheck:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
