### PR TITLE
Add the securityContext.enabled value. Will be useful for openshift deployment

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -78,6 +78,17 @@ properties:
     description: |
       See the documentation under [`fullnameOverride`](schema_fullnameOverride).
 
+  securityContext:
+    type: object
+    required: [enabled]
+    description: |
+      This is the configuration to enable the securityContext for all the workloads. Useful for openshift.
+    properties:
+        enabled:
+          type: boolean
+          description: |
+            This is the configuration to enable the securityContext for all the workloads. Useful for openshift.
+
   imagePullSecret:
     type: object
     required: [create]

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -84,10 +84,10 @@ properties:
     description: |
       This is the configuration to enable the securityContext for all the workloads. Useful for openshift.
     properties:
-        enabled:
-          type: boolean
-          description: |
-            This is the configuration to enable the securityContext for all the workloads. Useful for openshift.
+      enabled:
+        type: boolean
+        description: |
+          This is the configuration to enable the securityContext for all the workloads. Useful for openshift.
 
   imagePullSecret:
     type: object

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -78,8 +78,10 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ include "jupyterhub.hub.fullname" . }}
       {{- end }}
+      {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.hub.fsGid }}
+      {{- end }}
       {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.hub.image) }}
       imagePullSecrets: {{ . }}
       {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -62,9 +62,11 @@ spec:
             - -namespace={{ .Release.Namespace }}
             - -daemonset={{ include "jupyterhub.hook-image-puller.fullname" . }}
             - -pod-scheduling-wait-duration={{ .Values.prePuller.hook.podSchedulingWaitDuration }}
+          {{- if .Values.securityContext.enabled }}
           {{- with .Values.prePuller.hook.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- with .Values.prePuller.hook.resources }}
           resources:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -166,9 +166,11 @@ spec:
               scheme: HTTP
               {{- end }}
           {{- end }}
+          {{- if .Values.securityContext.enabled }}
           {{- with .Values.proxy.chp.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
       {{- with .Values.proxy.chp.extraPodSpec }}
       {{- . | toYaml | nindent 6 }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -63,8 +63,10 @@ spec:
           {{- with .Values.scheduling.userPlaceholder.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
+          {{- if .Values.securityContext.enabled }}
           {{- with .Values.scheduling.userPlaceholder.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -83,9 +83,11 @@ spec:
           resources:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
+          {{- if .Values.securityContext.enabled }}
           {{- with .Values.scheduling.userScheduler.containerSecurityContext }}
           securityContext:
             {{- . | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
       {{- with .Values.scheduling.userScheduler.extraPodSpec }}
       {{- . | toYaml | nindent 6 }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -3,6 +3,10 @@
 fullnameOverride: ""
 nameOverride:
 
+# securityContext will allow you to turn off all the securityContext (useful for the deployment on openshift)
+securityContext:
+  enabled: true
+
 # custom can contain anything you want to pass to the hub pod, as all passed
 # Helm template values will be made available there.
 custom: {}


### PR DESCRIPTION
Trying to fix issue  : Background: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2651
## Proposed change
Because my team is deploying zero-to-jupyterhub-k8s to a OpenShift platform i'd would like to be able to unset fsGid and containerSecurityContext values for all deployments/containers. So that OpenShift can define them automatically in the range that is configured at the platform level.

You would think that setting a null value would unset the value. But this is not possible wilt Helm v3 at the moment (when using nesterd charts). Background: https://github.com/helm/helm/issues/9136. A proposed solution would be to se an if statement in the templating.

Examples in code:
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/jupyterhub/templates/hub/deployment.yaml#L82
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/jupyterhub/templates/hub/deployment.yaml#L176
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/jupyterhub/templates/proxy/deployment.yaml#L170

## Alternative options
Downloading the zero-to-jupyterhub Helm template and editing it myself: I want to avoid this
Defining values in the allowed OpenShift range: i'd to like to let OpenShift decide this (what if the range changes?)
Who would use this feature?
At least every OpenShift user or any other platform what needs to set these ID's automatically

## My implementation

Adding some templating to be able to enable or disable containerSecurityContext values.

Proposed Helm solution:
```
{{- if .Values.securityContext.enabled }}
      securityContext:
        fsGroup: {{ .Values.hub.fsGid.id }}
{{- end }}  
 
{{- if .Values.securityContext.enabled }}
{{- with .Values.hub.containerSecurityContext }}
       securityContext:
        {{- . | toYaml | nindent 12 }}
{{- end }}
{{- end }}
 ```

With default value to true to avoid regression:
```
# securityContext will allow you to turn off all the securityContext (useful for the deployment on openshift)
securityContext:
  enabled: true
```
