### PR TITLE
ci: workaround intermittent test failures pending upstream fix in k3s 

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -190,7 +190,7 @@ jobs:
             local-chart-extra-args: >-
               --set hub.db.type=sqlite-pvc
               --set singleuser.storage.type=dynamic
-          - k3s-channel: v1.24
+          - k3s-channel: v1.22
             k3s-extra-setup-args: --egress-selector-mode=disabled
             test: upgrade
             # We're testing hub.db.upgrade with PostgreSQL so this version must be old

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -127,10 +127,15 @@ jobs:
         #
         # k3s-version: https://github.com/rancher/k3s/tags
         # k3s-channel: https://update.k3s.io/v1-release/channels
+        #
+        # NOTE: we workaround a bug for k3s 1.22+ by passing `extra-setup-args: --egress-selector-mode=disabled`
+        #
         include:
           - k3s-channel: latest
+            k3s-extra-setup-args: --egress-selector-mode=disabled
             test: install
           - k3s-channel: stable
+            k3s-extra-setup-args: --egress-selector-mode=disabled
             test: install
           - k3s-channel: v1.21 # also test prePuller.hook
             test: install
@@ -161,6 +166,7 @@ jobs:
           # https://jupyterhub.github.io/helm-chart/info.json
           #
           - k3s-channel: v1.23
+            k3s-extra-setup-args: --egress-selector-mode=disabled
             test: upgrade
             upgrade-from: stable
             upgrade-from-extra-args: >-
@@ -174,6 +180,7 @@ jobs:
               --set singleuser.storage.type=dynamic
             create-k8s-test-resources: true
           - k3s-channel: v1.23
+            k3s-extra-setup-args: --egress-selector-mode=disabled
             test: upgrade
             upgrade-from: dev
             upgrade-from-extra-args: >-
@@ -184,6 +191,7 @@ jobs:
               --set hub.db.type=sqlite-pvc
               --set singleuser.storage.type=dynamic
           - k3s-channel: v1.24
+            k3s-extra-setup-args: --egress-selector-mode=disabled
             test: upgrade
             # We're testing hub.db.upgrade with PostgreSQL so this version must be old
             # enough to require a DB upgrade
@@ -229,6 +237,7 @@ jobs:
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: true
+          extra-setup-args: "${{ matrix.k3s-extra-setup-args }}"
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Closes #2799 via a workaround patch. https://github.com/jupyterhub/action-k3s-helm/issues/59 is opened still to track possible further actions, but I'd like to avoid adding a workaround in that repo unless its clear this isn't going to resolve in k3s or some further time passes without resolution.