### PR TITLE
Add opengraph tags

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,4 +13,5 @@ pydata-sphinx-theme
 pyyaml
 sphinx-autobuild
 sphinx-copybutton
+sphinxext-opengraph
 sphinxext-rediraffe

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,6 +102,7 @@ extensions = [
     "sphinx_copybutton",
     "myst_parser",
     "sphinxext.rediraffe",
+    "sphinxext.opengraph",
 ]
 
 # List of patterns, relative to source directory, that match files and

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,6 +173,10 @@ rediraffe_redirects = {
     "advanced": "administrator/advanced",
 }
 
+# opengraph configuration
+# ogp_site_url/prefix is set automatically by RTD
+ogp_image = "_static/logo.png"
+ogp_use_first_image = True
 
 # -- Generate the Helm chart configuration reference from a schema file ------
 


### PR DESCRIPTION
Jupyter readthedocs sites are often referenced on the [Jupyter Discourse](https://discourse.jupyter.org/). The lack of Open Graph tags means link previews aren't useful, e.g. in the compose mode
![image](https://user-images.githubusercontent.com/1644105/168139447-cf897452-000e-4cd6-8000-5b2df814dcd0.png)

This uses [sphinxext-opengraph](https://github.com/wpilibsuite/sphinxext-opengraph) as suggested by @choldgraf in https://github.com/pydata/pydata-sphinx-theme/pull/664
