### PR TITLE
ci: enable buildkit for vuln scan workflow as needed for --mount

### DIFF
--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -104,6 +104,8 @@ jobs:
       - name: Rebuild image
         id: rebuild
         if: steps.scan_1.outcome == 'failure'
+        env:
+          DOCKER_BUILDKIT: "1"
         run: |
           docker build -t rebuilt-image images/${{ matrix.image_ref }}
 


### PR DESCRIPTION
This is a followup to an optimization made by Min that started using `--mount` as part of `RUN` in some Dockerfiles. It requires buildkit, which needs to be manually enabled.