### PR TITLE
ci: followup tweaks to dependency bumping automation

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -40,21 +40,39 @@ jobs:
             repository: jupyterhub/configurable-http-proxy
             values_path: proxy.chp.image.tag
             version_startswith: ""
+            version_patch_regexp_group_suffix: ""
+
+          # traefik made us need to introduce version_patch_regexp_group_suffix
+          # to control if we accept omitting the patch version. The traefik
+          # image provides tags like 2.7 even though 2.7.0 hasn't been released,
+          # which makes bumping to it something we don't want to do. We still
+          # need to accept major.minor formatted tags though as the pause image
+          # has them.
+          #
           - name: traefik
             registry: registry.hub.docker.com
             repository: library/traefik
             values_path: proxy.traefik.image.tag
             version_startswith: ""
+            version_patch_regexp_group_suffix: ""
+
+          # kube-scheduler should be pinned to its minor version as bumping it
+          # will require manual interventions sometimes, see the notes in
+          # values.yaml about bumping its version.
+          #
           - name: kube-scheduler
             registry: k8s.gcr.io
             repository: kube-scheduler
             values_path: scheduling.userScheduler.image.tag
             version_startswith: "v1.23"
+            version_patch_regexp_group_suffix: ""
+
           - name: pause
             registry: k8s.gcr.io
             repository: pause
             values_path: scheduling.userPlaceholder.image.tag
             version_startswith: ""
+            version_patch_regexp_group_suffix: "?"
 
     steps:
       - uses: actions/checkout@v3
@@ -76,7 +94,7 @@ jobs:
         run: |
           latest_tag=$(
               docker run --rm quay.io/skopeo/stable list-tags docker://${{ matrix.registry }}/${{ matrix.repository }} \
-            | jq -r '[.Tags[] | select(. | match("^v?\\d+\\.\\d+(\\.\\d+)?$") | .string | startswith("${{ matrix.version_startswith }}"))] | sort_by(split(".") | map(tonumber? // (.[1:] | tonumber))) | last'
+            | jq -r '[.Tags[] | select(. | match("^v?\\d+\\.\\d+(\\.\\d+)${{ matrix.version_patch_regexp_group_suffix }}$") | .string | startswith("${{ matrix.version_startswith }}"))] | sort_by(split(".") | map(tonumber? // (.[1:] | tonumber))) | last'
           )
           echo "::set-output name=tag::$latest_tag"
 

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -12,6 +12,8 @@ name: Watch dependencies
 
 on:
   push:
+    paths:
+      - ".github/workflows/watch-dependencies.yaml"
   schedule:
     # Run at 05:00 every day, ref: https://crontab.guru/#0_5_*_*_*
     - cron: "0 5 * * *"

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -1,11 +1,8 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
 # ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 #
-# - Watch the proxy.chp.image.tag field of values.yaml to match the latest
-#   jupyterhub/configurable-http-proxy image tag.
-#
-# - Watch the proxy.traefik.image.tag field of values.yaml to match the latest
-#   traefik image tag.
+# - Watch multiple images tags referenced in values.yaml to match the latest
+#   image tag.
 #
 # - Watch the jupyterhub pinning in images/hub/requirements.in to match the
 #   latest jupyterhub version available on PyPI, and if doing this, also


### PR DESCRIPTION
This is a followup PR to #2698 that didn't manage to function flawlessly.

1. We triggered the watch dependencies workflow on merges, which I think led to a duplicated PR to bump an already bumped version.
2. We had an outdated comment about what the workflow did, only mentioning bumping two specific images.
3. We had an issue where we bumped to `traefik:2.7` from `traefik:2.6.6` which could have made sense - but doesn't for the `traefik` image that use that `major.minor` version to include pre-releases as well - and we don't want to bump to an unstable version.