### PR TITLE
Switch from deprecated k8s.gcr.io to registry.k8s.io

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -65,14 +65,14 @@ jobs:
           # values.yaml about bumping its version.
           #
           - name: kube-scheduler
-            registry: k8s.gcr.io
+            registry: registry.k8s.io
             repository: kube-scheduler
             values_path: scheduling.userScheduler.image.tag
             version_startswith: "v1.23"
             version_patch_regexp_group_suffix: ""
 
           - name: pause
-            registry: k8s.gcr.io
+            registry: registry.k8s.io
             repository: pause
             values_path: scheduling.userPlaceholder.image.tag
             version_startswith: ""

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -499,7 +499,7 @@ scheduling:
       #            - If "successfully acquired lease" can be seen in the logs, it
       #              is a good sign kube-scheduler is ready to schedule pods.
       #
-      name: k8s.gcr.io/kube-scheduler
+      name: registry.k8s.io/kube-scheduler
       # tag is automatically bumped to new patch versions by the
       # watch-dependencies.yaml workflow. The minor version is pinned in the
       # workflow, and should be updated there if a minor version bump is done
@@ -531,7 +531,7 @@ scheduling:
   userPlaceholder:
     enabled: true
     image:
-      name: k8s.gcr.io/pause
+      name: registry.k8s.io/pause
       # tag is automatically bumped to new patch versions by the
       # watch-dependencies.yaml workflow.
       #
@@ -617,7 +617,7 @@ prePuller:
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
-      name: k8s.gcr.io/pause
+      name: registry.k8s.io/pause
       # tag is automatically bumped to new patch versions by the
       # watch-dependencies.yaml workflow.
       #


### PR DESCRIPTION
I've got some errors about k8s.gcr.io and googled my way to find that its been deprecated, see https://github.com/kubernetes/kubernetes/pull/109938 for example.