### PR TITLE
Fix docs for github org membership based auth

### DIFF
--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -175,7 +175,7 @@ hub:
       allowed_organizations:
         - my-github-organization
       scope:
-        - read:user
+        - read:org
 ```
 
 If you would like to restrict access to a specific team within a GitHub organization, use


### PR DESCRIPTION
To read members of an organization, the scope has to be read:org, not read:user. Debugging this cost me half a day and I hope fixing this can save others the time.