### PR TITLE
Fix bugs related to installing chart multiple times in the same namespace

### DIFF
--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -90,7 +90,9 @@
     {{- /* A hack to avoid issues from invoking this from a parent Helm chart. */}}
     {{- $existing_secret := .Values.hub.existingSecret }}
     {{- if ne .Chart.Name "jupyterhub" }}
-        {{- $existing_secret = .Values.jupyterhub.hub.existingSecret }}
+        {{- if .Values.jupyterhub }}
+            {{- $existing_secret = .Values.jupyterhub.hub.existingSecret }}
+        {{- end }}
     {{- end }}
     {{- if $existing_secret }}
         {{- $existing_secret }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -35,13 +35,15 @@ metadata:
   {{- end }}
 spec:
   selector:
+    # This service will target the autohttps pod if autohttps is configured, and
+    # the proxy pod if not. When autohttps is configured, the service proxy-http
+    # will be around to target the proxy pod directly.
     {{- if $autoHTTPS }}
-    component: autohttps
+    {{- $_ := merge (dict "componentLabel" "autohttps") . -}}
+    {{- include "jupyterhub.matchLabels" $_ | nindent 4 }}
     {{- else }}
-    component: proxy
+    {{- include "jupyterhub.matchLabels" . | nindent 4 }}
     {{- end }}
-    release: {{ .Release.Name }}
-    app: {{ .appLabel | default (include "jupyterhub.appLabel" .) }}
   ports:
     {{- if $HTTPS }}
     - name: https

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -41,6 +41,7 @@ spec:
     component: proxy
     {{- end }}
     release: {{ .Release.Name }}
+    app: {{ .appLabel | default (include "jupyterhub.appLabel" .) }}
   ports:
     {{- if $HTTPS }}
     - name: https


### PR DESCRIPTION
## Goals
I wanna create multi-hub for many users.
I'm trying to use an alias for this, and found out that it is supported with following PR.
[fix: bug if z2jh is used as a dependency with an alias](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2310)

However, I found some problems with it, and made this PR to fix it.

## Environments
- jupyterhub version: 2.0.0
- app version: 3.0.0

## Problem 1 - existing-secret
Like this [PR](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2310), `existing-secret` should also be in the conditional statement.

## Problem 2 - proxy service selector
After solving Problem 1, I succeeded in creating two hubs (each have different urls in `ingress.hosts`)
There is a bug that when spawning through one url, it randomly spawns in another hub
When I spawn singleuser via one url, other hub spawns randomly.
To prevent this, a selector was added to the proxy.