### PR TITLE
Mount wheels from build stage instead of copying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
 
       - run:
           command: |
+            export DOCKER_BUILDKIT=1
             chartpress
           name: Run chartpress
 

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -247,6 +247,8 @@ jobs:
         run: |
           pip3 install -r dev-requirements.txt
           chartpress
+        env:
+          DOCKER_BUILDKIT: "1"
 
       # Generate values.schema.json from schema.yaml
       - name: Generate values.schema.json from schema.yaml

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -7,8 +7,8 @@ FROM python:3.9-bullseye as build-stage
 
 WORKDIR /build-stage
 
-# set env for pip cache,
-# but use ARG to avoid persisting in image
+# set pip's cache directory using this environment variable, and use
+# ARG instead of ENV to ensure its only set when the image is built
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 
 # Build wheels

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # The build stage
 # ---------------
 FROM python:3.9-bullseye as build-stage
@@ -6,21 +7,16 @@ FROM python:3.9-bullseye as build-stage
 
 WORKDIR /build-stage
 
-# Build wheels for packages that require gcc or other build dependencies and
-# lack wheels either for amd64 or aarch64.
-#
-#   - https://pypi.org/project/pycurl/#files, no wheels available as of 7.45.1.
-#     See https://github.com/pycurl/pycurl/issues/738.
-#
-# If you find a dependency here no longer listed in requirements.txt, remove it
-# from here as well. The more wheels we build here and copy and then install,
-# where the copy and install are separate steps, the larger the final image
-# becomes.
-#
+# set env for pip cache,
+# but use ARG to avoid persisting in image
+ARG PIP_CACHE_DIR=/tmp/pip-cache
+
+# Build wheels
+# These are mounted into the final image for installation
 COPY requirements.txt requirements.txt
-RUN pip install build \
- && pip wheel \
-        $(cat requirements.txt | grep "pycurl==")
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    pip install build \
+ && pip wheel -r requirements.txt
 
 
 # The final stage
@@ -30,6 +26,7 @@ FROM python:3.9-slim-bullseye
 ARG NB_USER=jovyan
 ARG NB_UID=1000
 ARG HOME=/home/jovyan
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN adduser --disabled-password \
@@ -56,10 +53,16 @@ RUN apt-get update && \
         tini \
  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build-stage /build-stage/*.whl /tmp/pre-built-wheels/
+# set env for pip cache,
+# but use ARG to avoid persisting in image
+ARG PIP_CACHE_DIR=/tmp/pip-cache
+
+# install wheels built in the build-stage
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir \
-        /tmp/pre-built-wheels/*.whl \
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    --mount=type=cache,from=build-stage,source=/build-stage,target=/tmp/wheels \
+    pip install \
+        --find-links /tmp/wheels/ \
         -r /tmp/requirements.txt
 
 WORKDIR /srv/jupyterhub

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -62,7 +62,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/build-stage,target=/tmp/wheels \
     pip install \
-        --find-links /tmp/wheels/ \
+        --find-links=/tmp/wheels/ \
         -r /tmp/requirements.txt
 
 WORKDIR /srv/jupyterhub

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -53,8 +53,8 @@ RUN apt-get update && \
         tini \
  && rm -rf /var/lib/apt/lists/*
 
-# set env for pip cache,
-# but use ARG to avoid persisting in image
+# set pip's cache directory using this environment variable, and use
+# ARG instead of ENV to ensure its only set when the image is built
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 
 # install wheels built in the build-stage

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -7,8 +7,8 @@ FROM python:3.9-bullseye as build-stage
 
 WORKDIR /build-stage
 
-# set env for pip cache,
-# but use ARG to avoid persisting in image
+# set pip's cache directory using this environment variable, and use
+# ARG instead of ENV to ensure its only set when the image is built
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 
 # These are mounted into the final image for installation

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -57,7 +57,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/build-stage,target=/tmp/wheels \
     pip install \
-        --find-links /tmp/wheels/ \
+        --find-links=/tmp/wheels/ \
         -r /tmp/requirements.txt
 
 WORKDIR ${HOME}

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -48,8 +48,8 @@ RUN apt-get update \
         git \
  && rm -rf /var/lib/apt/lists/*
 
-# set env for pip cache,
-# but use ARG to avoid persisting in image
+# set pip's cache directory using this environment variable, and use
+# ARG instead of ENV to ensure its only set when the image is built
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 
 # install wheels built in the build-stage

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.3
 # The build stage
 # ---------------
 FROM python:3.9-bullseye as build-stage
@@ -6,21 +7,15 @@ FROM python:3.9-bullseye as build-stage
 
 WORKDIR /build-stage
 
-# Build wheels for packages that require gcc or other build dependencies and
-# lack wheels either for amd64 or aarch64.
-#
-#   - https://pypi.org/project/psutil/#files, no wheels available as of 5.9.1
-#     for aarch64. See https://github.com/giampaolo/psutil/pull/2070.
-#
-# If you find a dependency here no longer listed in requirements.txt, remove it
-# from here as well. The more wheels we build here and copy and then install,
-# where the copy and install are separate steps, the larger the final image
-# becomes.
-#
+# set env for pip cache,
+# but use ARG to avoid persisting in image
+ARG PIP_CACHE_DIR=/tmp/pip-cache
+
+# These are mounted into the final image for installation
 COPY requirements.txt requirements.txt
-RUN pip install build \
- && pip wheel \
-        $(cat requirements.txt | grep "psutil==")
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    pip install build \
+ && pip wheel -r requirements.txt
 
 
 # The final stage
@@ -53,10 +48,16 @@ RUN apt-get update \
         git \
  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build-stage /build-stage/*.whl /tmp/pre-built-wheels/
+# set env for pip cache,
+# but use ARG to avoid persisting in image
+ARG PIP_CACHE_DIR=/tmp/pip-cache
+
+# install wheels built in the build-stage
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir \
-        /tmp/pre-built-wheels/*.whl \
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    --mount=type=cache,from=build-stage,source=/build-stage,target=/tmp/wheels \
+    pip install \
+        --find-links /tmp/wheels/ \
         -r /tmp/requirements.txt
 
 WORKDIR ${HOME}


### PR DESCRIPTION
- avoids copying wheels, eliminating the need to track which need compilers on arm and select those for the build stage. The build stage can now be much simpler and build all wheels
- mount pip cache as a cache dir, so cache can be used without polluting the image

Requires buildkit for `--mount`

results: smaller images (when compared with the simpler `COPY --from` for all wheels, negligible difference with the more complex, optimized build stage), simpler Dockerfiles (no need to pick 'needs compile on arm' images for the build stage), faster rebuilds (cache is actually used, which saves a lot of time)