### PR TITLE
ci: add automation to update chp and traefik images

### DIFF
--- a/.github/workflows/watch-image-dependencies.yaml
+++ b/.github/workflows/watch-image-dependencies.yaml
@@ -1,0 +1,89 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+# - Watch the proxy.chp.image.tag field of values.yaml to match the latest
+#   jupyterhub/configurable-http-proxy image tag.
+#
+# - Watch the proxy.traefik.image.tag field of values.yaml to match the latest
+#   traefik image tag.
+#
+name: Watch image dependencies
+
+on:
+  schedule:
+    # Run at 05:00 every day, ref: https://crontab.guru/#0_5_*_*_*
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-image-dependencies:
+    # Don't run this job on forks
+    if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
+    runs-on: ubuntu-20.04
+
+    # Write permissions granted for the peter-evans/create-pull-request action
+    # to push to a branch and create/update a PR
+    permissions:
+      contents: write
+      pull-requests: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: chp
+            registry: registry.hub.docker.com
+            repository: jupyterhub/configurable-http-proxy
+            values_path: proxy.chp.image.tag
+          - name: traefik
+            registry: registry.hub.docker.com
+            repository: library/traefik
+            values_path: proxy.traefik.image.tag
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get values.yaml pinned tag of ${{ matrix.registry }}/${{ matrix.repository }}
+        id: local
+        run: |
+          local_tag=$(cat jupyterhub/values.yaml | yq e '.${{ matrix.values_path }}' -)
+          echo "::set-output name=tag::$local_tag"
+
+      - name: Get latest tag of ${{ matrix.registry }}/${{ matrix.repository }}
+        id: latest
+        # The skopeo image helps us list tags consistently from different docker
+        # registries. We use jq to filter out tags of the x.y.z format with the
+        # optional v prefix, and then sort based on the numerical x, y, and z
+        # values. Finally, we pick the last value in the list.
+        #
+        run: |
+          latest_tag=$(
+              docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
+            | jq -r '[.Tags[] | select(. | test("^v?\\d+\\.\\d+\\.\\d+$"))] | sort_by(split(".") | map(tonumber? // (.[1:] | tonumber))) | last'
+          )
+          echo "::set-output name=tag::$latest_tag"
+
+      - name: Update values.yaml pinned tag
+        run: sed --in-place 's/${{ steps.local.outputs.tag }}/${{ steps.latest.outputs.tag }}/g' jupyterhub/values.yaml
+
+      - name: git diff
+        run: git --no-pager diff --color=always
+
+      # ref: https://github.com/peter-evans/create-pull-request
+      - name: Create a PR
+        uses: peter-evans/create-pull-request@v4.0.3
+        with:
+          token: "${{ secrets.github_token }}"
+          branch: update-image-${{ matrix.name }}
+          labels: maintenance,dependencies
+          commit-message: Update ${{ matrix.repository }} version to ${{ steps.latest.outputs.tag }}
+          title: Update ${{ matrix.repository }} version to ${{ steps.latest.outputs.tag }}
+          body: >-
+            A new ${{ matrix.repository }} image version has been detected, version
+            `${{ steps.latest.outputs.tag }}`.
+
+
+            Please close and reopen this PR to run tests for now. This PR was
+            opened with a `secrets.github_token` and will therefore not trigger
+            other workflows to run. This can be resolved if we create a bot
+            account and use its personal access token instead.


### PR DESCRIPTION
Closes #2419 and tested to work in a fork already.

I've added a note about the need to close/reopen PRs created like this until we have setup a personal access token to a bot account, as that is required to trigger tests automatically.