### PR TITLE
Add a jupyterhub/k8s-hub-slim image alongside jupyterhub/k8s-hub

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -131,8 +131,10 @@ jobs:
         include:
           - k3s-channel: latest
             test: install
-          - k3s-channel: stable
+          - k3s-channel: stable # also test hub-slim
             test: install
+            local-chart-extra-args: >-
+              --set hub.image.name=jupyterhub/k8s-hub-slim
           - k3s-channel: v1.21 # also test prePuller.hook
             test: install
             local-chart-extra-args: >-

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -23,6 +23,12 @@ charts:
       # Authenticator are running.
       hub:
         valuesPath: hub.image
+      # hub-slim, an alternative hub image that doesn't include some
+      # basic utilities for k8s admins
+      hub-slim:
+        contextPath: images/hub
+        extraBuildCommandOptions:
+          - --target=slim-stage
 
       # secret-sync, a sidecar container running in the autohttps pod to next to
       # Traefik meant to sync a TLS certificate with a k8s Secret.

--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -167,6 +167,29 @@ security report generator. Use the following URL structure to test your domain:
 https://ssllabs.com/ssltest/analyze.html?d=<YOUR-DOMAIN>
 ```
 
+## Minimize hub image
+
+By excluding non essential tools in the `hub` pod's image, you can avoid
+exposure to vulnerabilities in those tools. You can use the slim version of the
+hub image that we provide for this.
+
+```yaml
+hub:
+  image:
+    # The slim variant excludes a few non-essential packages that are useful
+    # when debugging something from the hub pod. To use it, apply this
+    # configuration.
+    #
+    name: jupyterhub/k8s-hub-slim
+```
+
+```{note}
+We are based on Linux Debian as a base image. There are container
+scanners that pick up known vulnerabilities in Debian that the Debian security
+team has dismissed. For details about this, see [this
+comment](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2918#issuecomment-1295813128).
+```
+
 ## Secure access to Helm
 
 Helm 3 supports the security, identity, and authorization features of modern Kubernetes. Helm’s permissions are evaluated using your kubeconfig file. Cluster administrators can restrict user permissions at whatever granularity they see fit.

--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -167,11 +167,10 @@ security report generator. Use the following URL structure to test your domain:
 https://ssllabs.com/ssltest/analyze.html?d=<YOUR-DOMAIN>
 ```
 
-## Minimize hub image
+## Minimal hub image
 
-By excluding non essential tools in the `hub` pod's image, you can avoid
-exposure to vulnerabilities in those tools. You can use the slim version of the
-hub image that we provide for this.
+The default hub image includes some useful debugging tools.
+You can use the slim version of image to minimise your exposure to vulnerabilities in those optional tools.
 
 ```yaml
 hub:

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -19,9 +19,12 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
  && pip wheel -r requirements.txt
 
 
-# The final stage
-# ---------------
-FROM python:3.9-slim-bullseye
+# The final stage - slim version
+# ------------------------------
+# This stage is built and published as jupyterhub/k8s-hub-slim. It is meant to
+# provide no apt packages besides whats essential.
+#
+FROM python:3.9-slim-bullseye as slim-stage
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000
@@ -36,16 +39,9 @@ RUN adduser --disabled-password \
         --force-badname \
         ${NB_USER}
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-        # misc network utilities
-        curl \
-        dnsutils \
-        git \
-        # misc other utilities
-        less \
-        vim \
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y --no-install-recommends \
         # requirement for pycurl
         libcurl4 \
         # requirement for using a local sqlite database
@@ -72,3 +68,24 @@ USER ${NB_USER}
 EXPOSE 8081
 ENTRYPOINT ["tini", "--"]
 CMD ["jupyterhub", "--config", "/usr/local/etc/jupyterhub/jupyterhub_config.py"]
+
+
+# The final stage - default version
+# ---------------------------------
+# We add a few non-critical apt packages on top of the slim version to provide
+# some debugging utility for k8s admins.
+#
+FROM slim-stage
+
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        # misc network utilities
+        curl \
+        dnsutils \
+        git \
+        # misc other utilities
+        less \
+        vim \
+ && rm -rf /var/lib/apt/lists/*
+USER ${NB_USER}

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -95,11 +95,9 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-        # misc network utilities
         curl \
         dnsutils \
         git \
-        # misc other utilities
         less \
         vim \
  && rm -rf /var/lib/apt/lists/*

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,38 +1,41 @@
 # syntax = docker/dockerfile:1.3
-# The build stage
-# ---------------
-FROM python:3.9-bullseye as build-stage
-
 # VULN_SCAN_TIME=2022-08-08_05:22:22
 
-WORKDIR /build-stage
 
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
+# The build stage
+# ---------------
+# This stage is building Python wheels for use in later stages by using a base
+# image that has more pre-requisites to do so, such as a C++ compiler.
+#
+FROM python:3.9-bullseye as build-stage
 
 # Build wheels
-# These are mounted into the final image for installation
+#
+# We set pip's cache directory and expose it across build stages via an
+# ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}).
+#
 COPY requirements.txt requirements.txt
+ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     pip install build \
- && pip wheel -r requirements.txt
+ && pip wheel \
+        --wheel-dir=/tmp/wheels \
+        -r requirements.txt
 
 
 # The final stage - slim version
 # ------------------------------
 # This stage is built and published as jupyterhub/k8s-hub-slim. It is meant to
-# provide no apt packages besides whats essential.
+# provide no non-essential packages.
 #
 FROM python:3.9-slim-bullseye as slim-stage
-
-ARG NB_USER=jovyan
-ARG NB_UID=1000
-ARG HOME=/home/jovyan
-
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN adduser --disabled-password \
+ARG NB_USER=jovyan \
+    NB_UID=1000 \
+    HOME=/home/jovyan
+RUN adduser \
+        --disabled-password \
         --gecos "Default user" \
         --uid ${NB_UID} \
         --home ${HOME} \
@@ -49,14 +52,11 @@ RUN apt-get update \
         tini \
  && rm -rf /var/lib/apt/lists/*
 
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
-
 # install wheels built in the build-stage
 COPY requirements.txt /tmp/requirements.txt
+ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    --mount=type=cache,from=build-stage,source=/build-stage,target=/tmp/wheels \
+    --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
     pip install \
         --find-links=/tmp/wheels/ \
         -r /tmp/requirements.txt
@@ -72,10 +72,10 @@ CMD ["jupyterhub", "--config", "/usr/local/etc/jupyterhub/jupyterhub_config.py"]
 
 # The final stage - default version
 # ---------------------------------
-# We add a few non-critical apt packages on top of the slim version to provide
-# some debugging utility for k8s admins.
+# We add a few non-critical packages on top of the slim version to provide some
+# additional utility.
 #
-FROM slim-stage
+FROM slim-stage as default-stage
 
 USER root
 RUN apt-get update \

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -20,7 +20,11 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     pip install build \
  && pip wheel \
         --wheel-dir=/tmp/wheels \
-        -r requirements.txt
+        -r requirements.txt \
+        # Additional wheels for default-stage. Updates below should be repeated
+        # in default-stage.
+        #
+        py-spy
 
 
 # The final stage - slim version
@@ -78,6 +82,17 @@ CMD ["jupyterhub", "--config", "/usr/local/etc/jupyterhub/jupyterhub_config.py"]
 FROM slim-stage as default-stage
 
 USER root
+
+ARG PIP_CACHE_DIR=/tmp/pip-cache
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
+    pip install \
+        --find-links=/tmp/wheels/ \
+        # Updates below should be repeated in build-stage.
+        #
+        # py-spy is useful for profiling performance of running hubs
+        py-spy
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         # misc network utilities
@@ -88,4 +103,5 @@ RUN apt-get update \
         less \
         vim \
  && rm -rf /var/lib/apt/lists/*
+
 USER ${NB_USER}

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -35,8 +35,3 @@ statsd  # statsd metrics collection (TODO: remove soon, since folks use promethe
 
 # The idle culler service
 jupyterhub-idle-culler
-
-## Useful tools
-
-# py-spy is useful for profiling running hubs
-py-spy

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -124,8 +124,6 @@ prometheus-client==0.15.0
     # via jupyterhub
 psycopg2-binary==2.9.4
     # via -r requirements.in
-py-spy==0.3.14
-    # via -r requirements.in
 pyasn1==0.4.8
     # via ldap3
 pycparser==2.21

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,36 +1,39 @@
 # syntax = docker/dockerfile:1.3
-# The build stage
-# ---------------
-FROM python:3.9-bullseye as build-stage
-
 # VULN_SCAN_TIME=2022-08-08_05:22:22
 
-WORKDIR /build-stage
 
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
+# The build stage
+# ---------------
+# This stage is building Python wheels for use in later stages by using a base
+# image that has more pre-requisites to do so, such as a C++ compiler.
+#
+FROM python:3.9-bullseye as build-stage
 
-# These are mounted into the final image for installation
+# Build wheels
+#
+# We set pip's cache directory and expose it across build stages via an
+# ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}).
+#
 COPY requirements.txt requirements.txt
+ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     pip install build \
- && pip wheel -r requirements.txt
+ && pip wheel \
+        --wheel-dir=/tmp/wheels \
+        -r requirements.txt
 
 
 # The final stage
 # ---------------
-
+#
 FROM python:3.9-slim-bullseye
+ENV DEBIAN_FRONTEND=noninteractive
 
-# VULN_SCAN_TIME=
-
-ENV DEBIAN_FRONTEND=noninteractive \
-    NB_USER=jovyan \
+ENV NB_USER=jovyan \
     NB_UID=1000 \
     HOME=/home/jovyan
-
-RUN adduser --disabled-password \
+RUN adduser \
+        --disabled-password \
         --gecos "Default user" \
         --uid ${NB_UID} \
         --home ${HOME} \
@@ -48,14 +51,11 @@ RUN apt-get update \
         git \
  && rm -rf /var/lib/apt/lists/*
 
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
-
 # install wheels built in the build-stage
 COPY requirements.txt /tmp/requirements.txt
+ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    --mount=type=cache,from=build-stage,source=/build-stage,target=/tmp/wheels \
+    --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
     pip install \
         --find-links=/tmp/wheels/ \
         -r /tmp/requirements.txt


### PR DESCRIPTION
The jupyterhub/k8s-hub-slim image is tested in the (stable, install) job now - it works fine and I think we don't need anything more in tooling etc, just another chartpress.yaml configuration entry.

This PR stems from a discussion in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2917#issuecomment-1293465924. It also made me discover a chartpress bug in https://github.com/jupyterhub/chartpress/issues/189.

## Image size

Image | Size
-|-
(current) | 413 MB
Debian slim | 256 MB
Debian fat | 414 MB

## Image vulnerabilities

Image | Size
-|-
(current) | Total: 625 (UNKNOWN: 4, LOW: 16, MEDIUM: 131, HIGH: 454, CRITICAL: 20)
Debian slim | Total: 95 (UNKNOWN: 0, LOW: 12, MEDIUM: 39, HIGH: 40, CRITICAL: 4)
Debian fat | Total: 625 (UNKNOWN: 4, LOW: 16, MEDIUM: 131, HIGH: 454, CRITICAL: 20)

## Image build time

It seems we may end up with a significantly longer build time.

Image | Size
-|-
(current) | min 1m40s, max 2m40s
Debian slim/fat | min 2m51s, max 3m53s

## Conclusion

We drop 36% of the image size by removing these additional tools. In the case of using `python:3.9-bullseye-slim` as a base image still, we also drop a huge amount of since long unfixed known vulnerabilities.

This PR also did not add notable complexity, and I think its very reasonable to go for this since no additional tooling was required and the Dockerfile is easy to understand still etc.

For considerations on using this as default image or similar, I suggest another issue/pr is to be opened.