### PR TITLE
ci: Auto-create GitHub release when repo is tagged

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,32 @@
+# Create a GitHub release whenever a tag is pushed.
+# Tags that aren't in the form N.N.N are considered pre-releases.
+
+name: release-tag
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # https://github.com/actions/github-script
+      # https://octokit.github.io/rest.js/v18#repos-create-release
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            if (!context.ref.startsWith('refs/tags/')) {
+              core.setFailed(`${context.ref} is not in the form refs/tags/$tag`)
+            }
+            const tag = context.ref.slice(10)
+            const prerelease = !tag.match(/\d+\.\d+\.\d+$/)
+            github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              prerelease: prerelease,
+              body: 'Please see the [changelog](https://zero-to-jupyterhub.readthedocs.io/en/latest/changelog.html) for details.'
+            });

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,6 +67,7 @@ Also the images we build are based on some image specified in the `FROM` stateme
     git reset --hard <upstream>/main
     tbump x.y.z-beta.1
     ```
+    This will automatically create a [GitHub prerelease](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/releases).
 
 - Announce the x.y.z-beta.1 release
   - [ ] Write a discourse post
@@ -91,14 +92,13 @@ Also the images we build are based on some image specified in the `FROM` stateme
     tbump x.y.z
     ```
 
+    This will automatically create a [GitHub release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/releases).
+
   - [ ] Set the next prerelease version (don't create a tag).
 
     ```bash
     tbump --no-tag x.y.z+1-0.dev
     ```
-
-  - [ ] Create a GitHub release.
-        Visit the [release page](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/releases) and create a new release referencing the recent tag. Add a brief text like the one below.
 
 - Communicate
   - [ ] Update the beta release's discourse post.


### PR DESCRIPTION
Alternative solution for https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2861 which avoids disrupting anyone who was relying on GitHub releases.

I've tested this in
https://github.com/manicstreetpreacher/github-api-test/blob/main/.github/workflows/release-tag.yml
by manually pushing tags `0.0.1-test` and `0.0.1`, resulting in
https://github.com/manicstreetpreacher/github-api-test/releases

Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2861