### PR TITLE
Test postgres schema upgrade in CI

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -146,16 +146,18 @@ jobs:
               --set hub.config.CryptKeeper.keys[0]=cccc3333
             create-k8s-test-resources: true
 
-          # We run two upgrade tests where we first install an already released
-          # Helm chart version and then upgrades to the version we are now
-          # testing. We test upgrading from the latest stable version (like
-          # 1.2.3), and one from the latest dev version (like
-          # 1.2.3-n012.h1234abc).
+          # We run three upgrade tests where we first install an already released
+          # Helm chart version and then upgrade to the version we are now
+          # testing:
+          # - latest stable version (like 1.2.3)
+          # - latest dev version (like 1.2.3-n012.h1234abc),
+          # - and an old version that requires a JupyterHub DB upgrade
           #
           # It can be very useful to see the "Helm diff" step's output from the
           # latest dev version.
           #
-          # The upgrade-from input should match the version information from
+          # The upgrade-from input should be a chart version, or match the version
+          # information from
           # https://jupyterhub.github.io/helm-chart/info.json
           #
           - k3s-channel: v1.23
@@ -181,6 +183,34 @@ jobs:
             local-chart-extra-args: >-
               --set hub.db.type=sqlite-pvc
               --set singleuser.storage.type=dynamic
+          - k3s-channel: v1.24
+            test: upgrade
+            # We're testing hub.db.upgrade with PostgreSQL so this version must be old
+            # enough to require a DB upgrade
+            upgrade-from: 1.2.0
+            upgrade-from-extra-args: >-
+              --set proxy.secretToken=aaaa1111
+              --set hub.cookieSecret=bbbb2222
+              --set hub.config.CryptKeeper.keys[0]=cccc3333
+              --set hub.db.type=postgres
+              --set hub.db.url=postgresql+psycopg2://postgres:postgres@postgresql:5432/jupyterhub
+              --set singleuser.storage.type=dynamic
+            local-chart-extra-args: >-
+              --set hub.db.type=postgres
+              --set hub.db.url=postgresql+psycopg2://postgres:postgres@postgresql:5432/jupyterhub
+              --set singleuser.storage.type=dynamic
+              --set hub.db.upgrade=true
+            create-k8s-test-resources: true
+            # https://artifacthub.io/packages/helm/bitnami/postgresql
+            setup-postgresql-args: >-
+              --version=11.6.13
+              --set auth.enablePostgresUser=true
+              --set auth.postgresPassword=postgres
+              --set auth.database=jupyterhub
+              --set audit.logHostname=true
+              --set audit.logConnections=true
+              --set audit.logDisconnections=true
+              --set audit.clientMinMessages=debug
 
     steps:
       - uses: actions/checkout@v3
@@ -237,11 +267,23 @@ jobs:
           timeout: 150
           max-restarts: 1
 
+      - name: "(Upgrade) Install PostgreSQL server chart"
+        if: matrix.setup-postgresql-args
+        run: |
+          . ./ci/common
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm install postgresql bitnami/postgresql ${{ matrix.setup-postgresql-args }}
+          await_kubectl_rollout statefulset/postgresql
+
       - name: "(Upgrade) Install ${{ matrix.upgrade-from }} chart"
         if: matrix.test == 'upgrade'
         run: |
           . ./ci/common
-          UPGRADE_FROM_VERSION=$(curl -sS https://jupyterhub.github.io/helm-chart/info.json | jq -er '.jupyterhub.${{ matrix.upgrade-from }}')
+          if [ ${{ matrix.upgrade-from }} = stable -o ${{ matrix.upgrade-from }} = dev ]; then
+            UPGRADE_FROM_VERSION=$(curl -sS https://jupyterhub.github.io/helm-chart/info.json | jq -er '.jupyterhub.${{ matrix.upgrade-from }}')
+          else
+            UPGRADE_FROM_VERSION=${{ matrix.upgrade-from }}
+          fi
           echo "UPGRADE_FROM_VERSION=$UPGRADE_FROM_VERSION" >> $GITHUB_ENV
 
           echo ""
@@ -333,3 +375,8 @@ jobs:
         if: always()
         with:
           important-workloads: deploy/hub deploy/proxy
+
+      - name: Debug PostgreSQL logs on failure
+        if: failure() && matrix.setup-postgresql-args
+        run: |
+          kubectl logs statefulset/postgresql

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -271,8 +271,7 @@ jobs:
         if: matrix.setup-postgresql-args
         run: |
           . ./ci/common
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm install postgresql bitnami/postgresql ${{ matrix.setup-postgresql-args }}
+          helm install postgresql postgresql --repo=https://charts.bitnami.com/bitnami ${{ matrix.setup-postgresql-args }}
           await_kubectl_rollout statefulset/postgresql
 
       - name: "(Upgrade) Install ${{ matrix.upgrade-from }} chart"

--- a/ci/common
+++ b/ci/common
@@ -13,22 +13,26 @@ setup_helm () {
     curl -sf https://raw.githubusercontent.com/helm/helm/HEAD/scripts/get-helm-3 | DESIRED_VERSION=${HELM_VERSION} bash
 }
 
+await_kubectl_rollout() {
+    kubectl rollout status --watch --timeout 300s "$1"
+}
+
 await_pebble() {
-    kubectl rollout status --watch --timeout 300s deployment/pebble \
-        && kubectl rollout status --watch --timeout 300s deployment/pebble-coredns
+    await_kubectl_rollout deployment/pebble \
+        && await_kubectl_rollout deployment/pebble-coredns
 }
 
 await_jupyterhub() {
-    kubectl rollout status --watch --timeout 300s deployment/proxy \
-        && kubectl rollout status --watch --timeout 300s deployment/hub \
+    await_kubectl_rollout deployment/proxy \
+        && await_kubectl_rollout deployment/hub \
         && (
         if kubectl get deploy/autohttps &> /dev/null; then
-            kubectl rollout status --watch --timeout 300s deployment/autohttps
+            await_kubectl_rollout deployment/autohttps
         fi
     ) \
         && (
         if kubectl get deploy/user-scheduler &> /dev/null; then
-            kubectl rollout status --watch --timeout 300s deployment/user-scheduler
+            await_kubectl_rollout deployment/user-scheduler
         fi
     )
 }

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -51,10 +51,13 @@ hub:
     test-generation-of-apiToken: {}
   networkPolicy:
     egress: # overrides allowance of 0.0.0.0/0
-      # In kind/k3s clusters the Kubernetes API server is exposing this port
       - ports:
+          # In kind/k3s clusters the Kubernetes API server is exposing this port
           - protocol: TCP
             port: 6443
+          # For testing postgres
+          - protocol: TCP
+            port: 5432
   resources:
     requests:
       memory: 0

--- a/docs/source/administrator/upgrading/index.md
+++ b/docs/source/administrator/upgrading/index.md
@@ -66,6 +66,9 @@ helm upgrade --cleanup-on-fail jhub jupyterhub/jupyterhub --version=1.1.1 --valu
 Major releases of Z2JH may include a major release of JupyterHub that requires an upgrade of the database schema.
 If you are using the default database provider (SQLite), then the required db upgrades
 will be performed automatically when you do a `helm upgrade`.
+A backup of the old database is automatically created on the hub volume.
+
+It is not possible to automatically backup other database providers, so the upgrade is not done automatically.
 
 **Default (SQLite)**: The database upgrade will be performed automatically when you
 [perform the upgrade](helm-upgrade-command)
@@ -84,7 +87,7 @@ will be performed automatically when you do a `helm upgrade`.
    ```
 
 4. Do a [`helm upgrade`](helm-upgrade-command). This should perform the database upgrade needed.
-5. Remove the lines added in step 3, and do another [`helm upgrade`](helm-upgrade-command).
+5. Remove the lines added in step 3, and do another [`helm upgrade`](helm-upgrade-command) so that future JupyterHub upgrades don't inadvertently upgrade the schema.
 
 ## Custom Docker Images: JupyterHub version match
 


### PR DESCRIPTION
Adds a test of `hub.db.upgrade` for PostgreSQL. This requires pinning an old chart that requires a schema upgrade, in general stable will be too close to dev for there to be an upgrade.

Adds docs on why the upgrade isn't automatic for other DB provides.
Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2783