### PR TITLE
feat: Implement `serviceAccount.create`

### DIFF
--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -3,7 +3,7 @@ FROM jupyter/base-notebook:latest
 #               https://github.com/jupyter/docker-stacks/blob/HEAD/base-notebook/Dockerfile
 # Built from... Ubuntu 20.04
 
-# VULN_SCAN_TIME=2022-05-15_02:03:52
+# VULN_SCAN_TIME=2022-05-30_05:27:31
 
 USER root
 RUN apt-get update \

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1259,6 +1259,10 @@ properties:
           Configuration for a k8s ServiceAccount dedicated for use by the
           specific pod which this configuration is nested under.
         properties:
+          create:
+            type: boolean
+            description: |
+              Whether or not to create the `ServiceAccount` resource
           annotations:
             type: object
             additionalProperties: false

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1263,6 +1263,14 @@ properties:
             type: boolean
             description: |
               Whether or not to create the `ServiceAccount` resource
+          name:
+            type: ["string", "null"]
+            description: |
+              This configuration serves multiple purposes:
+              - It will be the `serviceAccountName` referenced by related Pods.
+              - If `create` is set, the created ServiceAccount resource will be named like this.
+              - If [`rbac.enabled`](schema_rbac.enabled) is set, the associated (Cluster)RoleBindings will bind to this name.
+              If not explicitly provided, a default name will be used.
           annotations:
             type: object
             additionalProperties: false

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -78,10 +78,10 @@
 
 {{- /* hub-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.hub-serviceaccount.fullname" -}}
-    {{- if .Values.hub.serviceAccount.name }}
-        {{- .Values.hub.serviceAccount.name }}
-    {{- else if .Values.hub.serviceAccount.create }}
-        {{- include "jupyterhub.hub.fullname" . }}
+    {{- if .Values.hub.serviceAccount.create }}
+        {{- .Values.hub.serviceAccount.name | default (include "jupyterhub.hub.fullname" . ) }}
+    {{- else }}
+        {{- .Values.hub.serviceAccount.name | default "default"}}
     {{- end }}
 {{- end }}
 
@@ -144,10 +144,10 @@
 
 {{- /* autohttps-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.autohttps-serviceaccount.fullname" -}}
-    {{- if .Values.proxy.traefik.serviceAccount.name }}
-        {{- .Values.proxy.traefik.serviceAccount.name }}
-    {{- else if .Values.proxy.traefik.serviceAccount.create }}
-        {{- include "jupyterhub.autohttps.fullname" . }}
+    {{- if .Values.proxy.traefik.serviceAccount.create }}
+        {{- .Values.proxy.traefik.serviceAccount.name | default (include "jupyterhub.autohttps.fullname" . ) }}
+    {{- else }}
+        {{- .Values.proxy.traefik.serviceAccount.name | default "default"}}
     {{- end }}
 {{- end }}
 
@@ -158,10 +158,10 @@
 
 {{- /* user-scheduler-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.user-scheduler-serviceaccount.fullname" -}}
-    {{- if .Values.scheduling.userScheduler.serviceAccount.name }}
-        {{- .Values.scheduling.userScheduler.serviceAccount.name }}
-    {{- else if .Values.scheduling.userScheduler.serviceAccount.create }}
-        {{- include "jupyterhub.user-scheduler-deploy.fullname" . }}
+    {{- if .Values.scheduling.userScheduler.serviceAccount.create }}
+        {{- .Values.scheduling.userScheduler.serviceAccount.name | default (include "jupyterhub.user-scheduler-deploy.fullname" . ) }}
+    {{- else }}
+        {{- .Values.scheduling.userScheduler.serviceAccount.name | default "default"}}
     {{- end }}
 {{- end }}
 
@@ -182,10 +182,10 @@
 
 {{- /* image-awaiter-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.hook-image-awaiter-serviceaccount.fullname" -}}
-    {{- if .Values.prePuller.hook.serviceAccount.name }}
-        {{- .Values.prePuller.hook.serviceAccount.name }}
-    {{- else if .Values.prePuller.hook.serviceAccount.create }}
-        {{- include "jupyterhub.hook-image-awaiter.fullname" . }}
+    {{- if .Values.prePuller.hook.serviceAccount.create }}
+        {{- .Values.prePuller.hook.serviceAccount.name | default (include "jupyterhub.hook-image-awaiter.fullname" . ) }}
+    {{- else }}
+        {{- .Values.prePuller.hook.serviceAccount.name | default "default"}}
     {{- end }}
 {{- end }}
 

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -76,6 +76,11 @@
     {{- include "jupyterhub.fullname.dash" . }}hub
 {{- end }}
 
+{{- /* hub-serviceaccount ServiceAccount */}}
+{{- define "jupyterhub.hub-serviceaccount.fullname" -}}
+    {{- .Values.hub.serviceAccount.name | default (include "jupyterhub.hub.fullname" .) }}
+{{- end }}
+
 {{- /* hub-existing-secret Secret */}}
 {{- define "jupyterhub.hub-existing-secret.fullname" -}}
     {{- /* A hack to avoid issues from invoking this from a parent Helm chart. */}}
@@ -133,9 +138,19 @@
     {{- include "jupyterhub.fullname.dash" . }}autohttps
 {{- end }}
 
+{{- /* autohttps-serviceaccount ServiceAccount */}}
+{{- define "jupyterhub.autohttps-serviceaccount.fullname" -}}
+    {{- .Values.proxy.traefik.serviceAccount.name | default (include "jupyterhub.autohttps.fullname" .) }}
+{{- end }}
+
 {{- /* user-scheduler Deployment */}}
 {{- define "jupyterhub.user-scheduler-deploy.fullname" -}}
     {{- include "jupyterhub.fullname.dash" . }}user-scheduler
+{{- end }}
+
+{{- /* user-scheduler-serviceaccount ServiceAccount */}}
+{{- define "jupyterhub.user-scheduler-serviceaccount.fullname" -}}
+    {{- .Values.scheduling.userScheduler.serviceAccount.name | default (include "jupyterhub.user-scheduler-deploy.fullname" .) }}
 {{- end }}
 
 {{- /* user-scheduler leader election lock resource */}}
@@ -151,6 +166,11 @@
 {{- /* image-awaiter Job */}}
 {{- define "jupyterhub.hook-image-awaiter.fullname" -}}
     {{- include "jupyterhub.fullname.dash" . }}hook-image-awaiter
+{{- end }}
+
+{{- /* image-awaiter-serviceaccount ServiceAccount */}}
+{{- define "jupyterhub.hook-image-awaiter-serviceaccount.fullname" -}}
+    {{- .Values.prePuller.hook.serviceAccount.name | default (include "jupyterhub.hook-image-awaiter.fullname" .) }}
 {{- end }}
 
 {{- /* hook-image-puller DaemonSet */}}

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -276,6 +276,7 @@
 fullname: {{ include "jupyterhub.fullname" . | quote }}
 fullname-dash: {{ include "jupyterhub.fullname.dash" . | quote }}
 hub: {{ include "jupyterhub.hub.fullname" . | quote }}
+hub-serviceaccount: {{ include "jupyterhub.hub-serviceaccount.fullname" . | quote }}
 hub-existing-secret: {{ include "jupyterhub.hub-existing-secret.fullname" . | quote }}
 hub-existing-secret-or-default: {{ include "jupyterhub.hub-existing-secret-or-default.fullname" . | quote }}
 hub-pvc: {{ include "jupyterhub.hub-pvc.fullname" . | quote }}
@@ -286,11 +287,14 @@ proxy-public: {{ include "jupyterhub.proxy-public.fullname" . | quote }}
 proxy-public-tls: {{ include "jupyterhub.proxy-public-tls.fullname" . | quote }}
 proxy-public-manual-tls: {{ include "jupyterhub.proxy-public-manual-tls.fullname" . | quote }}
 autohttps: {{ include "jupyterhub.autohttps.fullname" . | quote }}
+autohttps-serviceaccount: {{ include "jupyterhub.autohttps-serviceaccount.fullname" . | quote }}
 user-scheduler-deploy: {{ include "jupyterhub.user-scheduler-deploy.fullname" . | quote }}
+user-scheduler-serviceaccount: {{ include "jupyterhub.user-scheduler-serviceaccount.fullname" . | quote }}
 user-scheduler-lock: {{ include "jupyterhub.user-scheduler-lock.fullname" . | quote }}
 user-placeholder: {{ include "jupyterhub.user-placeholder.fullname" . | quote }}
 image-puller-priority: {{ include "jupyterhub.image-puller-priority.fullname" . | quote }}
 hook-image-awaiter: {{ include "jupyterhub.hook-image-awaiter.fullname" . | quote }}
+hook-image-awaiter-serviceaccount: {{ include "jupyterhub.hook-image-awaiter-serviceaccount.fullname" . | quote }}
 hook-image-puller: {{ include "jupyterhub.hook-image-puller.fullname" . | quote }}
 continuous-image-puller: {{ include "jupyterhub.continuous-image-puller.fullname" . | quote }}
 singleuser: {{ include "jupyterhub.singleuser.fullname" . | quote }}

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -79,9 +79,9 @@
 {{- /* hub-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.hub-serviceaccount.fullname" -}}
     {{- if .Values.hub.serviceAccount.create }}
-        {{- .Values.hub.serviceAccount.name | default (include "jupyterhub.hub.fullname" . ) }}
+        {{- .Values.hub.serviceAccount.name | default (include "jupyterhub.hub.fullname" .) }}
     {{- else }}
-        {{- .Values.hub.serviceAccount.name | default "default"}}
+        {{- .Values.hub.serviceAccount.name | default "default" }}
     {{- end }}
 {{- end }}
 
@@ -145,9 +145,9 @@
 {{- /* autohttps-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.autohttps-serviceaccount.fullname" -}}
     {{- if .Values.proxy.traefik.serviceAccount.create }}
-        {{- .Values.proxy.traefik.serviceAccount.name | default (include "jupyterhub.autohttps.fullname" . ) }}
+        {{- .Values.proxy.traefik.serviceAccount.name | default (include "jupyterhub.autohttps.fullname" .) }}
     {{- else }}
-        {{- .Values.proxy.traefik.serviceAccount.name | default "default"}}
+        {{- .Values.proxy.traefik.serviceAccount.name | default "default" }}
     {{- end }}
 {{- end }}
 
@@ -159,9 +159,9 @@
 {{- /* user-scheduler-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.user-scheduler-serviceaccount.fullname" -}}
     {{- if .Values.scheduling.userScheduler.serviceAccount.create }}
-        {{- .Values.scheduling.userScheduler.serviceAccount.name | default (include "jupyterhub.user-scheduler-deploy.fullname" . ) }}
+        {{- .Values.scheduling.userScheduler.serviceAccount.name | default (include "jupyterhub.user-scheduler-deploy.fullname" .) }}
     {{- else }}
-        {{- .Values.scheduling.userScheduler.serviceAccount.name | default "default"}}
+        {{- .Values.scheduling.userScheduler.serviceAccount.name | default "default" }}
     {{- end }}
 {{- end }}
 
@@ -183,9 +183,9 @@
 {{- /* image-awaiter-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.hook-image-awaiter-serviceaccount.fullname" -}}
     {{- if .Values.prePuller.hook.serviceAccount.create }}
-        {{- .Values.prePuller.hook.serviceAccount.name | default (include "jupyterhub.hook-image-awaiter.fullname" . ) }}
+        {{- .Values.prePuller.hook.serviceAccount.name | default (include "jupyterhub.hook-image-awaiter.fullname" .) }}
     {{- else }}
-        {{- .Values.prePuller.hook.serviceAccount.name | default "default"}}
+        {{- .Values.prePuller.hook.serviceAccount.name | default "default" }}
     {{- end }}
 {{- end }}
 

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -78,7 +78,11 @@
 
 {{- /* hub-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.hub-serviceaccount.fullname" -}}
-    {{- .Values.hub.serviceAccount.name | default (include "jupyterhub.hub.fullname" .) }}
+    {{- if .Values.hub.serviceAccount.name }}
+        {{- .Values.hub.serviceAccount.name }}
+    {{- else if .Values.hub.serviceAccount.create }}
+        {{- include "jupyterhub.hub.fullname" . }}
+    {{- end }}
 {{- end }}
 
 {{- /* hub-existing-secret Secret */}}
@@ -140,7 +144,11 @@
 
 {{- /* autohttps-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.autohttps-serviceaccount.fullname" -}}
-    {{- .Values.proxy.traefik.serviceAccount.name | default (include "jupyterhub.autohttps.fullname" .) }}
+    {{- if .Values.proxy.traefik.serviceAccount.name }}
+        {{- .Values.proxy.traefik.serviceAccount.name }}
+    {{- else if .Values.proxy.traefik.serviceAccount.create }}
+        {{- include "jupyterhub.autohttps.fullname" . }}
+    {{- end }}
 {{- end }}
 
 {{- /* user-scheduler Deployment */}}
@@ -150,7 +158,11 @@
 
 {{- /* user-scheduler-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.user-scheduler-serviceaccount.fullname" -}}
-    {{- .Values.scheduling.userScheduler.serviceAccount.name | default (include "jupyterhub.user-scheduler-deploy.fullname" .) }}
+    {{- if .Values.scheduling.userScheduler.serviceAccount.name }}
+        {{- .Values.scheduling.userScheduler.serviceAccount.name }}
+    {{- else if .Values.scheduling.userScheduler.serviceAccount.create }}
+        {{- include "jupyterhub.user-scheduler-deploy.fullname" . }}
+    {{- end }}
 {{- end }}
 
 {{- /* user-scheduler leader election lock resource */}}
@@ -170,7 +182,11 @@
 
 {{- /* image-awaiter-serviceaccount ServiceAccount */}}
 {{- define "jupyterhub.hook-image-awaiter-serviceaccount.fullname" -}}
-    {{- .Values.prePuller.hook.serviceAccount.name | default (include "jupyterhub.hook-image-awaiter.fullname" .) }}
+    {{- if .Values.prePuller.hook.serviceAccount.name }}
+        {{- .Values.prePuller.hook.serviceAccount.name }}
+    {{- else if .Values.prePuller.hook.serviceAccount.create }}
+        {{- include "jupyterhub.hook-image-awaiter.fullname" . }}
+    {{- end }}
 {{- end }}
 
 {{- /* hook-image-puller DaemonSet */}}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "jupyterhub.hub-pvc.fullname" . }}
         {{- end }}
-      {{- if .Values.rbac.enabled }}
+      {{- if .Values.hub.serviceAccount.create }}
       serviceAccountName: {{ include "jupyterhub.hub.fullname" . }}
       {{- end }}
       {{- with .Values.hub.podSecurityContext }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             claimName: {{ include "jupyterhub.hub-pvc.fullname" . }}
         {{- end }}
       {{- if .Values.hub.serviceAccount.create }}
-      serviceAccountName: {{ include "jupyterhub.hub.fullname" . }}
+      serviceAccountName: {{ include "jupyterhub.hub-serviceaccount.fullname" . }}
       {{- end }}
       {{- with .Values.hub.podSecurityContext }}
       securityContext:

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -75,8 +75,8 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "jupyterhub.hub-pvc.fullname" . }}
         {{- end }}
-      {{- if .Values.hub.serviceAccount.create }}
-      serviceAccountName: {{ include "jupyterhub.hub-serviceaccount.fullname" . }}
+      {{- with include "jupyterhub.hub-serviceaccount.fullname" . }}
+      serviceAccountName: {{ . }}
       {{- end }}
       {{- with .Values.hub.podSecurityContext }}
       securityContext:

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "jupyterhub.hub.fullname" . }}
+    name: {{ include "jupyterhub.hub-serviceaccount.fullname" . }}
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,16 +1,3 @@
-{{- if .Values.hub.serviceAccount.create -}}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "jupyterhub.hub.fullname" . }}
-  {{- with .Values.hub.serviceAccount.annotations }}
-  annotations:
-    {{- . | toYaml | nindent 4 }}
-  {{- end }}
-  labels:
-    {{- include "jupyterhub.labels" . | nindent 4 }}
-{{- end }}
 {{- if .Values.rbac.enabled -}}
 ---
 kind: Role

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.hub.serviceAccount.create -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,6 +10,8 @@ metadata:
   {{- end }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+{{- end }}
+{{- if .Values.rbac.enabled -}}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.enabled -}}
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/jupyterhub/templates/hub/serviceaccount.yaml
+++ b/jupyterhub/templates/hub/serviceaccount.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.hub.serviceAccount.create -}}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/jupyterhub/templates/hub/serviceaccount.yaml
+++ b/jupyterhub/templates/hub/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.hub.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.hub.fullname" . }}
+  {{- with .Values.hub.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+{{- end }}

--- a/jupyterhub/templates/hub/serviceaccount.yaml
+++ b/jupyterhub/templates/hub/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "jupyterhub.hub.fullname" . }}
+  name: {{ include "jupyterhub.hub-serviceaccount.fullname" . }}
   {{- with .Values.hub.serviceAccount.annotations }}
   annotations:
     {{- . | toYaml | nindent 4 }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -34,8 +34,8 @@ spec:
       {{- end }}
     spec:
       restartPolicy: Never
-      {{- if .Values.prePuller.hook.serviceAccount.create }}
-      serviceAccountName: {{ include "jupyterhub.hook-image-awaiter-serviceaccount.fullname" . }}
+      {{- with include "jupyterhub.hook-image-awaiter-serviceaccount.fullname" . }}
+      serviceAccountName: {{ . }}
       {{- end }}
       {{- with .Values.prePuller.hook.nodeSelector }}
       nodeSelector:

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
     spec:
       restartPolicy: Never
-      {{- if .Values.rbac.enabled }}
+      {{- if .Values.prePuller.hook.serviceAccount.create }}
       serviceAccountName: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
       {{- end }}
       {{- with .Values.prePuller.hook.nodeSelector }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       restartPolicy: Never
       {{- if .Values.prePuller.hook.serviceAccount.create }}
-      serviceAccountName: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
+      serviceAccountName: {{ include "jupyterhub.hook-image-awaiter-serviceaccount.fullname" . }}
       {{- end }}
       {{- with .Values.prePuller.hook.nodeSelector }}
       nodeSelector:

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -3,7 +3,6 @@ Permissions to be used by the hook-image-awaiter job
 */}}
 {{- if .Values.rbac.enabled -}}
 {{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) -}}
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -36,7 +36,7 @@ metadata:
     "helm.sh/hook-weight": "0"
 subjects:
   - kind: ServiceAccount
-    name: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
+    name: {{ include "jupyterhub.hook-image-awaiter-serviceaccount.fullname" . }}
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -1,8 +1,8 @@
 {{- /*
 Permissions to be used by the hook-image-awaiter job
 */}}
-{{- if .Values.rbac.enabled }}
-{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) }}
+{{- if .Values.rbac.enabled -}}
+{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) -}}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -1,32 +1,9 @@
 {{- /*
 Permissions to be used by the hook-image-awaiter job
 */}}
-{{- if .Values.prePuller.hook.serviceAccount.create }}
-{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) }}
-{{- /*
-This service account...
-*/ -}}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
-  labels:
-    {{- include "jupyterhub.labels" . | nindent 4 }}
-    hub.jupyter.org/deletable: "true"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    "helm.sh/hook-weight": "0"
-    {{- with .Values.prePuller.hook.serviceAccount.annotations }}
-    {{- . | toYaml | nindent 4 }}
-    {{- end }}
-{{- end }}
 {{- if .Values.rbac.enabled }}
+{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) }}
 ---
-{{- /*
-... will be used by this role...
-*/}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -1,11 +1,12 @@
 {{- /*
 Permissions to be used by the hook-image-awaiter job
 */}}
-{{- if .Values.rbac.enabled }}
+{{- if .Values.prePuller.hook.serviceAccount.create }}
 {{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) }}
 {{- /*
 This service account...
 */ -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -20,6 +21,8 @@ metadata:
     {{- with .Values.prePuller.hook.serviceAccount.annotations }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
+{{- end }}
+{{- if .Values.rbac.enabled }}
 ---
 {{- /*
 ... will be used by this role...

--- a/jupyterhub/templates/image-puller/serviceaccount.yaml
+++ b/jupyterhub/templates/image-puller/serviceaccount.yaml
@@ -3,7 +3,6 @@ ServiceAccount for the pre-puller hook's image-awaiter-job
 */}}
 {{- if .Values.prePuller.hook.serviceAccount.create -}}
 {{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) -}}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/jupyterhub/templates/image-puller/serviceaccount.yaml
+++ b/jupyterhub/templates/image-puller/serviceaccount.yaml
@@ -7,7 +7,7 @@ ServiceAccount for the pre-puller hook's image-awaiter-job
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
+  name: {{ include "jupyterhub.hook-image-awaiter-serviceaccount.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"

--- a/jupyterhub/templates/image-puller/serviceaccount.yaml
+++ b/jupyterhub/templates/image-puller/serviceaccount.yaml
@@ -1,0 +1,22 @@
+{{- /*
+ServiceAccount for the pre-puller hook's image-awaiter-job
+*/}}
+{{- if .Values.prePuller.hook.serviceAccount.create }}
+{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    hub.jupyter.org/deletable: "true"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+    {{- with .Values.prePuller.hook.serviceAccount.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/image-puller/serviceaccount.yaml
+++ b/jupyterhub/templates/image-puller/serviceaccount.yaml
@@ -1,8 +1,8 @@
 {{- /*
 ServiceAccount for the pre-puller hook's image-awaiter-job
 */}}
-{{- if .Values.prePuller.hook.serviceAccount.create }}
-{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) }}
+{{- if .Values.prePuller.hook.serviceAccount.create -}}
+{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -27,8 +27,8 @@ spec:
         # entrypoint of all network traffic.
         checksum/static-config: {{ include "jupyterhub.traefik.yaml" . | fromYaml | merge .Values.proxy.traefik.extraStaticConfig | toYaml | sha256sum }}
     spec:
-      {{- if .Values.proxy.traefik.serviceAccount.create }}
-      serviceAccountName: {{ include "jupyterhub.autohttps-serviceaccount.fullname" . }}
+      {{- with include "jupyterhub.autohttps-serviceaccount.fullname" . }}
+      serviceAccountName: {{ . }}
       {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         checksum/static-config: {{ include "jupyterhub.traefik.yaml" . | fromYaml | merge .Values.proxy.traefik.extraStaticConfig | toYaml | sha256sum }}
     spec:
       {{- if .Values.proxy.traefik.serviceAccount.create }}
-      serviceAccountName: {{ include "jupyterhub.autohttps.fullname" . }}
+      serviceAccountName: {{ include "jupyterhub.autohttps-serviceaccount.fullname" . }}
       {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         # entrypoint of all network traffic.
         checksum/static-config: {{ include "jupyterhub.traefik.yaml" . | fromYaml | merge .Values.proxy.traefik.extraStaticConfig | toYaml | sha256sum }}
     spec:
-      {{- if .Values.rbac.enabled }}
+      {{- if .Values.proxy.traefik.serviceAccount.create }}
       serviceAccountName: {{ include "jupyterhub.autohttps.fullname" . }}
       {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -1,15 +1,6 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- if $autoHTTPS -}}
-{{- if .Values.proxy.traefik.serviceAccount.create }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "jupyterhub.autohttps.fullname" . }}
-  labels:
-    {{- include "jupyterhub.labels" . | nindent 4 }}
-{{- end }}
 {{- if .Values.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -1,7 +1,7 @@
-{{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
-{{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
+{{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) -}}
+{{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) -}}
 {{- if $autoHTTPS -}}
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.enabled -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -26,7 +26,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "jupyterhub.autohttps.fullname" . }}
+  name: {{ include "jupyterhub.autohttps-serviceaccount.fullname" . }}
   apiGroup:
 roleRef:
   kind: Role

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -1,6 +1,17 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
-{{- if (and $autoHTTPS .Values.rbac.enabled) -}}
+{{- if $autoHTTPS -}}
+{{- if .Values.proxy.traefik.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.autohttps.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+{{- end }}
+{{- if .Values.rbac.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -30,11 +41,5 @@ roleRef:
   kind: Role
   name: {{ include "jupyterhub.autohttps.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "jupyterhub.autohttps.fullname" . }}
-  labels:
-    {{- include "jupyterhub.labels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -2,7 +2,6 @@
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) -}}
 {{- if $autoHTTPS -}}
 {{- if .Values.rbac.enabled -}}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/jupyterhub/templates/proxy/autohttps/serviceaccount.yaml
+++ b/jupyterhub/templates/proxy/autohttps/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
+{{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
+{{- if $autoHTTPS -}}
+{{- if .Values.proxy.traefik.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.autohttps.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/proxy/autohttps/serviceaccount.yaml
+++ b/jupyterhub/templates/proxy/autohttps/serviceaccount.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "jupyterhub.autohttps.fullname" . }}
+  name: {{ include "jupyterhub.autohttps-serviceaccount.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/serviceaccount.yaml
+++ b/jupyterhub/templates/proxy/autohttps/serviceaccount.yaml
@@ -2,7 +2,6 @@
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) -}}
 {{- if $autoHTTPS -}}
 {{- if .Values.proxy.traefik.serviceAccount.create -}}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/jupyterhub/templates/proxy/autohttps/serviceaccount.yaml
+++ b/jupyterhub/templates/proxy/autohttps/serviceaccount.yaml
@@ -1,7 +1,7 @@
-{{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
-{{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
+{{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) -}}
+{{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) -}}
 {{- if $autoHTTPS -}}
-{{- if .Values.proxy.traefik.serviceAccount.create }}
+{{- if .Values.proxy.traefik.serviceAccount.create -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.scheduling.userScheduler.serviceAccount.create }}
-      serviceAccountName: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
+      serviceAccountName: {{ include "jupyterhub.user-scheduler-serviceaccount.fullname" . }}
       {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.rbac.enabled }}
+      {{- if .Values.scheduling.userScheduler.serviceAccount.create }}
       serviceAccountName: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
       {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -17,8 +17,8 @@ spec:
       annotations:
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.scheduling.userScheduler.serviceAccount.create }}
-      serviceAccountName: {{ include "jupyterhub.user-scheduler-serviceaccount.fullname" . }}
+      {{ with include "jupyterhub.user-scheduler-serviceaccount.fullname" . }}
+      serviceAccountName: {{ . }}
       {{- end }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
-{{- if .Values.rbac.enabled }}
+{{- if .Values.scheduling.userScheduler.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,6 +10,8 @@ metadata:
   annotations:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
+{{- end }}
+{{- if .Values.rbac.enabled }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
 {{- if .Values.rbac.enabled -}}
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -224,7 +224,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
+    name: {{ include "jupyterhub.user-scheduler-serviceaccount.fullname" . }}
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: ClusterRole

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.enabled -}}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,16 +1,4 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
-{{- if .Values.scheduling.userScheduler.serviceAccount.create }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
-  labels:
-    {{- include "jupyterhub.labels" . | nindent 4 }}
-  {{- with .Values.scheduling.userScheduler.serviceAccount.annotations }}
-  annotations:
-    {{- . | toYaml | nindent 4 }}
-  {{- end }}
-{{- end }}
 {{- if .Values.rbac.enabled }}
 ---
 kind: ClusterRole

--- a/jupyterhub/templates/scheduling/user-scheduler/serviceaccount.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.scheduling.userScheduler.enabled -}}
+{{- if .Values.scheduling.userScheduler.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- with .Values.scheduling.userScheduler.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/serviceaccount.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
+  name: {{ include "jupyterhub.user-scheduler-serviceaccount.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   {{- with .Values.scheduling.userScheduler.serviceAccount.annotations }}

--- a/jupyterhub/templates/scheduling/user-scheduler/serviceaccount.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
-{{- if .Values.scheduling.userScheduler.serviceAccount.create }}
+{{- if .Values.scheduling.userScheduler.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -137,6 +137,7 @@ hub:
     timeoutSeconds: 1
   existingSecret:
   serviceAccount:
+    create: true
     annotations: {}
   extraPodSpec: {}
 
@@ -278,6 +279,7 @@ proxy:
       maxUnavailable:
       minAvailable: 1
     serviceAccount:
+      create: true
       annotations: {}
     extraPodSpec: {}
   secretSync:
@@ -514,6 +516,7 @@ scheduling:
       minAvailable:
     resources: {}
     serviceAccount:
+      create: true
       annotations: {}
     extraPodSpec: {}
   podPriority:
@@ -593,6 +596,7 @@ prePuller:
     tolerations: []
     resources: {}
     serviceAccount:
+      create: true
       annotations: {}
   continuous:
     enabled: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -138,6 +138,7 @@ hub:
   existingSecret:
   serviceAccount:
     create: true
+    name:
     annotations: {}
   extraPodSpec: {}
 
@@ -280,6 +281,7 @@ proxy:
       minAvailable: 1
     serviceAccount:
       create: true
+      name:
       annotations: {}
     extraPodSpec: {}
   secretSync:
@@ -517,6 +519,7 @@ scheduling:
     resources: {}
     serviceAccount:
       create: true
+      name:
       annotations: {}
     extraPodSpec: {}
   podPriority:
@@ -597,6 +600,7 @@ prePuller:
     resources: {}
     serviceAccount:
       create: true
+      name:
       annotations: {}
   continuous:
     enabled: true

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -189,6 +189,8 @@ hub:
       value: mock-taint-value-hub
       effect: NoSchedule
   serviceAccount: &serviceAccount
+    create: true
+    name: mock-serviceaccount-name
     annotations: *annotations
   extraPodSpec: &extraPodSpec
     hostNetwork: true


### PR DESCRIPTION
This feature introduces a new `.serviceAccount.create` for all
`ServiceAccount` resources, which defaults to `true`. This is a breaking
change for all users with `rbac.enabled` set to `false`, as these users will get some ServiceAccount resources created where they previously ran as the default user.

For context, please see the discussion at https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2691 .

The use-case for this feature is to allow users who use `rbac.enabled=false` to provision `serviceAccounts` without rbac resources like `Role` and `RoleBinding`. It also limits the `rbac.enabled` to only refer to resources that relate to the actual rbac API in kubernetes.