### PR TITLE
Set singleuser.args to jupyterhub-singleuser

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -395,6 +395,8 @@ singleuser:
     limits: {}
     guarantees: {}
   cmd:
+  args:
+    - jupyterhub-singleuser
   defaultUrl:
   extraPodConfig: {}
   profileList: []


### PR DESCRIPTION
After writing
https://github.com/pangeo-data/pangeo-docker-images/pull/355/files#diff-a77643b43a7be453fa8556937bf32b27907e152a10d4c693f3e7670c66a44378,
I would like to ask that we reconsider *requiring* entrypoint be set to
a specific thing (`jupyterhub-singleuser`) in the images users are
required to produce. This makes it quite difficult to produce images
that *work across multiple tools* without having to configure each of
those tools. In this case, we want to use the *exact same image* in both
binder and apache beam. Apache beam *requires* an entrypoint be
specified, while at least as of now binder does not - so I wrote a
script that uses heuristics to determine if the caller is apache beam or
something else, and change behavior accordingly. But if I want this
image to also work with JupyterHub in the future, I'll have to modify my
script to detect if JupyterHub is calling it, and exec
`jupyterhub-singleuser`. Now if dask also wants to use this image, I'd
need to have a code path for that as well. I think this strong coupling
causes a lot of unnecessary friction here.

Another point of confusion here is that `cmd` in helm / k8s is actually
*ENTRYPOINT* in docker, while `args` in helm / k8s is *CMD* in docker.
Earlier, we were setting `cmd` to `jupyterhub-singleuser`, which
overrode any entrypoint the docker builder had set up - causing the
issues we were trying to fix. However, now that KubeSpawner doesn't
actually use `args` (k8s / helm) in any meaningful fashion, can we set
the default `args` to `jupyterhub-singleuser`? This has a few
advantages:

1. *ENTRYPOINT* set in Dockerfile is *not* overriden by what we set in
   helm, which is the current problem. This goes away
2. All existing docker images continue to work without admins having to
   set extra config or the image having to be rebuilt.
3. The same image can be used in multiple places without having to be
   aware of who is calling it.

I think this is an approach to solving the original problem that is both
*easier to document*, *easier for our users (existing and new)* and
makes life a lot less difficult for people building images.

Re-implementation of https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2449