### PR TITLE
Add revisionHistoryLimit to all deployments

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1445,7 +1445,6 @@ properties:
     type: object
     additionalProperties: false
     properties:
-      revisionHistoryLimit: *revisionHistoryLimit
       chp:
         type: object
         additionalProperties: false
@@ -1453,6 +1452,7 @@ properties:
           Configure the configurable-http-proxy (chp) pod managed by jupyterhub to route traffic
           both to itself and to user pods.
         properties:
+          revisionHistoryLimit: *revisionHistoryLimit
           networkPolicy: *networkPolicy-spec
           extraCommandLineFlags:
             type: array
@@ -1754,6 +1754,7 @@ properties:
         description: |
           Configure the traefik proxy used to terminate TLS when 'autohttps' is enabled
         properties:
+          revisionHistoryLimit: *revisionHistoryLimit
           labels:
             type: object
             additionalProperties: false
@@ -2521,6 +2522,7 @@ properties:
           enabled:
             type: boolean
           image: *image-spec
+          revisionHistoryLimit: *revisionHistoryLimit
           replicas:
             type: integer
             description: |
@@ -2685,6 +2687,7 @@ properties:
     additionalProperties: false
     required: [hook, continuous]
     properties:
+      revisionHistoryLimit: *revisionHistoryLimit
       labels:
         type: object
         additionalProperties: false

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -190,6 +190,14 @@ properties:
     additionalProperties: false
     required: [baseUrl]
     properties:
+      revisionHistoryLimit: &revisionHistoryLimit
+        type: [integer, "null"]
+        minimum: 0
+        description: |
+          Configures the Deployment's `spec.revisionHistoryLimit`.
+
+          See the [Kubernetes docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit)
+          for more info.
       config:
         type: object
         additionalProperties: true
@@ -1437,6 +1445,7 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      revisionHistoryLimit: *revisionHistoryLimit
       chp:
         type: object
         additionalProperties: false
@@ -2347,6 +2356,7 @@ properties:
             type: boolean
             description: |
               Enables the user scheduler.
+          revisionHistoryLimit: *revisionHistoryLimit
           replicas:
             type: integer
             description: |

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -194,7 +194,8 @@ properties:
         type: [integer, "null"]
         minimum: 0
         description: |
-          Configures the Deployment's `spec.revisionHistoryLimit`.
+          Configures the resource's `spec.revisionHistoryLimit`. This is
+          available for Deployment, StatefulSet, and DaemonSet resources.
 
           See the [Kubernetes docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit)
           for more info.

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if not (eq nil .Values.hub.revisionHistoryLimit) }}
+  {{- if typeIs "int" .Values.hub.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.hub.revisionHistoryLimit }}
   {{- end }}
   replicas: 1

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
+  {{- if not (eq nil .Values.hub.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.hub.revisionHistoryLimit }}
+  {{- end }}
   replicas: 1
   selector:
     matchLabels:

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -34,7 +34,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 100%
-  {{- if not (eq nil .Values.prePuller.revisionHistoryLimit) }}
+  {{- if typeIs "int" .Values.prePuller.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.prePuller.revisionHistoryLimit }}
   {{- end }}
   template:

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -34,6 +34,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 100%
+  {{- if not (eq nil .Values.prePuller.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.prePuller.revisionHistoryLimit }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if not (eq nil .Values.proxy.traefik.revisionHistoryLimit) }}
+  {{- if typeIs "int" .Values.proxy.traefik.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.proxy.traefik.revisionHistoryLimit }}
   {{- end }}
   replicas: 1

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -8,8 +8,8 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if not (eq nil .Values.proxy.revisionHistoryLimit) }}
-  revisionHistoryLimit: {{ .Values.proxy.revisionHistoryLimit }}
+  {{- if not (eq nil .Values.proxy.traefik.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.proxy.traefik.revisionHistoryLimit }}
   {{- end }}
   replicas: 1
   selector:

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
+  {{- if not (eq nil .Values.proxy.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.proxy.revisionHistoryLimit }}
+  {{- end }}
   replicas: 1
   selector:
     matchLabels:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
+  {{- if not (eq nil .Values.proxy.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.proxy.revisionHistoryLimit }}
+  {{- end }}
   replicas: 1
   selector:
     matchLabels:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if not (eq nil .Values.proxy.revisionHistoryLimit) }}
-  revisionHistoryLimit: {{ .Values.proxy.revisionHistoryLimit }}
+  {{- if not (eq nil .Values.proxy.chp.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.proxy.chp.revisionHistoryLimit }}
   {{- end }}
   replicas: 1
   selector:

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if not (eq nil .Values.proxy.chp.revisionHistoryLimit) }}
+  {{- if typeIs "int" .Values.proxy.chp.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.proxy.chp.revisionHistoryLimit }}
   {{- end }}
   replicas: 1

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
   podManagementPolicy: Parallel
-  {{- if not (eq nil .Values.scheduling.userPlaceholder.revisionHistoryLimit) }}
+  {{- if typeIs "int" .Values.scheduling.userPlaceholder.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.scheduling.userPlaceholder.revisionHistoryLimit }}
   {{- end }}
   replicas: {{ .Values.scheduling.userPlaceholder.replicas }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -16,6 +16,9 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
   podManagementPolicy: Parallel
+  {{- if not (eq nil .Values.scheduling.userPlaceholder.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.scheduling.userPlaceholder.revisionHistoryLimit }}
+  {{- end }}
   replicas: {{ .Values.scheduling.userPlaceholder.replicas }}
   selector:
     matchLabels:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
+  {{- if not (eq nil .Values.scheduling.userScheduler.revisionHistoryLimit) }}
+  revisionHistoryLimit: {{ .Values.scheduling.userScheduler.revisionHistoryLimit }}
+  {{- end }}
   replicas: {{ .Values.scheduling.userScheduler.replicas }}
   selector:
     matchLabels:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if not (eq nil .Values.scheduling.userScheduler.revisionHistoryLimit) }}
+  {{- if typeIs "int" .Values.scheduling.userScheduler.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.scheduling.userScheduler.revisionHistoryLimit }}
   {{- end }}
   replicas: {{ .Values.scheduling.userScheduler.replicas }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -145,7 +145,6 @@ rbac:
 # proxy relates to the proxy pod, the proxy-public service, and the autohttps
 # pod and proxy-http service.
 proxy:
-  revisionHistoryLimit:
   secretToken:
   annotations: {}
   deploymentStrategy:
@@ -189,6 +188,7 @@ proxy:
   # chp relates to the proxy pod, which is responsible for routing traffic based
   # on dynamic configuration sent from JupyterHub to CHP's REST API.
   chp:
+    revisionHistoryLimit:
     containerSecurityContext:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
@@ -239,6 +239,7 @@ proxy:
   # traefik relates to the autohttps pod, which is responsible for TLS
   # termination when proxy.https.type=letsencrypt.
   traefik:
+    revisionHistoryLimit:
     containerSecurityContext:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
@@ -539,6 +540,7 @@ scheduling:
       tag: "3.7"
       pullPolicy:
       pullSecrets: []
+    revisionHistoryLimit:
     replicas: 0
     labels: {}
     annotations: {}
@@ -574,6 +576,7 @@ scheduling:
 
 # prePuller relates to the hook|continuous-image-puller DaemonsSets
 prePuller:
+  revisionHistoryLimit:
   labels: {}
   annotations: {}
   resources: {}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -26,6 +26,7 @@ imagePullSecrets: []
 # ConfigurableHTTPProxy speaks with the actual ConfigurableHTTPProxy server in
 # the proxy pod.
 hub:
+  revisionHistoryLimit:
   config:
     JupyterHub:
       admin_access: true
@@ -144,6 +145,7 @@ rbac:
 # proxy relates to the proxy pod, the proxy-public service, and the autohttps
 # pod and proxy-http service.
 proxy:
+  revisionHistoryLimit:
   secretToken:
   annotations: {}
   deploymentStrategy:
@@ -403,6 +405,7 @@ singleuser:
 scheduling:
   userScheduler:
     enabled: true
+    revisionHistoryLimit:
     replicas: 2
     logLevel: 4
     # plugins are configured on the user-scheduler to make us score how we

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -8,6 +8,7 @@ imagePullSecret:
 imagePullSecrets: [a, b]
 
 hub:
+  revisionHistoryLimit: 1
   config:
     # We pin these to avoid generating changes which cause diffs
     ConfigurableHTTPProxy:
@@ -221,6 +222,7 @@ proxy:
       http:
       https:
   chp:
+    revisionHistoryLimit: 1
     extraCommandLineFlags:
       - "--auto-rewrite"
       - "--mock-flag {{ .Values.proxy.chp.resources.requests.memory }}"
@@ -261,6 +263,7 @@ proxy:
       minAvailable: 1
     extraPodSpec: *extraPodSpec
   traefik:
+    revisionHistoryLimit: 1
     labels: *labels
     resources: *resources
     extraEnv: *extraEnv
@@ -460,6 +463,7 @@ singleuser:
 scheduling:
   userScheduler:
     enabled: true
+    revisionHistoryLimit: 1
     replicas: 1
     logLevel: 10
     image: *image
@@ -492,6 +496,7 @@ scheduling:
     enabled: true
   userPlaceholder:
     enabled: true
+    revisionHistoryLimit: 1
     replicas: 1
     resources: *resources
   corePods:
@@ -512,6 +517,7 @@ scheduling:
       matchNodePurpose: require
 
 prePuller:
+  revisionHistoryLimit: 1
   extraTolerations:
     - key: mock-taint-key-prePuller
       operator: Equal


### PR DESCRIPTION
## Description

Users need to be able to control how many old ReplicaSets are retained. Some users prefer to keep minimum number or even zero to clean up clutter (ArgoCD for example) or if they use `helm rollback` instead of kubectl rollout undo to roll back.

## Changes

Added revision history limit property to all deployments and added default of 10 to values file.