### PR TITLE
Fix user-scheduler backward compatibility for AWS EKS

### DIFF
--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -28,7 +28,7 @@ data:
        and configuration (v1beta1) of kube-scheduler.
   */}}
   config.yaml: |
-    {{- if ge (atoi .Capabilities.KubeVersion.Minor) 21 }}
+    {{- if ge (atoi ( .Capabilities.KubeVersion.Minor | replace "+" "" )) 21 }}
     apiVersion: kubescheduler.config.k8s.io/v1beta3
     kind: KubeSchedulerConfiguration
     leaderElection:

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -28,7 +28,14 @@ data:
        and configuration (v1beta1) of kube-scheduler.
   */}}
   config.yaml: |
-    {{- if ge (atoi ( .Capabilities.KubeVersion.Minor | replace "+" "" )) 21 }}
+    {{- /*
+      FIXME: We have added a workaround for EKS where
+            .Capabilities.KubeVersion.Minor can return a
+            string like "22+" instead of just "22".
+
+            See https://github.com/aws/eks-distro/issues/1128.
+    */}}
+    {{- if ge (atoi (.Capabilities.KubeVersion.Minor | replace "+" "")) 21 }}
     apiVersion: kubescheduler.config.k8s.io/v1beta3
     kind: KubeSchedulerConfiguration
     leaderElection:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
         - name: kube-scheduler
-          {{- if ge (atoi .Capabilities.KubeVersion.Minor) 21 }}
+          {{- if ge (atoi ( .Capabilities.KubeVersion.Minor | replace "+" "" )) 21 }}
           image: {{ .Values.scheduling.userScheduler.image.name }}:{{ .Values.scheduling.userScheduler.image.tag }}
           {{- else }}
           # WARNING: The tag of this image is hardcoded, and the

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -47,7 +47,14 @@ spec:
       {{- end }}
       containers:
         - name: kube-scheduler
-          {{- if ge (atoi ( .Capabilities.KubeVersion.Minor | replace "+" "" )) 21 }}
+          {{- /*
+            FIXME: We have added a workaround for EKS where
+                  .Capabilities.KubeVersion.Minor can return a
+                  string like "22+" instead of just "22".
+
+                  See https://github.com/aws/eks-distro/issues/1128.
+          */}}
+          {{- if ge (atoi (.Capabilities.KubeVersion.Minor | replace "+" "")) 21 }}
           image: {{ .Values.scheduling.userScheduler.image.name }}:{{ .Values.scheduling.userScheduler.image.tag }}
           {{- else }}
           # WARNING: The tag of this image is hardcoded, and the


### PR DESCRIPTION
# Introduction

user-scheduler support both kubernetes before 1.20 and after 1.21. It is done by helm conditionals `if ge (atoi .Capabilities.KubeVersion.Minor) 21`

# Problem

`.Capabilities.KubeVersion.Minor` is not a simple number in AWS EKS environment. It is something like `22+`. So backward compatibility fallback is applied to every kubernetes clusters even if its version is greater than 1.20.

# Solution

I suggest simple solution just to replace every `+` signs into empty string `''`. Helm `replace` function can do this.

# Alternative

[`semverCompare`](https://helm.sh/docs/chart_template_guide/function_list/#semvercompare) can achieve better result, but I am worried about its unexpected behaviors. It changes things a lot.

# Appendix
Refer this image for various Helm expression results.
![image](https://user-images.githubusercontent.com/4434752/180410032-4f60e77e-fcc8-437e-81e9-a8bf7eb3b24d.png)
