### PR TITLE
Fix for PDBs in k8s 1.20

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,4 @@
-# dependabot.yml reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+# dependabot.yml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # Notes:
 # - Status and logs from dependabot are provided at

--- a/jupyterhub/templates/hub/pdb.yaml
+++ b/jupyterhub/templates/hub/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hub.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 {{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}

--- a/jupyterhub/templates/proxy/autohttps/pdb.yaml
+++ b/jupyterhub/templates/proxy/autohttps/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.proxy.traefik.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 {{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.proxy.chp.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 {{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}

--- a/jupyterhub/templates/scheduling/user-placeholder/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/pdb.yaml
@@ -3,7 +3,7 @@ The cluster autoscaler should be allowed to evict and reschedule these pods if
 it would help in order to scale down a node.
 */}}
 {{- if .Values.scheduling.userPlaceholder.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 {{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}

--- a/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.scheduling.userScheduler.enabled .Values.scheduling.userScheduler.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
 {{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
 {{- else }}


### PR DESCRIPTION
Closes #2649 as reported by @geoffo-dev, where policy/v1 seems to be available in the k8s cluster event though policy/v1 PodDisruptionBudgets only come around in k8s 1.21.

I was on track to get this done across other repos, and went along and did it also for this repo. The actual work was not making the PR, it was to realize there is a bug like this. Thank you @geoffo-dev!