### PR TITLE
2.0.0 upgrade guide

### DIFF
--- a/docs/source/administrator/index.md
+++ b/docs/source/administrator/index.md
@@ -15,6 +15,7 @@ services
 optimization
 security
 upgrading
+upgrade-1-to-2
 ../../jupyterhub/customization
 troubleshooting
 advanced

--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -283,6 +283,8 @@ singleuser:
     ip: 169.254.169.254
 ```
 
+(netpol)=
+
 ## Kubernetes Network Policies
 
 ```{warning}

--- a/docs/source/administrator/upgrade-1-to-2.md
+++ b/docs/source/administrator/upgrade-1-to-2.md
@@ -1,0 +1,142 @@
+# Major upgrade: 1.\* to 2.\*
+
+Z2JH 2 contains several breaking changes, including some that affect the security of your deployment.
+This guide will help you upgrade from 1.\* to 2.\*.
+
+## Security: breaking change to `*.networkPolicy.egress`
+
+NetworkPolicy egress rules have been extended with a new property.
+If you have configured any of:
+
+- `hub.networkPolicy.egress`
+- `proxy.chp.networkPolicy.egress`
+- `proxy.traefik.networkPolicy.egress`
+- `singleuser.networkPolicy.egress`
+
+you must review your configuration as additional default egress routes have been added.
+Previously `...networkPolicy.egress` controlled all egress but a new properties `...networkPolicy.egressAllowRules` add additional egress rules by default.
+
+If you have configured `...networkPolicy.egress` for `hub`, `proxy.chp`,
+`proxy.traefik` or `singleuser` to restrict the permissions to establish
+outbound network connections, then this upgrade is likely to _escalate those
+permissions unless you revise your configuration_. The new configuration
+`...networkPolicy.egressAllowRules` are by default granting most of the egress
+permissions previously granted by default via the `...networkPolicy.egress`
+configuration, and `...networkPolicy.egress` are now by default not providing
+any permissions.
+
+If you for example had overridden the previously very permissive default value
+of `singleuser.networkPolicy.egress` to be less permissive, you should consider
+disabling all `singleuser.networkPolicy.egressAllowRules` like this
+to not risk escalating the permissions.
+
+```yaml
+singleuser:
+  networkPolicy:
+    egressAllowRules:
+      cloudMetadataServer: false
+      dnsPortsPrivateIPs: false
+      nonPrivateIPs: false
+      privateIPs: false
+```
+
+For more details, see the documentation on [Kubernetes Network Policies](netpol)
+and the configuration reference entries under
+[`...networkPolicy.egress`](schema_hub.networkPolicy.egress) and
+[`...networkPolicy.egressAllowRules`](schema_hub.networkPolicy.egressAllowRules).
+
+## JupyterHub 2 and related hub components
+
+Z2JH 2.0.0 upgrades JupyterHub to the 2.\* series, and also upgrades all hub components.
+If you are using any custom JupyterHub services, addons, API integrations, or extra configuration, you should review the breaking changes in the
+[JupyterHub 2.0.0 changelog](https://github.com/jupyterhub/jupyterhub/blob/2.3.1/docs/source/changelog.md#200).
+
+JupyterHub 2 uses an updated database schema.
+Z2JH 2.0.0 automatically handles the upgrade, but it will not be possible to downgrade to older releases after this.
+
+JupyterHub 2 adds RBAC for managing permissions in JupyterHub.
+The old permissions model of admin/non-admin still works but you should use
+[RBAC to assign the required privileges to users or services in future](https://jupyterhub.readthedocs.io/en/stable/rbac/index.html)
+
+See
+`TODO: link to Notable dependencies updated`
+in the changelog for more information on other upgraded hub components.
+
+## JupyterLab and Jupyter Server
+
+The default singleuser server is [JupyterLab](https://jupyterlab.readthedocs.io/), running on [Jupyter server](https://jupyter-server.readthedocs.io/en/latest/).
+To switch back to Jupyter Notebook either configure/rebuild your singleuser image to default to notebook, or see [the documentation on user interfaces](user-interfaces)
+
+## Default to using the container image's command instead of `jupyterhub-singleuser` [#2449](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449)
+
+Z2JH now launches the container's default command (equivalent to setting `CMD` in a `Dockerfile`) instead of overriding it.
+This ensures that containers that use a custom start command to configure their environment, such as some
+[Jupyter Docker Stacks](https://jupyter-docker-stacks.readthedocs.io/en/latest/)
+images, will work without any changes.
+To restore the old behaviour set:
+
+```yaml
+singleuser:
+  cmd: jupyterhub-singleuser
+```
+
+## Configuration in `jupyterhub_config.d` has a higher priority than `hub.config` [#2457](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2457)
+
+Previously if `hub.config` was used to configure some JupyterHub traitlets it would override any custom configuration files mounted into `jupyterhub_config.d` in the hub container.
+In 2.0.0 all extra customisations (e.g. using `hub.extraConfig` to provide in-line configuration, or `hub.extraFiles` to mount files into `jupyterhub_config.d`) will always take precedence over any Helm chart values.
+
+
+## User scheduler plugin configuration has changed to match `kubescheduler.config.k8s.io/v1beta3` [#2590](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2590)
+
+Advanced customisation of the user scheduler using plugins now requires Kubernetes 1.21+, and the configuration must follow `kubescheduler.config.k8s.io/v1beta3`.
+Customisation is no longer possible with Kubernetes 1.20.
+
+If you are using the user scheduler without custom plugin configuration you are not affected.
+
+## Kubernetes version 1.20+ is required [#2635](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2635)
+
+This Helm chart uses Kubernetes resources that are not available in Kubernetes versions prior to 1.20.
+
+## `hub.fsGid` is replaced by `hub.podSecurityContext` [#2720](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2720)
+
+In previous versions of Z2JH `hub.fsGid` set a supplemental group ID, which is required on some K8s systems to ensure JupyterHub has permissions to read/write files on a volume.
+This has been replaced by the more general [`hub.podSecurityContext`](schema_hub.podSecurityContext).
+To upgrade set:
+
+```yaml
+hub:
+  podSecurityContext:
+    fsGroup: GROUP-ID
+```
+
+## Hub image is based on Debian instead of Ubuntu [#2733](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2733)
+
+The hub container base image has switched from `ubuntu:20.04` to `python:3.9-slim-bullseye` which is based on `debian:bullseye-slim`.
+If you have extended the Z2JH hub image please review the [hub Dockerfile](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/2.0.0/images/hub/Dockerfile).
+Note the singleuser image is not affected.
+
+## Disabling RBAC requires setting multiple properties,`rbac.enable` is removed [#2736](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2736) [#2739](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2739)
+
+If you previously disabled RBAC using `rbac.enable: False` you should set
+
+```yaml
+rbac:
+  create: False
+hub:
+  serviceAccount:
+    create: false
+proxy:
+  traefik:
+    serviceAccount:
+      create: false
+scheduling:
+  userScheduler:
+    serviceAccount:
+      create: false
+prePuller:
+  hook:
+    serviceAccount:
+      create: false
+```
+
+When you have updated your configuration follow the rest of the [upgrade guide](upgrading).

--- a/docs/source/administrator/upgrading.md
+++ b/docs/source/administrator/upgrading.md
@@ -1,5 +1,3 @@
-(upgrading)=
-
 # Upgrading your Helm chart
 
 This page covers best-practices in upgrading your JupyterHub deployment via updates

--- a/docs/source/administrator/upgrading.md
+++ b/docs/source/administrator/upgrading.md
@@ -16,9 +16,10 @@ or the [Discourse forum](https://discourse.jupyter.org/).
 ## Major helm-chart upgrades
 
 These steps are **critical** before performing a major upgrade.
+Z2JH follows semantic versioning, so major upgrades are indicated by an increase in the first component of the version.
 
 1. Always backup your database!
-2. Review the [CHANGELOG](changelog) for incompatible changes and upgrade instructions.
+2. Review the [CHANGELOG](changelog) and [2.0.0 upgrade guide](upgrade-1-to-2) for incompatible changes and upgrade instructions.
 3. Update your configuration accordingly.
 4. User servers may need be stopped prior to the upgrade,
    or restarted after it.
@@ -26,32 +27,10 @@ These steps are **critical** before performing a major upgrade.
    we recommend you test the upgrade out on a staging cluster first
    before applying it to production.
 
-### v0.5 to v0.6
-
-See the [CHANGELOG](changelog).
-
-### v0.4 to v0.5
-
-Release 0.5 contains a major JupyterHub version bump (from 0.7.2 to 0.8).
-Since it is a major upgrade of JupyterHub that changes how authentication is
-implemented, user servers must be stopped during the upgrade.
-The database schema has also changed, so a database upgrade must be performed.
-
-See the [CHANGELOG](changelog) for this release for more information about
-changes.
-
-## Subtopics
-
-This section covers upgrade information specific to the following:
-
-- `helm upgrade` command
-- Databases
-- RBAC (Role Based Access Control)
-- Custom Docker images
 
 (helm-upgrade-command)=
 
-### `helm upgrade` command
+## `helm upgrade` command
 
 After modifying your `config.yaml` file according to the CHANGELOG, you will need
 `<helm-release-name>` to run the upgrade commands. To find `<helm-release-name>`, run:
@@ -75,10 +54,10 @@ For example, to upgrade to version `1.1.1` with a helm release name of `jhub` in
 helm upgrade --cleanup-on-fail jhub jupyterhub/jupyterhub --version=1.1.1 --values config.yaml --namespace jhub
 ```
 
-### Database
+## Database
 
-This release contains a major JupyterHub version bump (from 0.7.2 to 0.8). If
-you are using the default database provider (SQLite), then the required db upgrades
+Major releases of Z2JH may include a major release of JupyterHub that requires an upgrade of the database schema.
+If you are using the default database provider (SQLite), then the required db upgrades
 will be performed automatically when you do a `helm upgrade`.
 
 **Default (SQLite)**: The database upgrade will be performed automatically when you
@@ -100,18 +79,24 @@ will be performed automatically when you do a `helm upgrade`.
 4. Do a [`helm upgrade`](helm-upgrade-command). This should perform the database upgrade needed.
 5. Remove the lines added in step 3, and do another [`helm upgrade`](helm-upgrade-command).
 
-### Custom Docker Images: JupyterHub version match
+## Custom Docker Images: JupyterHub version match
 
 If you are using a custom built image, make sure that the version of the
-JupyterHub package installed in it is now 0.8.1. It needs to be 0.8.1 for it to work with
-v0.6 of the helm chart.
+JupyterHub package installed in it matches the major version of JupyterHub, current 2.\*.
 
 For example, if you are using `pip` to install JupyterHub in your custom Docker Image,
 you would use:
 
 ```Dockerfile
-RUN pip install --no-cache-dir jupyterhub==0.8.1
+RUN pip install --no-cache-dir jupyterhub==2.3.1
 ```
+If you are using conda or mamba:
+```Dockerfile
+RUN conda install -y jupyterhub-base=2.3.1
+```
+
+Update the configuration to use this new image, which is typically done via
+`singleuser.image` or as part of `singleuser.profileList`.
 
 ## JupyterHub versions installed in each Helm Chart
 


### PR DESCRIPTION
The Z2JH changelog is already very long, and the upgrade details in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2528 make it even longer.

I think moving the details to a separate page and keeping the changelog concise is more useful- people who want technical details can go through the changelog, administrators can go straight to the upgrade page without wading through a large changelog.