### PR TITLE
Add scheduling.userPlaceholder.annotations

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2509,6 +2509,12 @@ properties:
             type: integer
             description: |
               How many placeholder pods would you like to have?
+          annotations:
+            type: object
+            additionalProperties: false
+            patternProperties: *labels-and-annotations-patternProperties
+            description: |
+              Extra annotations to add to the placeholder pods.
           resources:
             type: object
             additionalProperties: true

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -23,6 +23,10 @@ spec:
   serviceName: {{ include "jupyterhub.user-placeholder.fullname" . }}
   template:
     metadata:
+      {{- if .Values.scheduling.userPlaceholder.annotations }}
+      annotations:
+        {{- toYaml .Values.scheduling.userPlaceholder.annotations | nindent 8 }}
+      {{- end }}
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -23,9 +23,9 @@ spec:
   serviceName: {{ include "jupyterhub.user-placeholder.fullname" . }}
   template:
     metadata:
-      {{- if .Values.scheduling.userPlaceholder.annotations }}
+      {{- with .Values.scheduling.userPlaceholder.annotations }}
       annotations:
-        {{- toYaml .Values.scheduling.userPlaceholder.annotations | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -535,6 +535,7 @@ scheduling:
       pullPolicy:
       pullSecrets: []
     replicas: 0
+    annotations: {}
     containerSecurityContext:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group


### PR DESCRIPTION
This is a generic pattern to allow user annotations on the resulting pods.

The specific use case I have is adding `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"`. A snippet from the [cluster-autoscaler docs](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node):

>    What types of pods can prevent CA from removing a node?
>    - Pods with local storage. *
>    *Unless the pod has the following annotation (supported in CA 1.0.3 or later): "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"

and what I see in the autoscaler logs:
```
Fast evaluation: node ip-10-10-10-10.us-west-2.compute.internal cannot be removed: pod with local storage present: user-placeholder-0
```

### Your personal set up
- EKS 1.22
- cluster-autoscaler 1.22.2
- Zero-to-JupyterHub Chart 1.2.0

My running environment is a separate node pool for the notebook pods. I have a node running with only the `user-placeholder` Pod (and DaemonSet pods, but they don’t count. they evict just fine.) _and_ there’s room on another notebook node for the placeholder. I want the placeholder pod to be rescheduled onto the in-use node and then the autoscaler can tear down the empty node.