### PR TITLE
ci: use jupyterhub-bot PAT to trigger github workflow on opened PRs

### DIFF
--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -21,11 +21,6 @@ jobs:
   trivy_image_scan:
     if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
     runs-on: ubuntu-20.04
-    # Write permissions granted for the peter-evans/create-pull-request action
-    # to push to a branch and create/update a PR
-    permissions:
-      contents: write
-      pull-requests: write
 
     strategy:
       fail-fast: false
@@ -197,7 +192,7 @@ jobs:
         if: steps.analyze.outputs.proceed == 'yes' && github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@f094b77505fb89581e68a1163fbd2fffece39da1
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.jupyterhub_bot_pat }}"
           author: jupyterhub vuln-scan bot <noreply@github.com>
           reviewers: consideratio
           branch: vuln-scan-${{ matrix.image_ref }}

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -25,12 +25,6 @@ jobs:
     if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
     runs-on: ubuntu-20.04
 
-    # Write permissions granted for the peter-evans/create-pull-request action
-    # to push to a branch and create/update a PR
-    permissions:
-      contents: write
-      pull-requests: write
-
     strategy:
       fail-fast: false
       matrix:
@@ -112,7 +106,7 @@ jobs:
         if: steps.local.outputs.tag != steps.latest.outputs.tag
         uses: peter-evans/create-pull-request@v4.0.3
         with:
-          token: "${{ secrets.github_token }}"
+          token: "${{ secrets.jupyterhub_bot_pat }}"
           branch: update-image-${{ matrix.name }}
           labels: maintenance,dependencies
           commit-message: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
@@ -121,22 +115,10 @@ jobs:
             A new ${{ matrix.repository }} image version has been detected, version
             `${{ steps.latest.outputs.tag }}`.
 
-
-            Please close and reopen this PR to run tests for now. This PR was
-            opened with a `secrets.github_token` and will therefore not trigger
-            other workflows to run. This can be resolved if we create a bot
-            account and use its personal access token instead.
-
   update-jupyterhub-dependencies:
     # Don't run this job on forks
     if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
     runs-on: ubuntu-20.04
-
-    # Write permissions granted for the peter-evans/create-pull-request action
-    # to push to a branch and create/update a PR
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3
@@ -180,7 +162,7 @@ jobs:
         if: steps.local.outputs.version != steps.latest.outputs.version
         uses: peter-evans/create-pull-request@v4.0.3
         with:
-          token: "${{ secrets.github_token }}"
+          token: "${{ secrets.jupyterhub_bot_pat }}"
           branch: update-jupyterhub
           labels: maintenance,dependencies
           commit-message: Update jupyterhub from ${{ steps.local.outputs.version }} to ${{ steps.latest.outputs.version }}
@@ -188,9 +170,3 @@ jobs:
           body: >-
             A new jupyterhub version has been detected, version
             `${{ steps.latest.outputs.version }}`.
-
-
-            Please close and reopen this PR to run tests for now. This PR was
-            opened with a `secrets.github_token` and will therefore not trigger
-            other workflows to run. This can be resolved if we create a bot
-            account and use its personal access token instead.


### PR DESCRIPTION
This is associated with discussion in https://github.com/jupyterhub/team-compass/issues/516. The wish is to trigger relevant GitHub test workflows when we open new PRs, which a PR opened with a `secrets.github_token` wouldn't do.