### PR TITLE
Bump versions of image-awaiter dependencies

### DIFF
--- a/images/image-awaiter/Dockerfile
+++ b/images/image-awaiter/Dockerfile
@@ -1,5 +1,5 @@
 # compile the code to an executable using an intermediary image
-FROM golang:1.17
+FROM golang:1.18
 
 # VULN_SCAN_TIME=
 

--- a/images/image-awaiter/go.mod
+++ b/images/image-awaiter/go.mod
@@ -1,5 +1,7 @@
 module github.com/jupyterhub/zero-to-jupyterhub-k8s/image-awaiter
 
-go 1.15
+go 1.18
 
-require github.com/hashicorp/go-retryablehttp v0.6.7
+require github.com/hashicorp/go-retryablehttp v0.7.1
+
+require github.com/hashicorp/go-cleanhttp v0.5.1 // indirect

--- a/images/image-awaiter/go.sum
+++ b/images/image-awaiter/go.sum
@@ -1,8 +1,9 @@
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
-github.com/hashicorp/go-retryablehttp v0.6.7 h1:8/CAEZt/+F7kR7GevNHulKkUjLht3CPmn7egmhieNKo=
-github.com/hashicorp/go-retryablehttp v0.6.7/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
- Move to a newer go version
- Move to a newer version of the HTTP client we use