### PR TITLE
Update kube-scheduler to v1.25 and its configuration api to v1 if k8s >=1.24

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -68,7 +68,7 @@ jobs:
             registry: registry.k8s.io
             repository: kube-scheduler
             values_path: scheduling.userScheduler.image.tag
-            version_startswith: "v1.23"
+            version_startswith: "v1.25"
             version_patch_regexp_group_suffix: ""
 
           - name: pause

--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -8,23 +8,28 @@ metadata:
 data:
   {{- /*
     This is configuration of a k8s official kube-scheduler binary running in the
-    user-scheduler pod.
+    user-scheduler.
+
+    The config version and kube-scheduler binary version has a fallback for k8s
+    clusters versioned v1.23 or lower because:
+
+    - v1 / v1beta3 config requires kube-scheduler binary >=1.25 / >=1.23
+    - kube-scheduler binary >=1.25 requires storage.k8s.io/v1/CSIStorageCapacity
+      available first in k8s >=1.24
 
     ref: https://kubernetes.io/docs/reference/scheduling/config/
-    ref: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta3/
     ref: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1/
-
-    kubescheduler.config.k8s.io/v1beta3 requires kube-scheduler binary version >=1.23
-    kubescheduler.config.k8s.io/v1 requires kube-scheduler binary version >=1.25
-
-    FIXME: Add logic to transition from v1beta3 to v1 if its supported.
-           v1beta3 is likeley to be removed in k8s 1.27.
+    ref: https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1beta3/
   */}}
   config.yaml: |
+    {{- if semverCompare ">=1.24.0-0" .Capabilities.KubeVersion.Version }}
+    apiVersion: kubescheduler.config.k8s.io/v1
+    {{- else }}
     apiVersion: kubescheduler.config.k8s.io/v1beta3
+    {{- end }}
     kind: KubeSchedulerConfiguration
     leaderElection:
-      resourceLock: endpoints
+      resourceLock: endpointsleases
       resourceName: {{ include "jupyterhub.user-scheduler-lock.fullname" . }}
       resourceNamespace: "{{ .Release.Namespace }}"
     profiles:

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -50,7 +50,17 @@ spec:
       {{- end }}
       containers:
         - name: kube-scheduler
+          {{- if semverCompare ">=1.24.0-0" .Capabilities.KubeVersion.Version }}
           image: {{ .Values.scheduling.userScheduler.image.name }}:{{ .Values.scheduling.userScheduler.image.tag }}
+          {{- else }}
+          # WARNING: The tag of this image is hardcoded, and the
+          #          "scheduling.userScheduler.image.tag" configuration of the
+          #          Helm chart that generated this resource manifest isn't
+          #          respected. If you install the Helm chart in a k8s cluster
+          #          versioned 1.24 or higher, your configuration will be
+          #          respected.
+          image: {{ .Values.scheduling.userScheduler.image.name }}:v1.23.14
+          {{- end }}
           {{- with .Values.scheduling.userScheduler.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -505,7 +505,7 @@ scheduling:
       # workflow, and should be updated there if a minor version bump is done
       # here.
       #
-      tag: "v1.23.14" # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
+      tag: "v1.25.4" # ref: https://github.com/kubernetes/website/blob/main/content/en/releases/patch-releases.md
       pullPolicy:
       pullSecrets: []
     nodeSelector: {}

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -477,7 +477,7 @@ scheduling:
     plugins:
       score:
         disabled:
-          - name: SelectorSpread
+          - name: PodTopologySpread
         enabled:
           - name: NodePreferAvoidPods
             weight: 161051


### PR DESCRIPTION
We can't transition to kube-scheduler 1.25 unless we are on k8s >=1.24 because then that binary crashes, so we stick with kube-scheduler 1.23 if the k8s versions is too old.