### PR TITLE
values.yaml: fix link to configurable-http-proxy releases

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -198,7 +198,7 @@ proxy:
       # tag is automatically bumped to new patch versions by the
       # watch-dependencies.yaml workflow.
       #
-      tag: "4.5.3" # https://github.com/jupyterhub/configurable-http-proxy/releases
+      tag: "4.5.3" # https://github.com/jupyterhub/configurable-http-proxy/tags
       pullPolicy:
       pullSecrets: []
     extraCommandLineFlags: []


### PR DESCRIPTION
There are no GitHub releases, only tags