### PR TITLE
Enable image-puller pods to evict user-placeholder pods

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2259,6 +2259,11 @@ properties:
           4. Normal user pods have a higher priority than the user-placeholder
              pods
 
+          Additionally, continuous image puller pods should get a priority
+          between normal user pods and placeholder pods. Otherwise, continuous
+          image puller pods may block normal user pods to spawn, and placeholder
+          pods may block continuous image puller pods.
+
           Note that if the default priority cutoff if not configured on cluster
           autoscaler, it will currently default to 0, and that in the future
           this is meant to be lowered. If your cloud provider is installing the
@@ -2273,6 +2278,7 @@ properties:
             enabled: true
             globalDefault: false
             defaultPriority: 0
+            continuousImagePullerPriority: -5
             userPlaceholderPriority: -10
           ```
 
@@ -2283,6 +2289,7 @@ properties:
             enabled: true
             globalDefault: true
             defaultPriority: 10
+            continuousImagePullerPriority: 5
             userPlaceholderPriority: 0
           ```
         properties:
@@ -2301,6 +2308,10 @@ properties:
             type: integer
             description: |
               The actual value for the default pod priority.
+          continuousImagePullerPriority:
+            type: integer
+            description: |
+              The actual value for the continuous-image-puller pods' priority.
           userPlaceholderPriority:
             type: integer
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2248,21 +2248,22 @@ properties:
         type: object
         additionalProperties: false
         description: |
-          Pod Priority is used to allow real users evict placeholder pods that
-          in turn triggers a scale up by a cluster autoscaler. So, enabling this
-          option will only make sense if the following conditions are met:
+          Pod Priority is used to allow real users evict user placeholder pods
+          that in turn by entering a Pending state can trigger a scale up by a
+          cluster autoscaler.
 
-          1. Your Kubernetes cluster has at least version 1.11
-          2. A cluster autoscaler is installed
-          3. user-placeholer pods is configured to get a priority equal or
-             higher than the cluster autoscaler's priority cutoff
-          4. Normal user pods have a higher priority than the user-placeholder
-             pods
+          Having this option enabled only make sense if the following conditions
+          are met:
 
-          Additionally, continuous image puller pods should get a priority
-          between normal user pods and placeholder pods. Otherwise, continuous
-          image puller pods may block normal user pods to spawn, and placeholder
-          pods may block continuous image puller pods.
+          1. A cluster autoscaler is installed.
+          2. user-placeholer pods are configured to have a priority equal or
+             higher than the cluster autoscaler's "priority cutoff" so that the
+             cluster autoscaler scales up a node in advance for a pending user
+             placeholder pod.
+          3. Normal user pods have a higher priority than the user-placeholder
+             pods.
+          4. Image puller pods have a priority between normal user pods and
+             user-placeholder pods.
 
           Note that if the default priority cutoff if not configured on cluster
           autoscaler, it will currently default to 0, and that in the future
@@ -2278,7 +2279,7 @@ properties:
             enabled: true
             globalDefault: false
             defaultPriority: 0
-            continuousImagePullerPriority: -5
+            imagePullerPriority: -5
             userPlaceholderPriority: -10
           ```
 
@@ -2289,7 +2290,7 @@ properties:
             enabled: true
             globalDefault: true
             defaultPriority: 10
-            continuousImagePullerPriority: 5
+            imagePullerPriority: 5
             userPlaceholderPriority: 0
           ```
         properties:
@@ -2308,10 +2309,10 @@ properties:
             type: integer
             description: |
               The actual value for the default pod priority.
-          continuousImagePullerPriority:
+          imagePullerPriority:
             type: integer
             description: |
-              The actual value for the continuous-image-puller pods' priority.
+              The actual value for the [hook|continuous]-image-puller pods' priority.
           userPlaceholderPriority:
             type: integer
             description: |

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -210,12 +210,12 @@
     {{- end }}
 {{- end }}
 
-{{- /* continuous-image-puller.fullname Priority */}}
-{{- define "jupyterhub.continuous-image-puller-priority.fullname" -}}
+{{- /* image-puller Priority */}}
+{{- define "jupyterhub.image-puller-priority.fullname" -}}
     {{- if (include "jupyterhub.fullname" .) }}
-        {{- include "jupyterhub.continuous-image-puller.fullname" . }}
+        {{- include "jupyterhub.fullname.dash" . }}image-puller
     {{- else }}
-        {{- .Release.Name }}-continuous-image-puller-priority
+        {{- .Release.Name }}-image-puller-priority
     {{- end }}
 {{- end }}
 
@@ -253,6 +253,7 @@ autohttps: {{ include "jupyterhub.autohttps.fullname" . | quote }}
 user-scheduler-deploy: {{ include "jupyterhub.user-scheduler-deploy.fullname" . | quote }}
 user-scheduler-lock: {{ include "jupyterhub.user-scheduler-lock.fullname" . | quote }}
 user-placeholder: {{ include "jupyterhub.user-placeholder.fullname" . | quote }}
+image-puller-priority: {{ include "jupyterhub.image-puller-priority.fullname" . | quote }}
 hook-image-awaiter: {{ include "jupyterhub.hook-image-awaiter.fullname" . | quote }}
 hook-image-puller: {{ include "jupyterhub.hook-image-puller.fullname" . | quote }}
 continuous-image-puller: {{ include "jupyterhub.continuous-image-puller.fullname" . | quote }}

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -210,6 +210,15 @@
     {{- end }}
 {{- end }}
 
+{{- /* continuous-image-puller.fullname Priority */}}
+{{- define "jupyterhub.continuous-image-puller-priority.fullname" -}}
+    {{- if (include "jupyterhub.fullname" .) }}
+        {{- include "jupyterhub.continuous-image-puller.fullname" . }}
+    {{- else }}
+        {{- .Release.Name }}-continuous-image-puller-priority
+    {{- end }}
+{{- end }}
+
 {{- /* user-scheduler's registered name */}}
 {{- define "jupyterhub.user-scheduler.fullname" -}}
     {{- if (include "jupyterhub.fullname" .) }}

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -48,7 +48,7 @@ spec:
         per node limit all k8s clusters have.
       */}}
       {{- if and (not .hook) .Values.scheduling.podPriority.enabled }}
-      priorityClassName: {{ include "jupyterhub.user-placeholder-priority.fullname" . }}
+      priorityClassName: {{ include "jupyterhub.continuous-image-puller-priority.fullname" . }}
       {{- end }}
       {{- with .Values.singleuser.nodeSelector }}
       nodeSelector:

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -44,11 +44,12 @@ spec:
       {{- end }}
     spec:
       {{- /*
-        continuous-image-puller pods are made evictable to save on the k8s pods
-        per node limit all k8s clusters have.
+        image-puller pods are made evictable to save on the k8s pods
+        per node limit all k8s clusters have and have a higher priority
+        than user-placeholder pods that could block an entire node.
       */}}
-      {{- if and (not .hook) .Values.scheduling.podPriority.enabled }}
-      priorityClassName: {{ include "jupyterhub.continuous-image-puller-priority.fullname" . }}
+      {{- if .Values.scheduling.podPriority.enabled }}
+      priorityClassName: {{ include "jupyterhub.image-puller-priority.fullname" . }}
       {{- end }}
       {{- with .Values.singleuser.nodeSelector }}
       nodeSelector:

--- a/jupyterhub/templates/image-puller/priorityclass.yaml
+++ b/jupyterhub/templates/image-puller/priorityclass.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.scheduling.podPriority.enabled }}
+{{- if or .Values.prePuller.hook.enabled .Values.prePuller.continuous.enabled -}}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "jupyterhub.image-puller-priority.fullname" . }}
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+value: {{ .Values.scheduling.podPriority.imagePullerPriority }}
+globalDefault: false
+description: >-
+  Enables [hook|continuous]-image-puller pods to fit on nodes even though they
+  are clogged by user-placeholder pods, while not evicting normal user pods.
+{{- end }}
+{{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -507,6 +507,7 @@ scheduling:
     enabled: false
     globalDefault: false
     defaultPriority: 0
+    continuousImagePullerPriority: -5
     userPlaceholderPriority: -10
   userPlaceholder:
     enabled: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -507,7 +507,7 @@ scheduling:
     enabled: false
     globalDefault: false
     defaultPriority: 0
-    continuousImagePullerPriority: -5
+    imagePullerPriority: -5
     userPlaceholderPriority: -10
   userPlaceholder:
     enabled: true


### PR DESCRIPTION
I wanted to push a commit to #2574 but wasn't allowed to, due to that I decided to open a new PR built on top of #2574. @a3626a is this okay with you?

I've rebased @a3626a's commit from #2574 and added another commit with changes I wanted to see.

## Summary

This PR adds another PriorityClass resource that [hook|continuous]-image-puller pods can reference in order to acquire a priority making them considered more important than user placeholder pods but still not more important than normal user pods. In practice, this resolves a bug where we could have too many user placeholder pods to fit a image-puller pod and end up with a node that didn't get their image pre-pulled for users.

I labelled it as a bugfix, its kind of a new feature as well - intended to fix a bug in behavior.