### PR TITLE
Update chartpress to 2.1+ and adopt tbump in the release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -94,7 +94,7 @@ Also the images we build are based on some image specified in the `FROM` stateme
   - [ ] Set the next prerelease version (don't create a tag).
 
     ```bash
-    tbump --no-tag x.y+1.z-0.dev
+    tbump --no-tag x.y.z+1-0.dev
     ```
 
   - [ ] Create a GitHub release.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -65,8 +65,7 @@ Also the images we build are based on some image specified in the `FROM` stateme
     ```bash
     git checkout main
     git reset --hard <upstream>/main
-    git tag -a x.y.z-beta.1 -m x.y.z-beta.1 <commit on main>
-    git push --follow-tags <upstream> main
+    tbump x.y.z-beta.1
     ```
 
 - Announce the x.y.z-beta.1 release
@@ -89,11 +88,14 @@ Also the images we build are based on some image specified in the `FROM` stateme
     ```bash
     git checkout main
     git reset --hard <upstream>/main
-    git tag -a x.y.z -m x.y.z HEAD
-    git push --follow-tags <upstream> main
+    tbump x.y.z
     ```
 
-  - [ ] Update baseVersion in chartpress to the next release (e.g. `2.1.0-0.dev` after 2.0.0)
+  - [ ] Set the next prerelease version (don't create a tag).
+
+    ```bash
+    tbump --no-tag x.y+1.z-0.dev
+    ```
 
   - [ ] Create a GitHub release.
         Visit the [release page](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/releases) and create a new release referencing the recent tag. Add a brief text like the one below.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -93,6 +93,8 @@ Also the images we build are based on some image specified in the `FROM` stateme
     git push --follow-tags <upstream> main
     ```
 
+  - [ ] Update baseVersion in chartpress to the next release (e.g. `2.1.0-0.dev` after 2.0.0)
+
   - [ ] Create a GitHub release.
         Visit the [release page](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/releases) and create a new release referencing the recent tag. Add a brief text like the one below.
 

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -13,6 +13,7 @@ charts:
     # Dev: imagePrefix can be useful to override if you want to trial something
     #      locally developed in a remote k8s cluster.
     imagePrefix: jupyterhub/k8s-
+    baseVersion: "2.0.0-0.dev"
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -13,7 +13,7 @@ charts:
     # Dev: imagePrefix can be useful to override if you want to trial something
     #      locally developed in a remote k8s cluster.
     imagePrefix: jupyterhub/k8s-
-    baseVersion: "2.0.0-0.dev"
+    baseVersion: "2.0.0-beta.1"
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@
 #
 # ref: https://github.com/jupyterhub/chartpress
 #
-chartpress==2.*
+chartpress>=2.1,<3
 
 # pytest run tests that require requests and pyyaml
 pytest>=3.7.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@
 #
 # ref: https://github.com/jupyterhub/chartpress
 #
-chartpress>=1.1.0
+chartpress==2.*
 
 # pytest run tests that require requests and pyyaml
 pytest>=3.7.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,3 +17,6 @@ click
 
 # used to formatting and linting
 pre-commit>=2.0.0
+
+# used for tagging releases
+tbump

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,4 +1,9 @@
-# tbump config sets baseVersion in chartpress.yaml
+# tbump is a tool to update version fields that we use
+# to update baseVersion in chartpress.yaml as documented
+# in RELEASE.md
+#
+# Config reference: https://github.com/your-tools/tbump#readme
+#
 [version]
 current = "2.0.0-beta.1"
 

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,35 @@
+# tbump config sets baseVersion in chartpress.yaml
+[version]
+current = "2.0.0-0.dev"
+
+# match our prerelease prefixes
+# -alpha.1
+# -beta.2
+# -0.dev
+
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (\-
+    (?P<prelease>
+      (
+       (alpha|beta|rc)\.\d+|
+       0\.dev
+      )
+    )
+  )?
+  '''
+
+[git]
+message_template = "Bump to {new_version}"
+tag_template = "{new_version}"
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[file]]
+src = "chartpress.yaml"
+search = 'baseVersion: "{current_version}"'

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,6 +1,6 @@
 # tbump config sets baseVersion in chartpress.yaml
 [version]
-current = "2.0.0-0.dev"
+current = "2.0.0-beta.1"
 
 # match our prerelease prefixes
 # -alpha.1


### PR DESCRIPTION
- require chartpress 2 in dev-requirements (previous unbounded pinning meant we were using it already as soon as it shipped)
- set baseVersion in chartpress.yaml
- note baseVersion bump in release process

One bit of the new chartpress 2.0 process that may be useful, but I'm not sure where to write it down: since we publish versions continuously, we should bump the baseVersion e.g. 2.1.0-0.dev -> 3.0.0-0.dev in the first 'breaking' PR. It's not the _most_ important thing to get exactly right, but it will be easy to overlook. Arguably,w e could do the same for 2.0.1 -> 2.1.0 fr the first new thing. Alternately, we could always start with '3.0.0-0.dev' to indicate 'might be breaking' so we don't have to pay attention so much in mid-development.

