### PR TITLE
fix: add string type to cpu limit and guarantee in helm schema

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1955,9 +1955,9 @@ properties:
           for more info.
         properties:
           limit:
-            type: [number, "null"]
+            type: [number, string, "null"]
           guarantee:
-            type: [number, "null"]
+            type: [number, string, "null"]
       memory:
         type: object
         additionalProperties: false

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -447,7 +447,7 @@ singleuser:
       storageAccessModes: [ReadWriteOnce]
   startTimeout: 300
   cpu:
-    guarantee: 0.2
+    guarantee: 100m
     limit: 4
   memory:
     guarantee: 1G


### PR DESCRIPTION
Found this while using the chart, CPU limits and requests can be a string as well:

```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: frontend
spec:
  containers:
  - name: app
    image: images.my-company.example/app:v4
    resources:
      requests:
        memory: "64Mi"
        cpu: "250m"
      limits:
        memory: "128Mi"
        cpu: "500m"
  - name: log-aggregator
    image: images.my-company.example/log-aggregator:v6
    resources:
      requests:
        memory: "64Mi"
        cpu: "250m"
      limits:
        memory: "128Mi"
        cpu: "500m"
```
Source: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#example-1

In the current schema `100Mi` is an invalid value since the type is `string` instead of `number`