### PR TITLE
Allow additional properties for scheduling.userScheduler.plugins

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2379,7 +2379,7 @@ properties:
               kube-scheduler binary running within the user-scheduler pod.
           plugins:
             type: object
-            additionalProperties: false
+            additionalProperties: true
             description: |
               These plugins refers to kube-scheduler plugins as documented
               [here](https://kubernetes.io/docs/reference/scheduling/config/).
@@ -2387,29 +2387,6 @@ properties:
               The user-scheduler is really just a kube-scheduler configured in a
               way to pack users tight on nodes using these plugins. See
               values.yaml for information about the default plugins.
-            properties:
-              score:
-                type: object
-                additionalProperties: false
-                properties:
-                  disabled:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: false
-                      properties:
-                        name:
-                          type: string
-                  enabled:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: false
-                      properties:
-                        name:
-                          type: string
-                        weight:
-                          type: integer
           pluginConfig:
             type: array
             description: |


### PR DESCRIPTION
# Issue Reference
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2808

# Purpose
`scheduling.userScheduler.plugins` configures kube-scheduler for better scheduling of singluser pods. kube-scheduler support various extension points like queueSort, preFilter, filter, postFilter, preScore, score, reserve, permit, preBind, bind, multiPoint. However current implementation uses and allows only _score_.

Therefore, I suggest to allow other extension points.

# Changes
Allow additional properties for `scheduling.userScheduler.plugins`