### PR TITLE
Corrected indentation in the config.yml example

### DIFF
--- a/docs/source/jupyterhub/customizing/user-environment.md
+++ b/docs/source/jupyterhub/customizing/user-environment.md
@@ -44,9 +44,9 @@ image containing useful tools and libraries for data science, complete these ste
        # https://github.com/jupyter/docker-stacks/tree/HEAD/datascience-notebook/Dockerfile
        name: jupyter/datascience-notebook
        tag: latest
-       # `cmd: null` allows the custom CMD of the Jupyter docker-stacks to be used
-       # which performs further customization on startup.
-       cmd: null
+     # `cmd: null` allows the custom CMD of the Jupyter docker-stacks to be used
+     # which performs further customization on startup.
+     cmd: null
    ```
 
    ```{note}


### PR DESCRIPTION
At section `Modify your config.yaml file to specify the image`. This corrects following error when running helm upgrade using incorrect config:

```Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
jupyterhub:
- singleuser.image: Additional property cmd is not allowed