### PR TITLE
Fix `redirected permanently` linkcheck apart from changelog

### DIFF
--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -192,11 +192,11 @@ hub:
 ```
 
 ```{admonition} About the choice of scope
-The narrower scope `read:user` is sufficient for a configuration of `allowed_organizations` to function if you both list only entire organizations rather than specific teams, and if the users [make their organization membership public](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership).
+The narrower scope `read:user` is sufficient for a configuration of `allowed_organizations` to function if you both list only entire organizations rather than specific teams, and if the users [make their organization membership public](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership).
 
-The broader scope `read:org` doesn't have the limitations of `read:user`, but will require a one-off approval by the admins of the GitHub organizations' listed in `allowed_organizations`. This kind of approval can be requested by organization users [as documented on GitHub](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/managing-your-membership-in-organizations/requesting-organization-approval-for-oauth-apps).
+The broader scope `read:org` doesn't have the limitations of `read:user`, but will require a one-off approval by the admins of the GitHub organizations' listed in `allowed_organizations`. This kind of approval can be requested by organization users [as documented on GitHub](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/requesting-organization-approval-for-oauth-apps).
 
-For details about GitHub scopes, see [GitHub's documentation](https://docs.github.com/en/developers/apps/scopes-for-oauth-apps).
+For details about GitHub scopes, see [GitHub's documentation](https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps).
 ```
 
 #### Google

--- a/docs/source/administrator/optimization.md
+++ b/docs/source/administrator/optimization.md
@@ -189,7 +189,7 @@ waiting time for the pod, and as a pod can represent a user, it can lead to a
 long waiting time for a user. There are now options to address this.
 
 With Kubernetes 1.11+ (that requires Helm 2.11+), [Pod Priority and
-Preemption](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
+Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
 was introduced. This allows pods with higher priority to preempt / evict pods
 with lower priority if that would help the higher priority pod fit on a node.
 

--- a/docs/source/kubernetes/ibm/step-zero-ibm.md
+++ b/docs/source/kubernetes/ibm/step-zero-ibm.md
@@ -48,7 +48,7 @@ Procedure:
    Or, if you prefer, create the cluster using the [IBM Cloud CLI tools](https://cloud.ibm.com/docs/containers?topic=containers-cs_cli_install))
 
 2. Configure kubectl
-   [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) is a CLI tool to interact with a Kubernetes cluster. In this occasion, you will use it to point forward to the created Kubernetes cluster.
+   [kubectl](https://kubernetes.io/docs/reference/kubectl/) is a CLI tool to interact with a Kubernetes cluster. In this occasion, you will use it to point forward to the created Kubernetes cluster.
 
    1. Use `ibmcloud login` to log in interactively into the IBM Cloud. Provide the organization (org), location and space under which the cluster is created. You can reconfirm the details by running `ibmcloud target` command.
    2. When the cluster is ready, retrieve the cluster configuration by using the cluster's name:

--- a/docs/source/kubernetes/microsoft/step-zero-azure.md
+++ b/docs/source/kubernetes/microsoft/step-zero-azure.md
@@ -5,7 +5,7 @@
 You can create a Kubernetes cluster [either through the Azure portal website, or using the Azure command line tools](https://docs.microsoft.com/en-us/azure/aks/).
 
 This page describes the commands required to setup a Kubernetes cluster using the command line.
-If you prefer to use the Azure portal see the [Azure Kubernetes Service quickstart](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-portal).
+If you prefer to use the Azure portal see the [Azure Kubernetes Service quickstart](https://docs.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-portal).
 
 1. Prepare your Azure shell environment. You have two options, one is to use
    the Azure interactive shell, the other is to install the Azure command-line
@@ -122,7 +122,7 @@ If you prefer to use the Azure portal see the [Azure Kubernetes Service quicksta
 
    To enable this in Azure, we must first create a [Virtual Network](https://docs.microsoft.com/en-gb/azure/virtual-network/virtual-networks-overview) with Azure's own network policies enabled.
 
-   This section of the documentation is following the Microsoft Azure tutorial on [creating an AKS cluster and enabling network policy](https://docs.microsoft.com/en-us/azure/aks/use-network-policies#create-an-aks-cluster-and-enable-network-policy), which includes information on using [Calico](https://docs.projectcalico.org) network policies.
+   This section of the documentation is following the Microsoft Azure tutorial on [creating an AKS cluster and enabling network policy](https://docs.microsoft.com/en-us/azure/aks/use-network-policies#create-an-aks-cluster-and-enable-network-policy), which includes information on using [Calico](https://projectcalico.docs.tigera.io/) network policies.
 
    ```
    az network vnet create \

--- a/docs/source/kubernetes/ovh/step-zero-ovh.md
+++ b/docs/source/kubernetes/ovh/step-zero-ovh.md
@@ -2,7 +2,7 @@
 
 # Kubernetes on [OVHcloud](https://www.ovh.ie/) (OVH)
 
-[OVHcloud](https://www.ovh.ie/) is a leader in the hosted private cloud services space in Europe.
+[OVHcloud](https://www.ovh.com/) is a leader in the hosted private cloud services space in Europe.
 
 They offer a managed Kubernetes service as well as a managed private registry for Docker images.
 


### PR DESCRIPTION
If redirects are permanent it makes sense to update them, so that if the redirect is later removed we won't end up with a broken link.

It _may_ make sense for some temporary redirects though those can be tricky since they might be related to locale/platform detection... but those can be dealt with separately.