### PR TITLE
Add scheduling.userScheduler.annotations

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2365,6 +2365,12 @@ properties:
           pdb: *pdb-spec
           nodeSelector: *nodeSelector-spec
           tolerations: *tolerations-spec
+          annotations:
+            type: object
+            additionalProperties: false
+            patternProperties: *labels-and-annotations-patternProperties
+            description: |
+              Extra annotations to add to the user-scheduler pods.
           containerSecurityContext: *containerSecurityContext-spec
           logLevel:
             type: integer

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -16,6 +16,9 @@ spec:
         {{- include "jupyterhub.matchLabels" . | nindent 8 }}
       annotations:
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
+        {{- with .Values.scheduling.userScheduler.annotations }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       {{ with include "jupyterhub.user-scheduler-serviceaccount.fullname" . }}
       serviceAccountName: {{ . }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         checksum/config-map: {{ include (print $.Template.BasePath "/scheduling/user-scheduler/configmap.yaml") . | sha256sum }}
         {{- with .Values.scheduling.userScheduler.annotations }}
-          {{- . | toYaml | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
     spec:
       {{ with include "jupyterhub.user-scheduler-serviceaccount.fullname" . }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -506,6 +506,7 @@ scheduling:
       pullSecrets: []
     nodeSelector: {}
     tolerations: []
+    annotations: {}
     pdb:
       enabled: true
       maxUnavailable: 1


### PR DESCRIPTION
This is a generic pattern to allow user annotations on the resulting pods.

The specific use case I have is adding `sidecar.istio.io/inject: 'false'`. 

### Bug description
#2576 says it all and this implements the resolution in the [last comment](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2576#issuecomment-1035852061). I'm running with Istio.

### Your personal set up
- EKS 1.22
- Istio 1.13.3
- Zero-to-JupyterHub Chart 1.2.0
- Istio is enabled in the namespace where all the Jupyter stuff is.