### PR TITLE
ci: fix for redirect to hub.jupyter.org

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -284,7 +284,7 @@ jobs:
         run: |
           . ./ci/common
           if [ ${{ matrix.upgrade-from }} = stable -o ${{ matrix.upgrade-from }} = dev ]; then
-            UPGRADE_FROM_VERSION=$(curl -sS https://jupyterhub.github.io/helm-chart/info.json | jq -er '.jupyterhub.${{ matrix.upgrade-from }}')
+            UPGRADE_FROM_VERSION=$(curl -sSL https://jupyterhub.github.io/helm-chart/info.json | jq -er '.jupyterhub.${{ matrix.upgrade-from }}')
           else
             UPGRADE_FROM_VERSION=${{ matrix.upgrade-from }}
           fi


### PR DESCRIPTION
See https://github.com/jupyterhub/team-compass/issues/444#issuecomment-1420350287.

Note that I don't want to update all links to hub.jupyter.org/helm-chart as part of this so that such change becomes consistent and something we discuss first.