### PR TITLE
ci: automatically bump kube-scheduler and pause image tags

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -98,8 +98,8 @@ jobs:
           token: "${{ secrets.github_token }}"
           branch: update-image-${{ matrix.name }}
           labels: maintenance,dependencies
-          commit-message: Update ${{ matrix.repository }} version to ${{ steps.latest.outputs.tag }}
-          title: Update ${{ matrix.repository }} version to ${{ steps.latest.outputs.tag }}
+          commit-message: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
+          title: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
           body: >-
             A new ${{ matrix.repository }} image version has been detected, version
             `${{ steps.latest.outputs.tag }}`.
@@ -166,10 +166,10 @@ jobs:
           token: "${{ secrets.github_token }}"
           branch: update-jupyterhub
           labels: maintenance,dependencies
-          commit-message: Update jupyterhub version to ${{ steps.latest.outputs.version }}
-          title: Update jupyterhub version to ${{ steps.latest.outputs.version }}
+          commit-message: Update jupyterhub from ${{ steps.local.outputs.version }} to ${{ steps.latest.outputs.version }}
+          title: Update jupyterhub from ${{ steps.local.outputs.version }} to ${{ steps.latest.outputs.version }}
           body: >-
-            A new jupyterhub image version has been detected, version
+            A new jupyterhub version has been detected, version
             `${{ steps.latest.outputs.version }}`.
 
 

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -40,10 +40,22 @@ jobs:
             registry: registry.hub.docker.com
             repository: jupyterhub/configurable-http-proxy
             values_path: proxy.chp.image.tag
+            version_startswith: ""
           - name: traefik
             registry: registry.hub.docker.com
             repository: library/traefik
             values_path: proxy.traefik.image.tag
+            version_startswith: ""
+          - name: kube-scheduler
+            registry: k8s.gcr.io
+            repository: kube-scheduler
+            values_path: scheduling.userScheduler.image.tag
+            version_startswith: "v1.23"
+          - name: pause
+            registry: k8s.gcr.io
+            repository: pause
+            values_path: scheduling.userPlaceholder.image.tag
+            version_startswith: ""
 
     steps:
       - uses: actions/checkout@v3
@@ -57,20 +69,22 @@ jobs:
       - name: Get latest tag of ${{ matrix.registry }}/${{ matrix.repository }}
         id: latest
         # The skopeo image helps us list tags consistently from different docker
-        # registries. We use jq to filter out tags of the x.y.z format with the
-        # optional v prefix, and then sort based on the numerical x, y, and z
-        # values. Finally, we pick the last value in the list.
+        # registries. We use jq to filter out tags of the x.y or x.y.z format
+        # with the optional v prefix or version_startswith filter, and then sort
+        # based on the numerical x, y, and z values. Finally, we pick the last
+        # value in the list.
         #
         run: |
           latest_tag=$(
               docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
-            | jq -r '[.Tags[] | select(. | test("^v?\\d+\\.\\d+\\.\\d+$"))] | sort_by(split(".") | map(tonumber? // (.[1:] | tonumber))) | last'
+            | jq -r '[.Tags[] | select(. | match("^v?\\d+\\.\\d+(\\.\\d+)?$") | .string | startswith("${{ matrix.version_startswith }}"))] | sort_by(split(".") | map(tonumber? // (.[1:] | tonumber))) | last'
           )
           echo "::set-output name=tag::$latest_tag"
 
       - name: Update values.yaml pinned tag
         if: steps.local.outputs.tag != steps.latest.outputs.tag
-        run: sed --in-place 's/${{ steps.local.outputs.tag }}/${{ steps.latest.outputs.tag }}/g' jupyterhub/values.yaml
+        run: |
+          sed --in-place 's/tag: "${{ steps.local.outputs.tag }}"/tag: "${{ steps.latest.outputs.tag }}"/g' jupyterhub/values.yaml
 
       - name: git diff
         if: steps.local.outputs.tag != steps.latest.outputs.tag

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -194,7 +194,10 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: jupyterhub/configurable-http-proxy
-      tag: 4.5.1 # https://github.com/jupyterhub/configurable-http-proxy/releases
+      # tag is automatically bumped to new patch versions by the
+      # watch-dependencies.yaml workflow.
+      #
+      tag: "4.5.1" # https://github.com/jupyterhub/configurable-http-proxy/releases
       pullPolicy:
       pullSecrets: []
     extraCommandLineFlags: []
@@ -239,7 +242,10 @@ proxy:
       allowPrivilegeEscalation: false
     image:
       name: traefik
-      tag: v2.6.6 # ref: https://hub.docker.com/_/traefik?tab=tags
+      # tag is automatically bumped to new patch versions by the
+      # watch-dependencies.yaml workflow.
+      #
+      tag: "v2.6.6" # ref: https://hub.docker.com/_/traefik?tab=tags
       pullPolicy:
       pullSecrets: []
     hsts:
@@ -490,7 +496,12 @@ scheduling:
       #              is a good sign kube-scheduler is ready to schedule pods.
       #
       name: k8s.gcr.io/kube-scheduler
-      tag: v1.23.4 # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
+      # tag is automatically bumped to new patch versions by the
+      # watch-dependencies.yaml workflow. The minor version is pinned in the
+      # workflow, and should be updated there if a minor version bump is done
+      # here.
+      #
+      tag: "v1.23.4" # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
       pullPolicy:
       pullSecrets: []
     nodeSelector: {}
@@ -513,10 +524,11 @@ scheduling:
     enabled: true
     image:
       name: k8s.gcr.io/pause
-      # tag's can be updated by inspecting the output of the command:
-      # gcloud container images list-tags k8s.gcr.io/pause --sort-by=~tags
+      # tag is automatically bumped to new patch versions by the
+      # watch-dependencies.yaml workflow.
       #
       # If you update this, also update prePuller.pause.image.tag
+      #
       tag: "3.6"
       pullPolicy:
       pullSecrets: []
@@ -591,10 +603,11 @@ prePuller:
       allowPrivilegeEscalation: false
     image:
       name: k8s.gcr.io/pause
-      # tag's can be updated by inspecting the output of the command:
-      # gcloud container images list-tags k8s.gcr.io/pause --sort-by=~tags
+      # tag is automatically bumped to new patch versions by the
+      # watch-dependencies.yaml workflow.
       #
       # If you update this, also update scheduling.userPlaceholder.image.tag
+      #
       tag: "3.6"
       pullPolicy:
       pullSecrets: []


### PR DESCRIPTION
A continuation of #2694 and #2696 to open PRs to bump the kube-scheduler and pause images this helm chart references as well. Now every image used by the Helm chart is automatically bumped.

---

I've tried this PR on a fork besides the PR title change commit.