### PR TITLE
maint: add pre-commit isort hook, and let pyupgrade assume py38+ in hub container

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,14 +25,17 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py36-plus
+          - --py38-plus
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-        args: [--target-version=py36]
+        args:
+          - --target-version=py38
+          - --target-version=py39
+          - --target-version=py310
 
   # Autoformat: Bash scripts
   - repo: https://github.com/lovesegfault/beautysh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,14 @@ repos:
           - --target-version=py39
           - --target-version=py310
 
+  # Autoformat: Python code
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args:
+          - --profile=black
+
   # Autoformat: Bash scripts
   - repo: https://github.com/lovesegfault/beautysh
     rev: v6.2.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,6 @@ import subprocess
 
 import yaml
 
-
 # -- Sphinx setup function ---------------------------------------------------
 # ref: http://www.sphinx-doc.org/en/latest/extdev/tutorial.html#the-setup-function
 

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -2,12 +2,11 @@ import glob
 import os
 import re
 import sys
-
 from binascii import a2b_hex
 
-from tornado.httpclient import AsyncHTTPClient
-from kubernetes_asyncio import client
 from jupyterhub.utils import url_path_join
+from kubernetes_asyncio import client
+from tornado.httpclient import AsyncHTTPClient
 
 # Make sure that modules placed in the same directory as the jupyterhub config are added to the pythonpath
 configuration_directory = os.path.dirname(os.path.realpath(__file__))
@@ -15,10 +14,10 @@ sys.path.insert(0, configuration_directory)
 
 from z2jh import (
     get_config,
-    set_config_if_not_none,
     get_name,
     get_name_env,
     get_secret_value,
+    set_config_if_not_none,
 )
 
 

--- a/jupyterhub/files/hub/z2jh.py
+++ b/jupyterhub/files/hub/z2jh.py
@@ -10,7 +10,7 @@ import os
 import yaml
 
 # memoize so we only load config once
-@lru_cache()
+@lru_cache
 def _load_config():
     """Load the Helm chart configuration used to render the Helm templates of
     the chart from a mounted k8s Secret, and merge in values from an optionally
@@ -29,7 +29,7 @@ def _load_config():
     return cfg
 
 
-@lru_cache()
+@lru_cache
 def _get_config_value(key):
     """Load value from the k8s ConfigMap given a key."""
 
@@ -41,7 +41,7 @@ def _get_config_value(key):
         raise Exception(f"{path} not found!")
 
 
-@lru_cache()
+@lru_cache
 def get_secret_value(key, default="never-explicitly-set"):
     """Load value from the user managed k8s Secret or the default k8s Secret
     given a key."""

--- a/jupyterhub/files/hub/z2jh.py
+++ b/jupyterhub/files/hub/z2jh.py
@@ -3,11 +3,12 @@ Utility methods for use in jupyterhub_config.py and dynamic subconfigs.
 
 Methods here can be imported by extraConfig in values.yaml
 """
+import os
 from collections.abc import Mapping
 from functools import lru_cache
-import os
 
 import yaml
+
 
 # memoize so we only load config once
 @lru_cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,12 @@ ref: https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 """
 
 import os
-import requests
 import textwrap
 import uuid
-
 from urllib.parse import urlparse
 
 import pytest
+import requests
 import yaml
 
 

--- a/tools/compare-values-schema-content.py
+++ b/tools/compare-values-schema-content.py
@@ -15,12 +15,11 @@ FIXME: It would be nice to run this as part of our CI pipeline to report if
        containerSecurityContext, readiness- and livenessProbe's, and hub.config.
 """
 
-import jsonschema
 import os
 import sys
-
 from collections.abc import MutableMapping
 
+import jsonschema
 import yaml
 
 here_dir = os.path.abspath(os.path.dirname(__file__))

--- a/tools/generate-json-schema.py
+++ b/tools/generate-json-schema.py
@@ -12,7 +12,6 @@ we trim away everything that isn't needed.
 import json
 import os
 import sys
-
 from collections.abc import MutableMapping
 
 import yaml

--- a/tools/set-chart-yaml-annotations.py
+++ b/tools/set-chart-yaml-annotations.py
@@ -12,7 +12,6 @@ FIXME: This implementation is done quick and dirty by appending to Chart.yaml
 
 import os
 import textwrap
-
 from collections.abc import MutableMapping
 
 import yaml

--- a/tools/templates/lint-and-validate.py
+++ b/tools/templates/lint-and-validate.py
@@ -14,12 +14,12 @@ yamllint: https://github.com/adrienverge/yamllint
   pip install yamllint
 """
 
-import os
-import sys
 import argparse
 import glob
+import os
 import pipes
 import subprocess
+import sys
 
 os.chdir(os.path.dirname(sys.argv[0]))
 

--- a/tools/validate-against-schema.py
+++ b/tools/validate-against-schema.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-import jsonschema
 import os
 import sys
+
+import jsonschema
 import yaml
 
 here_dir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
While this suddenly assumes the hub pod has py38+ and it could be seen as a breaking change, I don't think we should write about this in the changelog, as that version is considered internal.

What is a breaking change worth mentioning though is a transition from Python 3.8 to Python 3.9 within the hub image, see #2733.