### PR TITLE
feat: add KubeSpawner configuration singleuser.k8sApiRequestTimeout

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -137,6 +137,7 @@ set_config_if_not_none(
 for trait, cfg_key in (
     ("pod_name_template", None),
     ("start_timeout", None),
+    ("k8s_api_request_timeout", None),
     ("image_pull_policy", "image.pullPolicy"),
     # ('image_pull_secrets', 'image.pullSecrets'), # Managed manually below
     ("events_enabled", "events"),

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2065,6 +2065,11 @@ properties:
         description: |
           Passthrough configuration for
           [KubeSpawner.fs_gid](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.fs_gid).
+      k8sApiRequestTimeout:
+        type: [integer, "null"]
+        description: |
+          Passthrough configuration for
+          [KubeSpawner.k8s_api_request_timeout](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.k8s_api_request_timeout).
       lifecycleHooks:
         type: object
         additionalProperties: false

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -387,6 +387,7 @@ singleuser:
     pullPolicy:
     pullSecrets: []
   startTimeout: 300
+  k8sApiRequestTimeout: 3
   cpu:
     limit:
     guarantee:


### PR DESCRIPTION
On some clusters, keeping the default of 3 seconds makes it really hard to start a notebook. Allows to customize it while keeping the default of 3s.