### PR TITLE
Switch back from debian to ubuntu in hub and singleuser-sample images, and bump python to 3.10

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -131,8 +131,10 @@ jobs:
         include:
           - k3s-channel: latest
             test: install
-          - k3s-channel: stable
+          - k3s-channel: stable # also test hub-slim
             test: install
+            local-chart-extra-args: >-
+              --set hub.image.name=jupyterhub/k8s-hub-slim
           - k3s-channel: v1.21 # also test prePuller.hook
             test: install
             local-chart-extra-args: >-

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -23,6 +23,12 @@ charts:
       # Authenticator are running.
       hub:
         valuesPath: hub.image
+      # hub-slim, an alternative hub image that doesn't include some
+      # basic utilities for k8s admins
+      hub-slim:
+        contextPath: images/hub
+        extraBuildCommandOptions:
+          - --target=slim-stage
 
       # secret-sync, a sidecar container running in the autohttps pod to next to
       # Traefik meant to sync a TLS certificate with a k8s Secret.

--- a/ci/refreeze
+++ b/ci/refreeze
@@ -13,7 +13,7 @@ for img in ${IMAGES}; do
         --volume="$PWD:/io" \
         --workdir=/io \
         --user=root \
-        python:3.9-bullseye \
+        buildpack-deps:22.04 \
         sh -c 'pip install pip-tools==6.* && pip-compile --upgrade'
     popd
 done

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,22 +1,39 @@
 # syntax = docker/dockerfile:1.3
-# The build stage
-# ---------------
-FROM python:3.9-bullseye as build-stage
-
 # VULN_SCAN_TIME=2022-08-08_05:22:22
 
-WORKDIR /build-stage
 
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
+# The build stage
+# ---------------
+# This stage provides a slimmed /opt/python folder with python and dependencies
+# installed.
+#
+FROM buildpack-deps:22.04 as build-stage
 
-# Build wheels
-# These are mounted into the final image for installation
+ENV PATH=/opt/python/bin:$PATH
+
 COPY requirements.txt requirements.txt
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    pip install build \
- && pip wheel -r requirements.txt
+RUN arch=$(uname -m) \
+ && if [ "${arch}" = "x86_64" ]; then arch="64"; fi \
+ && wget -qO micromamba.tar.bz2 \
+        "https://micro.mamba.pm/api/micromamba/linux-${arch}/latest" \
+ && tar -xvjf micromamba.tar.bz2 --strip-components=1 bin/micromamba \
+ && rm micromamba.tar.bz2 \
+    # Install Python
+ && ./micromamba install \
+        --root-prefix=/opt/python \
+        --prefix=/opt/python \
+        --channel=conda-forge \
+        --yes \
+        "python=3.10" \
+        "mamba" \
+        "tini" \
+ && rm micromamba \
+    # Install dependencies
+ && pip install --no-cache-dir \
+        -r requirements.txt \
+    # Cleanup in /opt/python
+ && mamba clean --all --force-pkgs-dirs --yes \
+ && find /opt/python -type d -name __pycache__ -prune -exec rm -rf {} \;
 
 
 # The final stage - slim version
@@ -24,13 +41,12 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
 # This stage is built and published as jupyterhub/k8s-hub-slim. It is meant to
 # provide no apt packages besides whats essential.
 #
-FROM python:3.9-slim-bullseye as slim-stage
-
-ARG NB_USER=jovyan
-ARG NB_UID=1000
-ARG HOME=/home/jovyan
+FROM ubuntu:22.04 as slim-stage
 
 ENV DEBIAN_FRONTEND=noninteractive
+ARG NB_USER=jovyan \
+    NB_UID=1000 \
+    HOME=/home/jovyan
 
 RUN adduser --disabled-password \
         --gecos "Default user" \
@@ -39,27 +55,8 @@ RUN adduser --disabled-password \
         --force-badname \
         ${NB_USER}
 
-RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get install -y --no-install-recommends \
-        # requirement for pycurl
-        libcurl4 \
-        # requirement for using a local sqlite database
-        sqlite3 \
-        tini \
- && rm -rf /var/lib/apt/lists/*
-
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
-
-# install wheels built in the build-stage
-COPY requirements.txt /tmp/requirements.txt
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    --mount=type=cache,from=build-stage,source=/build-stage,target=/tmp/wheels \
-    pip install \
-        --find-links=/tmp/wheels/ \
-        -r /tmp/requirements.txt
+COPY --from=build-stage /opt/python /opt/python
+ENV PATH=/opt/python/bin:$PATH
 
 WORKDIR /srv/jupyterhub
 RUN chown ${NB_USER}:${NB_USER} /srv/jupyterhub

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -19,9 +19,12 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
  && pip wheel -r requirements.txt
 
 
-# The final stage
-# ---------------
-FROM python:3.9-slim-bullseye
+# The final stage - slim version
+# ------------------------------
+# This stage is built and published as jupyterhub/k8s-hub-slim. It is meant to
+# provide no apt packages besides whats essential.
+#
+FROM python:3.9-slim-bullseye as slim-stage
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000
@@ -36,16 +39,9 @@ RUN adduser --disabled-password \
         --force-badname \
         ${NB_USER}
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-        # misc network utilities
-        curl \
-        dnsutils \
-        git \
-        # misc other utilities
-        less \
-        vim \
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y --no-install-recommends \
         # requirement for pycurl
         libcurl4 \
         # requirement for using a local sqlite database
@@ -72,3 +68,24 @@ USER ${NB_USER}
 EXPOSE 8081
 ENTRYPOINT ["tini", "--"]
 CMD ["jupyterhub", "--config", "/usr/local/etc/jupyterhub/jupyterhub_config.py"]
+
+
+# The final stage - default version
+# ---------------------------------
+# We add a few non-critical apt packages on top of the slim version to provide
+# some debugging utility for k8s admins.
+#
+FROM slim-stage
+
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        # misc network utilities
+        curl \
+        dnsutils \
+        git \
+        # misc other utilities
+        less \
+        vim \
+ && rm -rf /var/lib/apt/lists/*
+USER ${NB_USER}

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -1,29 +1,45 @@
 # syntax = docker/dockerfile:1.3
-# The build stage
-# ---------------
-FROM python:3.9-bullseye as build-stage
-
 # VULN_SCAN_TIME=2022-08-08_05:22:22
 
-WORKDIR /build-stage
 
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
+# The build stage
+# ---------------
+# This stage provides a slimmed /opt/python folder with python and dependencies
+# installed.
+#
+FROM buildpack-deps:22.04 as build-stage
 
-# These are mounted into the final image for installation
+ENV PATH=/opt/python/bin:$PATH
+
 COPY requirements.txt requirements.txt
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    pip install build \
- && pip wheel -r requirements.txt
+RUN arch=$(uname -m) \
+ && if [ "${arch}" = "x86_64" ]; then arch="64"; fi \
+ && wget -qO micromamba.tar.bz2 \
+        "https://micro.mamba.pm/api/micromamba/linux-${arch}/latest" \
+ && tar -xvjf micromamba.tar.bz2 --strip-components=1 bin/micromamba \
+ && rm micromamba.tar.bz2 \
+    # Install Python
+ && ./micromamba install \
+        --root-prefix=/opt/python \
+        --prefix=/opt/python \
+        --channel=conda-forge \
+        --yes \
+        "python=3.10" \
+        "mamba" \
+        "tini" \
+ && rm micromamba \
+    # Install dependencies
+ && pip install --no-cache-dir \
+        -r requirements.txt \
+    # Cleanup in /opt/python
+ && mamba clean --all --force-pkgs-dirs --yes \
+ && find /opt/python -type d -name __pycache__ -prune -exec rm -rf {} \;
 
 
 # The final stage
 # ---------------
-
-FROM python:3.9-slim-bullseye
-
-# VULN_SCAN_TIME=
+#
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     NB_USER=jovyan \
@@ -43,22 +59,12 @@ RUN apt-get update \
         ca-certificates \
         dnsutils \
         iputils-ping \
-        tini \
         # requirement for nbgitpuller
         git \
  && rm -rf /var/lib/apt/lists/*
 
-# set pip's cache directory using this environment variable, and use
-# ARG instead of ENV to ensure its only set when the image is built
-ARG PIP_CACHE_DIR=/tmp/pip-cache
-
-# install wheels built in the build-stage
-COPY requirements.txt /tmp/requirements.txt
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    --mount=type=cache,from=build-stage,source=/build-stage,target=/tmp/wheels \
-    pip install \
-        --find-links=/tmp/wheels/ \
-        -r /tmp/requirements.txt
+COPY --from=build-stage /opt/python /opt/python
+ENV PATH=/opt/python/bin:$PATH
 
 WORKDIR ${HOME}
 USER ${NB_USER}


### PR DESCRIPTION
We observed (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2917#issuecomment-1291890917) many reported vulnerabiliies by container scanners that didn't seem to get fixed in the current base images `python:3.9-bullseye-slim` -> `debian:slim-bullseye`.

With this PR we switch to `ubuntu:22.04` as a base image, and by doing that goes to no reported vulnerabilities again.

- Includes #2920
- Reverts ubuntu->debian part of #2733
- Provides `mamba`, but stays with `pip` and `requirements.txt` etc.
  It was introduced to be able to use `mamba clean` after having used `micromamba` to install python and observing 100+ MB of things that wasn't needed.
- Use `COPY` of the entire python installation from the build stage. I have not trialed the previous approach where the build-stage builds wheels and the final stages mounts the wheels and installs using them. I'd like to compare the approaches practically, but its more work than I'm willing to trial myself atm.
- Bumped to Python 3.10
  Ping me if I should extract this as a dedicated PR and I'll do the work.

## Results

Image | Size | Reported vulnerabilities | Build time
-|-|-|-
(current) | 413 MB | Total: 625 (... HIGH: 454, CRITICAL: 20) | min 1m40s, max 2m40s
Debian slim | 266 MB | Total: 95 (... HIGH: 40, CRITICAL: 4) | -
Debian fat | 414 MB | Total: 625 (... HIGH: 454, CRITICAL: 20) | min 2m51s, max 3m53s
Ubuntu slim | 399 MB | Total: 0 (... HIGH: 0, CRITICAL: 0) | -
Ubuntu fat | 571 MB | Total: 0 (... HIGH: 0, CRITICAL: 0) | min 3m49s, max 6m45s

## Conclusion

- Using `ubuntu` mean longer build times, larger size, little to no reported vulnerabilities.
- Providing an intermediary `slim` stage seems like a pure win pretty much

My inclination is that we should go with `ubuntu` and a `slim` version.