### PR TITLE
breaking, maint: replace rbac.enabled with rbac.create

### DIFF
--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -205,7 +205,7 @@ If you want to disable the RBAC rules, for whatever reason, you can do so with t
 
 ```yaml
 rbac:
-  enabled: false
+  create: false
 ```
 
 We strongly **discourage disabling** the RBAC rules and remind you that this

--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -197,7 +197,7 @@ kubectl --namespace=kube-system delete rc kubernetes-dashboard
 Kubernetes supports, and often requires, using [Role Based Access Control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
 to secure which pods / users can perform what kinds of actions on the cluster. RBAC rules can be set to provide users with minimal necessary access based on their administrative needs.
 
-It is **critical** to understand that if RBAC is disabled, all pods are given `root` equivalent permission on the Kubernetes cluster and all the nodes in it. This opens up very bad vulnerabilites for your security.
+It is **critical** to understand that if RBAC is disabled, all pods are given `root` equivalent permission on the Kubernetes cluster and all the nodes in it. This opens up very bad vulnerabilities for your security.
 
 As of the Helm chart v0.5 used with JupyterHub and BinderHub, the helm chart can natively work with RBAC enabled clusters. To provide sensible security defaults, we ship appropriate minimal RBAC rules for the various components we use. We **highly recommend** using these minimal or more restrictive RBAC rules.
 

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1366,6 +1366,7 @@ properties:
         description: *jupyterhub-native-config-description
       serviceAccount: &serviceAccount
         type: object
+        required: [create]
         additionalProperties: false
         description: |
           Configuration for a k8s ServiceAccount dedicated for use by the
@@ -1374,14 +1375,16 @@ properties:
           create:
             type: boolean
             description: |
-              Whether or not to create the `ServiceAccount` resource
+              Whether or not to create the `ServiceAccount` resource.
           name:
             type: ["string", "null"]
             description: |
               This configuration serves multiple purposes:
+
               - It will be the `serviceAccountName` referenced by related Pods.
               - If `create` is set, the created ServiceAccount resource will be named like this.
-              - If [`rbac.enabled`](schema_rbac.enabled) is set, the associated (Cluster)RoleBindings will bind to this name.
+              - If [`rbac.create`](schema_rbac.create) is set, the associated (Cluster)RoleBindings will bind to this name.
+
               If not explicitly provided, a default name will be used.
           annotations:
             type: object
@@ -2837,13 +2840,43 @@ properties:
   rbac:
     type: object
     additionalProperties: false
-    required: [enabled]
+    required: [create]
     properties:
       enabled:
         type: boolean
+        # This schema entry is needed to help us print a more helpful error
+        # message in NOTES.txt if hub.fsGid is set.
+        #
         description: |
-          Decides if RBAC resources are to be created and referenced by the the
-          Helm chart's workloads.
+          ````{note}
+          Removed in version 2.0.0. If you have been using `rbac.enable=false`
+          (strongly discouraged), then the equivalent configuration would be:
+
+          ```yaml
+          rbac:
+            create: false
+          hub:
+            serviceAccount:
+              create: false
+          proxy:
+            traefik:
+              serviceAccount:
+                create: false
+          scheduling:
+            userScheduler:
+              serviceAccount:
+                create: false
+          prePuller:
+            hook:
+              serviceAccount:
+                create: false
+          ```
+          ````
+      create:
+        type: boolean
+        description: |
+          Decides if (Cluster)Role and (Cluster)RoleBinding resources are
+          created and bound to the configured serviceAccounts.
 
   global:
     type: object

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -138,6 +138,11 @@
 */}}
 
 
+{{- if hasKey .Values.rbac "enabled" }}
+{{- $breaking = print $breaking "\n\nCHANGED: rbac.enabled must as of version 2.0.0 be configured via rbac.create and <hub|proxy.traefik|scheduling.userScheduler|prePuller.hook>.serviceAccount.create." }}
+{{- end }}
+
+
 {{- if hasKey .Values.hub "fsGid" }}
 {{- $breaking = print $breaking "\n\nCHANGED: hub.fsGid must as of version 2.0.0 be configured via hub.podSecurityContext.fsGroup." }}
 {{- end }}

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -12,7 +12,7 @@
 
   When you ask a helper to render its content, one often forward the current
   scope to the helper in order to allow it to access .Release.Name,
-  .Values.rbac.enabled and similar values.
+  .Values.rbac.create and similar values.
 
   #### Example - Passing the current scope
   {{ include "jupyterhub.commonLabels" . }}

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/jupyterhub/templates/image-puller/rbac.yaml
+++ b/jupyterhub/templates/image-puller/rbac.yaml
@@ -1,7 +1,7 @@
 {{- /*
 Permissions to be used by the hook-image-awaiter job
 */}}
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 {{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) -}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -1,7 +1,7 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) -}}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) -}}
 {{- if $autoHTTPS -}}
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.scheduling.userScheduler.enabled -}}
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -139,7 +139,7 @@ hub:
   extraPodSpec: {}
 
 rbac:
-  enabled: true
+  create: true
 
 # proxy relates to the proxy pod, the proxy-public service, and the autohttps
 # pod and proxy-http service.

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -206,7 +206,7 @@ hub:
     dnsPolicy: ClusterFirstWithHostNet
 
 rbac:
-  enabled: true
+  create: true
 
 proxy:
   service:


### PR DESCRIPTION
To use `rbac.create` instead of `rbac.enabled` has been a common suggestion over time as that is how most other Helm charts have named this configuration, so like this we will better align with the common practice.

This is a followup PR to #2736 that changed the behavior of `rbac.enabled` in a way that motivated some breaking change documentation in the changelog. As part of that, I figured it could be motivated to also transition `rbac.enabled` to `rbac.create` and force users having declared `rbac.enabled` to adjust to the change.

Previously, `rbac.enabled` was handling both the creation of Role/RoleBinding and ServiceAccount resources, while after #2736 it is only managing the Role/RoleBinding resources. With this PR, users that has configured `rbac.enabled` explicitly, either true or false, will see the following error on template rendering.

```
helm template jupyterhub jupyterhub --set rbac.enabled=false
Error: execution error at (jupyterhub/templates/NOTES.txt:152:4): 

#################################################################################
######   BREAKING: The config values passed contained no longer accepted    #####
######             options. See the messages below for more details.        #####
######                                                                      #####
######             To verify your updated config is accepted, you can use   #####
######             the `helm template` command.                             #####
#################################################################################

CHANGED: rbac.enabled must as of version 2.0.0 be configured via rbac.create and <hub|proxy.traefik|scheduling.userScheduler|prePuller.hook>.serviceAccount.create.
```

## Related
- #2736
- #2680