### PR TITLE
ci: reduce frequency of gha/vuln bumps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,8 +6,6 @@
 # - YAML anchors are not supported here or in GitHub Workflows.
 # - versioning-strategy: lockfile-only must not be used if you only have a plain
 #   requirements.txt like we do in images/singleuser-sample.
-# - We explicitly set the "maintenance" label to help our changelog generator
-#   tool github-activity to categorize PRs.
 #
 version: 2
 updates:
@@ -20,7 +18,6 @@ updates:
       timezone: "Etc/UTC"
     versioning-strategy: lockfile-only
     labels:
-      - maintenance
       - dependencies
 
   # Maintain Python dependencies for the jupyterhub/k8s-singleuser-sample image
@@ -37,16 +34,14 @@ updates:
     ignore:
       - dependency-name: jupyterhub
     labels:
-      - maintenance
       - dependencies
 
   # Maintain dependencies in our GitHub Workflows
   - package-ecosystem: github-actions
     directory: "/" # This should be / rather than .github/workflows
     schedule:
-      interval: daily
+      interval: weekly
       time: "05:00"
       timezone: "Etc/UTC"
     labels:
-      - maintenance
       - dependencies

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -13,8 +13,8 @@ on:
     paths:
       - ".github/workflows/vuln-scan.yaml"
   schedule:
-    # At 00:00 - https://crontab.guru
-    - cron: "0 0 * * *"
+    # At 05:00 on Monday - https://crontab.guru
+    - cron: "0 5 * * 1"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The vulnerability scan PRs have been too noisy, and bumping github actions' versions isn't important to do fast I think. I've made them happen weekly instead of daily as part of this PR.