### PR TITLE
Add ability to specify existing ServiceAccount for all components.

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1259,12 +1259,25 @@ properties:
           Configuration for a k8s ServiceAccount dedicated for use by the
           specific pod which this configuration is nested under.
         properties:
+          create:
+            type: boolean
+            additionalProperties: false
+            description: |
+              Specifies whether a k8s ServiceAccount should be created.
           annotations:
             type: object
             additionalProperties: false
             patternProperties: *labels-and-annotations-patternProperties
             description: |
               Kubernetes annotations to apply to the k8s ServiceAccount.
+          name:
+            type: string
+            additionalProperties: false
+            description: |
+              Name of the k8s ServiceAccount to use.
+
+              If not set and create is true, a name is generated using the
+              component fullname template.
       extraPodSpec: &extraPodSpec-spec
         type: object
         additionalProperties: true

--- a/jupyterhub/templates/hub/_hub-helpers.tpl
+++ b/jupyterhub/templates/hub/_hub-helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "jupyterhub.hub.ServiceAccountName" -}}
+{{- if .Values.hub.serviceAccount.create -}}
+    {{ default (include "jupyterhub.hub.fullname" .) .Values.hub.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.hub.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -75,9 +75,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "jupyterhub.hub-pvc.fullname" . }}
         {{- end }}
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ include "jupyterhub.hub.fullname" . }}
-      {{- end }}
+      serviceAccountName: {{ include "jupyterhub.hub.ServiceAccountName" . }}
       {{- with .Values.hub.podSecurityContext }}
       securityContext:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,14 +1,16 @@
 {{- if .Values.rbac.enabled -}}
+{{- if .Values.hub.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "jupyterhub.hub.fullname" . }}
+  name: {{ include "jupyterhub.hub.ServiceAccountName" . }}
   {{- with .Values.hub.serviceAccount.annotations }}
   annotations:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+{{- end }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -32,7 +34,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "jupyterhub.hub.fullname" . }}
+    name: {{ include "jupyterhub.hub.ServiceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role

--- a/jupyterhub/templates/image-puller/_prepuller-helpers.tpl
+++ b/jupyterhub/templates/image-puller/_prepuller-helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "jupyterhub.hook-image-awaiter.serviceAccountName" -}}
+{{- if .Values.prePuller.hook.serviceAccount.create -}}
+    {{ default (include "jupyterhub.hook-image-awaiter.fullname" .) .Values.prePuller.hook.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.prePuller.hook.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -34,9 +34,7 @@ spec:
       {{- end }}
     spec:
       restartPolicy: Never
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
-      {{- end }}
+      serviceAccountName: {{ include "jupyterhub.hook-image-awaiter.serviceAccountName" . }}
       {{- with .Values.prePuller.hook.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -6,10 +6,11 @@ Permissions to be used by the hook-image-awaiter job
 {{- /*
 This service account...
 */ -}}
+{{- if .Values.prePuller.hook.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
+  name: {{ include "jupyterhub.hook-image-awaiter.serviceAccountName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     hub.jupyter.org/deletable: "true"
@@ -20,6 +21,7 @@ metadata:
     {{- with .Values.prePuller.hook.serviceAccount.annotations }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
+{{- end }}
 ---
 {{- /*
 ... will be used by this role...
@@ -56,7 +58,7 @@ metadata:
     "helm.sh/hook-weight": "0"
 subjects:
   - kind: ServiceAccount
-    name: {{ include "jupyterhub.hook-image-awaiter.fullname" . }}
+    name: {{ include "jupyterhub.hook-image-awaiter.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: Role

--- a/jupyterhub/templates/proxy/autohttps/_autohttps-helpers.tpl
+++ b/jupyterhub/templates/proxy/autohttps/_autohttps-helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "jupyterhub.autohttps.serviceAccountName" -}}
+{{- if .Values.proxy.traefik.serviceAccount.create -}}
+    {{ default (include "jupyterhub.autohttps.fullname" .) .Values.proxy.traefik.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.proxy.traefik.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -27,9 +27,7 @@ spec:
         # entrypoint of all network traffic.
         checksum/static-config: {{ include "jupyterhub.traefik.yaml" . | fromYaml | merge .Values.proxy.traefik.extraStaticConfig | toYaml | sha256sum }}
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ include "jupyterhub.autohttps.fullname" . }}
-      {{- end }}
+      serviceAccountName: {{ include "jupyterhub.autohttps.serviceAccountName" . }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -1,6 +1,15 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- if (and $autoHTTPS .Values.rbac.enabled) -}}
+{{- if .Values.proxy.traefik.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.autohttps.serviceAccountName" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -24,17 +33,10 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "jupyterhub.autohttps.fullname" . }}
+  name: {{ include "jupyterhub.autohttps.serviceAccountName" . }}
   apiGroup:
 roleRef:
   kind: Role
   name: {{ include "jupyterhub.autohttps.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "jupyterhub.autohttps.fullname" . }}
-  labels:
-    {{- include "jupyterhub.labels" . | nindent 4 }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
+++ b/jupyterhub/templates/scheduling/_scheduling-helpers.tpl
@@ -1,3 +1,11 @@
+{{- define "jupyterhub.user-scheduler-deploy.serviceAccountName" -}}
+{{- if .Values.scheduling.userScheduler.serviceAccount.create -}}
+    {{ default (include "jupyterhub.user-scheduler-deploy.fullname" .) .Values.scheduling.userScheduler.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.scheduling.userScheduler.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
 {{- define "jupyterhub.userNodeAffinityRequired" -}}
 {{- if eq .Values.scheduling.userPods.nodeAffinity.matchNodePurpose "require" -}}
 - matchExpressions:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -17,9 +17,7 @@ spec:
       annotations:
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
-      {{- end }}
+      serviceAccountName: {{ include "jupyterhub.user-scheduler-deploy.serviceAccountName" . }}
       {{- if .Values.scheduling.podPriority.enabled }}
       priorityClassName: {{ include "jupyterhub.priority.fullname" . }}
       {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
 {{- if .Values.rbac.enabled }}
+{{- if .Values.scheduling.userScheduler.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
+  name: {{ include "jupyterhub.user-scheduler-deploy.serviceAccountName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   {{- with .Values.scheduling.userScheduler.serviceAccount.annotations }}
@@ -11,6 +12,7 @@ metadata:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
 ---
+{{- end }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -234,7 +236,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}
+    name: {{ include "jupyterhub.user-scheduler-deploy.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: ClusterRole

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -137,7 +137,9 @@ hub:
     timeoutSeconds: 1
   existingSecret:
   serviceAccount:
+    create: true
     annotations: {}
+    name:
   extraPodSpec: {}
 
 rbac:
@@ -278,7 +280,9 @@ proxy:
       maxUnavailable:
       minAvailable: 1
     serviceAccount:
+      create: true
       annotations: {}
+      name:
     extraPodSpec: {}
   secretSync:
     containerSecurityContext:
@@ -514,7 +518,9 @@ scheduling:
       minAvailable:
     resources: {}
     serviceAccount:
+      create: true
       annotations: {}
+      name:
     extraPodSpec: {}
   podPriority:
     enabled: false
@@ -593,7 +599,9 @@ prePuller:
     tolerations: []
     resources: {}
     serviceAccount:
+      create: true
       annotations: {}
+      name:
   continuous:
     enabled: true
   pullProfileListImages: true


### PR DESCRIPTION
Some clusters may want to manually manage the RBACs with pre-defined ServiceAccounts, in this case we want to be able to specify it without creating it.