### PR TITLE
Fix link to authentication guide

### DIFF
--- a/docs/source/jupyterhub/customizing/user-management.md
+++ b/docs/source/jupyterhub/customizing/user-management.md
@@ -114,4 +114,4 @@ hub:
 ## Authenticating Users
 
 For information on authenticating users in JupyterHub, see
-[the Authentication guide](../../administrator/authentication).
+[the Authentication guide](../../administrator/authentication.md).


### PR DESCRIPTION
The current link results in a 404. It looks like is just missing the `.md` extension.