### PR TITLE
ci: bump docker action versions to v2 from v2.x.y

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,10 +74,10 @@ jobs:
           print(f"::set-output name=publishing::{publishing}")
 
       - name: Set up QEMU (for docker buildx)
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # dependabot updates to latest release
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx (for chartpress multi-arch builds)
-        uses: docker/setup-buildx-action@95cb08cb2672c73d4ffd2f422e6d11953d2a9c70 # dependabot updates to latest release
+        uses: docker/setup-buildx-action@v2
 
       - name: Install chart publishing dependencies (chartpress, helm)
         run: |

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -45,10 +45,10 @@ jobs:
         run: pip install chartpress
 
       - name: Set up QEMU (for docker buildx)
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # dependabot updates to latest release
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx (for chartpress multi-arch builds)
-        uses: docker/setup-buildx-action@95cb08cb2672c73d4ffd2f422e6d11953d2a9c70 # dependabot updates to latest release
+        uses: docker/setup-buildx-action@v2
 
       - name: Build a multiple architecture Docker image
         run: >-


### PR DESCRIPTION
It is more messy than needed to bump minor/patch when we can pin the major anyhow.
- Closes #2912
- Closes #2913