### PR TITLE
Add singleuser.allowPrivilegeEscalation for KubeSpawner 2+

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -142,6 +142,7 @@ for trait, cfg_key in (
     ("events_enabled", "events"),
     ("extra_labels", None),
     ("extra_annotations", None),
+    # ("allow_privilege_escalation", None), # Managed manually below
     ("uid", None),
     ("fs_gid", None),
     ("service_account", "serviceAccountName"),
@@ -166,7 +167,6 @@ for trait, cfg_key in (
     ("environment", "extraEnv"),
     ("profile_list", None),
     ("extra_pod_config", None),
-    ("allow_privilege_escalation", None),
 ):
     if cfg_key is None:
         cfg_key = camelCaseify(trait)
@@ -179,6 +179,15 @@ if image:
         image = f"{image}:{tag}"
 
     c.KubeSpawner.image = image
+
+# allow_privilege_escalation defaults to False in KubeSpawner 2+. Since its a
+# property where None, False, and True all are valid values that users of the
+# Helm chart may want to set, we can't use the set_config_if_not_none helper
+# function as someone may want to override the default False value to None.
+#
+c.KubeSpawner.allow_privilege_escalation = get_config(
+    "singleuser.allowPrivilegeEscalation"
+)
 
 # Combine imagePullSecret.create (single), imagePullSecrets (list), and
 # singleuser.image.pullSecrets (list).

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -166,6 +166,7 @@ for trait, cfg_key in (
     ("environment", "extraEnv"),
     ("profile_list", None),
     ("extra_pod_config", None),
+    ("allow_privilege_escalation", None),
 ):
     if cfg_key is None:
         cfg_key = camelCaseify(trait)

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2185,9 +2185,17 @@ properties:
               Decide if you want storage to be provisioned dynamically
               (dynamic), or if you want to attach existing storage (static), or
               don't want any storage to be attached (none).
+      allowPrivilegeEscalation:
+        type: [boolean, "null"]
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.allow_privilege_escalation](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.allow_privilege_escalation).
       uid:
         type: [integer, "null"]
         description: |
+          Passthrough configuration for
+          [KubeSpawner.uid](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.uid).
+
           This dictates as what user the main container will start up as.
 
           As an example of when this is needed, consider if you want to enable

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -361,6 +361,7 @@ singleuser:
   lifecycleHooks: {}
   initContainers: []
   extraContainers: []
+  allowPrivilegeEscalation: false
   uid: 1000
   fsGid: 100
   serviceAccountName:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -397,6 +397,7 @@ singleuser:
     - name: mock-extra-container-name
       image: mock-extra-container-image
       imagePullPolicy: IfNotPresent
+  allowPrivilegeEscalation: false
   uid: 1000
   fsGid: 100
   serviceAccountName:


### PR DESCRIPTION
I could not push to #2663 so I'm opening this PR to complement it with required parts. Closes #2663, ping @snickell!

---

I'm a bit unhappy about adding another dedicated passthrough config to the helm chart, but I'm also afraid of the work to champion the use of hub.config.KubeSpawner at this point. I'm afraid of the effort to clarify what can and can't be set there without trouble. Some configuration has been used both by helm chart templates, and by the jupyterhub_config.py file, and that config must still be read from the dedicated config values etc.