### PR TITLE
Drop support for k8s 1.21

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -135,12 +135,12 @@ jobs:
             test: install
             local-chart-extra-args: >-
               --set hub.image.name=jupyterhub/k8s-hub-slim
-          - k3s-channel: v1.22 # also test prePuller.hook
+          - k3s-channel: v1.26 # also test prePuller.hook
             test: install
             local-chart-extra-args: >-
               --set prePuller.hook.enabled=true
               --set prePuller.hook.pullOnlyOnChanges=true
-          - k3s-channel: v1.21 # also test hub.existingSecret
+          - k3s-channel: v1.25 # also test hub.existingSecret
             test: install
             local-chart-extra-args: >-
               --set hub.existingSecret=test-hub-existing-secret
@@ -163,7 +163,7 @@ jobs:
           # information from
           # https://jupyterhub.github.io/helm-chart/info.json
           #
-          - k3s-channel: v1.23
+          - k3s-channel: v1.24
             test: upgrade
             upgrade-from: stable
             upgrade-from-extra-args: >-

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -12,7 +12,7 @@ and as we merge [breaking changes in pull
 requests](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking),
 this list should be updated.
 
-- K8s 1.21 is now required.
+- K8s 1.22 is now required.
 - The Helm chart's provided images now use Python 3.11 instead of Python 3.9.
 
 ## 2.0

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -7,12 +7,16 @@
 # This stage is building Python wheels for use in later stages by using a base
 # image that has more pre-requisites to do so, such as a C++ compiler.
 #
+# NOTE: If the image version is updated, also update it in ci/refreeze and
+#       singleuser-sample's Dockerfile!
+#
 FROM python:3.11-bullseye as build-stage
 
 # Build wheels
 #
 # We set pip's cache directory and expose it across build stages via an
-# ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}).
+# ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}). We use
+# the same technique for the directory /tmp/wheels.
 #
 COPY requirements.txt requirements.txt
 ARG PIP_CACHE_DIR=/tmp/pip-cache
@@ -56,7 +60,7 @@ RUN apt-get update \
         tini \
  && rm -rf /var/lib/apt/lists/*
 
-# install wheels built in the build-stage
+# install wheels built in the build stage
 COPY requirements.txt /tmp/requirements.txt
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -7,12 +7,16 @@
 # This stage is building Python wheels for use in later stages by using a base
 # image that has more pre-requisites to do so, such as a C++ compiler.
 #
+# NOTE: If the image version is updated, also update it in ci/refreeze and
+#       hub's Dockerfile!
+#
 FROM python:3.11-bullseye as build-stage
 
 # Build wheels
 #
 # We set pip's cache directory and expose it across build stages via an
-# ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}).
+# ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}). We use
+# the same technique for the directory /tmp/wheels.
 #
 COPY requirements.txt requirements.txt
 ARG PIP_CACHE_DIR=/tmp/pip-cache

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org
 sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
 icon: https://jupyterhub.github.io/helm-chart/images/hublogo.svg
-kubeVersion: ">=1.21.0-0"
+kubeVersion: ">=1.22.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team

--- a/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/rbac.yaml
@@ -19,9 +19,9 @@ rules:
   #       - unchanged between 1.18 and 1.20
   #       - changed in 1.21: get/list/watch permission for namespace,
   #                          csidrivers, csistoragecapacities was added.
-  #       - unchanged between 1.22 and 1.25
+  #       - unchanged between 1.22 and 1.26
   #
-  # ref: https://github.com/kubernetes/kubernetes/blob/v1.25.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L730-L886
+  # ref: https://github.com/kubernetes/kubernetes/blob/v1.26.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L730-L886
   - apiGroups:
     - ""
     - events.k8s.io
@@ -183,9 +183,9 @@ rules:
   # Copied from the system:volume-scheduler ClusterRole of the k8s version
   # matching the kube-scheduler binary we use.
   #
-  # NOTE: These rules have not changed between 1.12 and 1.25.
+  # NOTE: These rules have not changed between 1.12 and 1.26.
   #
-  # ref: https://github.com/kubernetes/kubernetes/blob/v1.25.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1305-L1332
+  # ref: https://github.com/kubernetes/kubernetes/blob/v1.26.0/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml#L1306-L1333
   - apiGroups:
     - ""
     resources:


### PR DESCRIPTION
- Closes #2979 as GKE/EKS/AKS has dropped support for k8s 1.21 now a bit earlier than March as previously declared.

I squeezed in a few smaller docs updates into this PR that could have been separate PRs. The linkcheck failure is unrelated and reported in https://github.com/jupyterhub/jupyterhub/issues/4376.