### PR TITLE
Drop support for k8s 1.20

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -135,12 +135,12 @@ jobs:
             test: install
             local-chart-extra-args: >-
               --set hub.image.name=jupyterhub/k8s-hub-slim
-          - k3s-channel: v1.21 # also test prePuller.hook
+          - k3s-channel: v1.22 # also test prePuller.hook
             test: install
             local-chart-extra-args: >-
               --set prePuller.hook.enabled=true
               --set prePuller.hook.pullOnlyOnChanges=true
-          - k3s-channel: v1.20 # also test hub.existingSecret
+          - k3s-channel: v1.21 # also test hub.existingSecret
             test: install
             local-chart-extra-args: >-
               --set hub.existingSecret=test-hub-existing-secret

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -12,6 +12,9 @@ and as we merge [breaking changes in pull
 requests](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking),
 this list should be updated.
 
+- K8s 1.21 is now required.
+- The Helm chart's provided images now use Python 3.11 instead of Python 3.9.
+
 ## 2.0
 
 ### 2.0.0 - 2022-09-09

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org
 sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
 icon: https://jupyterhub.github.io/helm-chart/images/hublogo.svg
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.21.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team

--- a/jupyterhub/templates/hub/pdb.yaml
+++ b/jupyterhub/templates/hub/pdb.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.hub.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
-{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "jupyterhub.hub.fullname" . }}

--- a/jupyterhub/templates/proxy/autohttps/pdb.yaml
+++ b/jupyterhub/templates/proxy/autohttps/pdb.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.proxy.traefik.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
-{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: proxy

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -1,10 +1,5 @@
 {{- if .Values.proxy.chp.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
-{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "jupyterhub.proxy.fullname" . }}

--- a/jupyterhub/templates/scheduling/user-placeholder/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/pdb.yaml
@@ -3,12 +3,7 @@ The cluster autoscaler should be allowed to evict and reschedule these pods if
 it would help in order to scale down a node.
 */}}
 {{- if .Values.scheduling.userPlaceholder.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
-{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "jupyterhub.user-placeholder.fullname" . }}

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -11,31 +11,16 @@ data:
     user-scheduler pod.
 
     ref: https://kubernetes.io/docs/reference/scheduling/config/
-    ref: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta2/
     ref: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta3/
+    ref: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1/
 
-    v1beta1 can be used with kube-scheduler binary version <=1.21
-    v1beta2 requires kube-scheduler binary version >=1.22
-    v1beta3 requires kube-scheduler binary version >=1.23
+    kubescheduler.config.k8s.io/v1beta3 requires kube-scheduler binary version >=1.23
+    kubescheduler.config.k8s.io/v1 requires kube-scheduler binary version >=1.25
 
-    kube-scheduler binaries versioned >=1.21 will error in k8s clusters
-    versioned <=1.20. To support a modern version of kube-scheduler and k8s
-    versions <=1.20 upwards, we provide two scenarios:
-
-    1. For k8s >= 1.21 we use a modern version of kube-scheduler and Helm chart
-       configuration works as expected.
-    2. For k8s <= 1.20 we use a hardcoded version of kube-scheduler (v1.20.15)
-       and configuration (v1beta1) of kube-scheduler.
+    FIXME: Add logic to transition from v1beta3 to v1 if its supported.
+           v1beta3 is likeley to be removed in k8s 1.27.
   */}}
   config.yaml: |
-    {{- /*
-      FIXME: We have added a workaround for EKS where
-            .Capabilities.KubeVersion.Minor can return a
-            string like "22+" instead of just "22".
-
-            See https://github.com/aws/eks-distro/issues/1128.
-    */}}
-    {{- if ge (atoi (.Capabilities.KubeVersion.Minor | replace "+" "")) 21 }}
     apiVersion: kubescheduler.config.k8s.io/v1beta3
     kind: KubeSchedulerConfiguration
     leaderElection:
@@ -52,44 +37,4 @@ data:
         pluginConfig:
           {{- . | toYaml | nindent 10 }}
         {{- end }}
-    {{- else }}
-    # WARNING: The tag of this image is hardcoded, and the
-    #          "scheduling.userScheduler.plugins" configuration of the Helm
-    #          chart that generated this resource manifest wasn't respected. If
-    #          you install the Helm chart in a k8s cluster versioned 1.21 or
-    #          higher, your configuration will be respected.
-    apiVersion: kubescheduler.config.k8s.io/v1beta1
-    kind: KubeSchedulerConfiguration
-    leaderElection:
-      resourceLock: endpoints
-      resourceName: {{ include "jupyterhub.user-scheduler-lock.fullname" . }}
-      resourceNamespace: "{{ .Release.Namespace }}"
-    profiles:
-      - schedulerName: {{ include "jupyterhub.user-scheduler.fullname" . }}
-        plugins:
-          score:
-            disabled:
-              - name: SelectorSpread
-              - name: TaintToleration
-              - name: PodTopologySpread
-              - name: NodeResourcesBalancedAllocation
-              - name: NodeResourcesLeastAllocated
-              # Disable plugins to be allowed to enable them again with a
-              # different weight and avoid an error.
-              - name: NodePreferAvoidPods
-              - name: NodeAffinity
-              - name: InterPodAffinity
-              - name: ImageLocality
-            enabled:
-              - name: NodePreferAvoidPods
-                weight: 161051
-              - name: NodeAffinity
-                weight: 14631
-              - name: InterPodAffinity
-                weight: 1331
-              - name: NodeResourcesMostAllocated
-                weight: 121
-              - name: ImageLocality
-                weight: 11
-    {{- end }}
 {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -50,24 +50,7 @@ spec:
       {{- end }}
       containers:
         - name: kube-scheduler
-          {{- /*
-            FIXME: We have added a workaround for EKS where
-                  .Capabilities.KubeVersion.Minor can return a
-                  string like "22+" instead of just "22".
-
-                  See https://github.com/aws/eks-distro/issues/1128.
-          */}}
-          {{- if ge (atoi (.Capabilities.KubeVersion.Minor | replace "+" "")) 21 }}
           image: {{ .Values.scheduling.userScheduler.image.name }}:{{ .Values.scheduling.userScheduler.image.tag }}
-          {{- else }}
-          # WARNING: The tag of this image is hardcoded, and the
-          #          "scheduling.userScheduler.image.tag" configuration of the
-          #          Helm chart that generated this resource manifest isn't
-          #          respected. If you install the Helm chart in a k8s cluster
-          #          versioned 1.21 or higher, your configuration will be
-          #          respected.
-          image: {{ .Values.scheduling.userScheduler.image.name }}:v1.20.15
-          {{- end }}
           {{- with .Values.scheduling.userScheduler.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/pdb.yaml
@@ -1,10 +1,5 @@
 {{- if and .Values.scheduling.userScheduler.enabled .Values.scheduling.userScheduler.pdb.enabled -}}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
-{{- /* k8s 1.21+ required */ -}}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "jupyterhub.user-scheduler-deploy.fullname" . }}

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -19,9 +19,9 @@ rules:
   #       - unchanged between 1.18 and 1.20
   #       - changed in 1.21: get/list/watch permission for namespace,
   #                          csidrivers, csistoragecapacities was added.
-  #       - unchanged between 1.22 and 1.23
+  #       - unchanged between 1.22 and 1.25
   #
-  # ref: https://github.com/kubernetes/kubernetes/blob/v1.23.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L705-L861
+  # ref: https://github.com/kubernetes/kubernetes/blob/v1.25.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L730-L886
   - apiGroups:
     - ""
     - events.k8s.io
@@ -183,9 +183,9 @@ rules:
   # Copied from the system:volume-scheduler ClusterRole of the k8s version
   # matching the kube-scheduler binary we use.
   #
-  # NOTE: These rules have not changed between 1.12 and 1.23.
+  # NOTE: These rules have not changed between 1.12 and 1.25.
   #
-  # ref: https://github.com/kubernetes/kubernetes/blob/v1.23.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1280-L1307
+  # ref: https://github.com/kubernetes/kubernetes/blob/v1.25.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1305-L1332
   - apiGroups:
     - ""
     resources:


### PR DESCRIPTION
- Closes #2935 by dropping support for k8s 1.20 that is no longer supported by cloud managed k8s clusters (GKE, EKS, or AKS).
- As part of dropping that support, we this PR also cleans away misc logic no longer needed.