### PR TITLE
Replace vim with nano in hub image to reduce known vulnerabilities

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && \
         git \
         # misc other utilities
         less \
-        vim \
+        nano \
         # requirement for pycurl
         libcurl4 \
         # requirement for using a local sqlite database


### PR DESCRIPTION
I hope we don't need to discuss what editors to use in general, but agree that `nano` can do the trick for the occational debugging needed in the `hub` pod.

- Closes #2916 