### PR TITLE
ci: remove dependabot bumping for hub image's req file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,17 +9,6 @@
 #
 version: 2
 updates:
-  # Maintain Python dependencies for the jupyterhub/k8s-hub image
-  - package-ecosystem: pip
-    directory: "/images/hub"
-    schedule:
-      interval: daily
-      time: "05:00"
-      timezone: "Etc/UTC"
-    versioning-strategy: lockfile-only
-    labels:
-      - dependencies
-
   # Maintain Python dependencies for the jupyterhub/k8s-singleuser-sample image
   - package-ecosystem: pip
     directory: "/images/singleuser-sample"


### PR DESCRIPTION
I've not seen dependabot refreeze and keep a requirements.txt that is associated with a requirements.in updated.

So, there is instead now a [refreeze requirements.txt job in the watch-dependacies workflow](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/f133567f9f739c8e7c3b3e7ee0476a1ecb1b1134/.github/workflows/watch-dependencies.yaml#L186-L233) that can be used. So, I suggest removing this dependabot bumping that doesn't seem to keep the frozen requirements.txt packages updated.