### PR TITLE
ci: fix jupyterhub version bumping automation

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -141,6 +141,9 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Install Python dependencies
+        run: pip install requests
+
       - name: Get images/hub/requirements.in pinned version of jupyterhub
         id: local
         run: |
@@ -149,12 +152,16 @@ jobs:
 
       - name: Get latest version of jupyterhub
         id: latest
+        shell: python
         run: |
-          latest_version=$(
-              curl -s https://pypi.org/pypi/jupyterhub/json \
-            | jq -r .info.version
-          )
-          echo "::set-output name=version::$latest_version"
+          import requests
+
+          request = requests.get("https://pypi.org/pypi/jupyterhub/json")
+          data = request.json()
+          releases = data["releases"]
+          latest_version = list(releases.keys())[-1]
+
+          print(f"::set-output name=version::{latest_version}")
 
       - name: Update pinned version of jupyterhub
         if: steps.local.outputs.version != steps.latest.outputs.version

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -170,6 +170,22 @@ jobs:
           sed --in-place 's/jupyterhub==${{ steps.local.outputs.version }}/jupyterhub==${{ steps.latest.outputs.version }}/g' images/singleuser-sample/requirements.txt
           sed --in-place 's/appVersion: "${{ steps.local.outputs.version }}"/appVersion: "${{ steps.latest.outputs.version }}"/g' jupyterhub/Chart.yaml
 
+      - name: Refreeze images/hub/requirements.txt based on images/hub/requirements.in
+        if: steps.local.outputs.version != steps.latest.outputs.version
+        # IMPORTANT: This run segment is duplicated in this workflow file across
+        #            two separate jobs, any update here should be made in the
+        #            other job as well.
+        #
+        run: |
+          cd images/hub
+          docker run --rm \
+              --env=CUSTOM_COMPILE_COMMAND='Use the "Run workflow" button at https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions/workflows/watch-dependencies.yaml' \
+              --volume=$PWD:/io \
+              --workdir=/io \
+              --user=root \
+              python:3.9-bullseye \
+              sh -c 'pip install pip-tools==6.* && pip-compile --upgrade'
+
       - name: git diff
         if: steps.local.outputs.version != steps.latest.outputs.version
         run: git --no-pager diff --color=always
@@ -210,6 +226,10 @@ jobs:
         # Note that as of 2022-05-29, `pip-compile` has issues with `pycurl`,
         # but we workaround them by by omitting the `-slim` part from the image
         # in the command below.
+        #
+        # IMPORTANT: This run segment is duplicated in this workflow file across
+        #            two separate jobs, any update here should be made in the
+        #            other job as well.
         #
         run: |
           cd images/hub

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -142,7 +142,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install Python dependencies
-        run: pip install requests
+        run: pip install packaging requests
 
       - name: Get images/hub/requirements.in pinned version of jupyterhub
         id: local
@@ -154,12 +154,13 @@ jobs:
         id: latest
         shell: python
         run: |
+          import packaging.version
           import requests
 
           request = requests.get("https://pypi.org/pypi/jupyterhub/json")
           data = request.json()
           releases = data["releases"]
-          latest_version = list(releases.keys())[-1]
+          latest_version = sorted(releases.keys(), key=packaging.version.Version)[-1]
 
           print(f"::set-output name=version::{latest_version}")
 

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -5,7 +5,8 @@
 # that will also update the jupyterhub version if needed.
 # README.md file.
 
-# JupyterHub itself
+# JupyterHub itself, update this version pinning by running the workflow
+# mentioned above.
 jupyterhub==3.0.0b1
 
 ## Authenticators


### PR DESCRIPTION
This PR makes us bump to pre-releases of jupyterhub automatically, and to as part of that PR also make sure we refreeze the dependencies in requiements.txt if jupyterhub was bumped. The refreezing part makes us duplicate code a bit, but I think it should be fine. I added a note about it.

Fixes #2828 and addresses https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2827#issuecomment-1203718287.

---

While this version bumping automation is a bit complicated, I like that it makes us codify knowledge on chore maintenance tasks so anyone can do it quickly.