### PR TITLE
Added ability to specify labels for k8s-objects like DaemonSets and Deployments

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -185,6 +185,16 @@ properties:
       `{"name": "my-secret-name"}`, or you can let list elements be strings
       naming the secrets directly.
 
+  labels:
+    type: object
+    additionalProperties: false
+    patternProperties:
+      ".*":
+        type: string
+    description: |
+      Chart wide ability to add specific labels via values.yaml to K8s
+      objects such as DaemonSets or Deployments
+
   hub:
     type: object
     additionalProperties: false

--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -109,6 +109,18 @@
 {{- end }}
 
 
+{{/*
+helper function for building up labels key value pairs
+*/}}
+{{- define "jupyterhub.determinedLabels" -}}
+  {{- with .Values.labels }}
+    {{- range $key, $value := . }}
+{{ $key }}: {{ $value | quote | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+
 {{- /*
   jupyterhub.commonLabels:
     Foundation for "jupyterhub.labels".
@@ -118,6 +130,7 @@
 app: {{ .appLabel | default (include "jupyterhub.appLabel" .) }}
 release: {{ .Release.Name }}
 {{- if not .matchLabels }}
+{{- include "jupyterhub.determinedLabels" . }}
 chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 heritage: {{ .heritageLabel | default .Release.Service }}
 {{- end }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -20,6 +20,10 @@ imagePullSecret:
 # Helm chart's pods can get credentials from to pull their images.
 imagePullSecrets: []
 
+# labels enables an opportunity to add general labels to the created K8s objects,
+# e.g. DaemonSets or Deployments
+labels: {}
+
 # hub relates to the hub pod, responsible for running JupyterHub, its configured
 # Authenticator class KubeSpawner, and its configured Proxy class
 # ConfigurableHTTPProxy. KubeSpawner creates the user pods, and


### PR DESCRIPTION
Hi,
I was requested by a client to label all k8s objects of the Jupyterhub helm chart with additional, team specific informations.

Therefore I added a helper function called **jupyterhub.determinedLabels** to the _helpers.tpl, which extracts given labels from the values.yaml and appends them to the _commonLabels_.

As far as I see it, this solution overlaps with the pull request https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2948 .
As it reaches out not only for the Deployment-objects, but everything which gets labeled via _commonLabels_, I suppose it is more generic.