### PR TITLE
docs: Replace most permanent-redirects from linkcheck

### DIFF
--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -198,7 +198,7 @@ The narrower scope `read:user` is sufficient for a configuration of `allowed_org
 
 The broader scope `read:org` doesn't have the limitations of `read:user`, but will require a one-off approval by the admins of the GitHub organizations' listed in `allowed_organizations`. This kind of approval can be requested by organization users [as documented on GitHub](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/requesting-organization-approval-for-oauth-apps).
 
-For details about GitHub scopes, see [GitHub's documentation](https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps).
+For details about GitHub scopes, see [GitHub's documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps).
 ```
 
 #### Google
@@ -300,7 +300,7 @@ hub:
 
 #### Azure Active Directory
 
-[Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/)
+[Azure Active Directory](https://learn.microsoft.com/en-us/azure/active-directory/)
 is an identity provider from Microsoft Azure. Apart from needing a OAuth2
 _client id_ and _client secret_, you will also need a _tenant id_.
 

--- a/docs/source/administrator/upgrading/index.md
+++ b/docs/source/administrator/upgrading/index.md
@@ -11,7 +11,7 @@ then follow [](helm-upgrade-command).
 Major releases may contain breaking changes, and will often require changes to your configuration.
 They have dedicated instructions for upgrading your deployment in addition to the general instructions on this page.
 
-For additional help, feel free to reach out to us on [gitter](https://gitter.im/jupyterhub/jupyterhub)
+For additional help, feel free to reach out to us on [gitter](https://app.gitter.im/#/room/#jupyterhub_jupyterhub:gitter.im)
 or the [Discourse forum](https://discourse.jupyter.org/).
 
 (upgrading-major-upgrades)=
@@ -113,7 +113,7 @@ Update the configuration to use this new image, which is typically done via
 ## JupyterHub versions installed in each Helm Chart
 
 Each Helm Chart is packaged with a specific version of JupyterHub (and
-other software as well). See the [Helm Chart repository](https://jupyterhub.github.io/helm-chart/) for
+other software as well). See the [Helm Chart repository](https://hub.jupyter.org/helm-chart/) for
 information about the versions of relevant software packages.
 
 ## Troubleshooting

--- a/docs/source/jupyterhub/customizing/user-resources.md
+++ b/docs/source/jupyterhub/customizing/user-resources.md
@@ -95,7 +95,7 @@ provider. Here are a few links to help you get started:
 
 - [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus)
 - [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/blogs/compute/running-gpu-accelerated-kubernetes-workloads-on-p3-and-p2-ec2-instances-with-amazon-eks/)
-- [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/gpu-cluster)
+- [Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/gpu-cluster)
 
 You will also need to deploy the k8s-device-plugin following the instructions [here](https://github.com/NVIDIA/k8s-device-plugin#quick-start).
 

--- a/docs/source/kubernetes/amazon/step-zero-aws-eks.md
+++ b/docs/source/kubernetes/amazon/step-zero-aws-eks.md
@@ -89,4 +89,4 @@ This guide uses AWS to set up a cluster. This mirrors the steps found at [Gettin
 
 If you'd like to do some {ref}`optimizations <efficient-cluster-autoscaling>`, you need to deploy Cluster Autoscaler (CA) first.
 
-See <https://www.eksworkshop.com/beginner/080_scaling/deploy_ca/>
+See <https://archive.eksworkshop.com/beginner/080_scaling/deploy_ca/>

--- a/docs/source/kubernetes/google/step-zero-gcp.md
+++ b/docs/source/kubernetes/google/step-zero-gcp.md
@@ -5,7 +5,7 @@
 [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/)
 (GKE) is the simplest and most common way of setting
 up a Kubernetes Cluster. You may be able to receive [free credits](https://cloud.google.com/free/) for trying it out (though note that a
-free account [comes with limitations](https://cloud.google.com/free/docs/gcp-free-tier#free-tier-usage-limits)).
+free account [comes with limitations](https://cloud.google.com/free/docs/free-cloud-features#free-tier-usage-limits)).
 Either way, you will need to connect your credit card or other payment method to
 your google cloud account.
 
@@ -68,7 +68,7 @@ your google cloud account.
    - Replace `<CLUSTERNAME>` with a name that can be used to refer to this cluster
      in the future.
    - `--machine-type` specifies the amount of CPU and RAM in each node within
-     this default node pool. There is a [variety of types](https://cloud.google.com/compute/docs/machine-types) to choose from.
+     this default node pool. There is a [variety of types](https://cloud.google.com/compute/docs/machine-resource) to choose from.
    - `--num-nodes` specifies how many nodes to spin up. You can change this
      later through the cloud console or using the `gcloud` command line tool.
    - `--zone` specifies the data center zone where your cluster will be created.

--- a/docs/source/kubernetes/microsoft/step-zero-azure.md
+++ b/docs/source/kubernetes/microsoft/step-zero-azure.md
@@ -2,10 +2,10 @@
 
 # Kubernetes on Microsoft Azure Kubernetes Service (AKS)
 
-You can create a Kubernetes cluster [either through the Azure portal website, or using the Azure command line tools](https://docs.microsoft.com/en-us/azure/aks/).
+You can create a Kubernetes cluster [either through the Azure portal website, or using the Azure command line tools](https://learn.microsoft.com/en-us/azure/aks/).
 
 This page describes the commands required to setup a Kubernetes cluster using the command line.
-If you prefer to use the Azure portal see the [Azure Kubernetes Service quickstart](https://docs.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-portal).
+If you prefer to use the Azure portal see the [Azure Kubernetes Service quickstart](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-portal).
 
 1. Prepare your Azure shell environment. You have two options, one is to use
    the Azure interactive shell, the other is to install the Azure command-line
@@ -77,7 +77,7 @@ If you prefer to use the Azure portal see the [Azure Kubernetes Service quicksta
      `<RESOURCE-GROUP-NAME>` of `ucb_2018sp_data100_hub`.
    - `--location` specifies the location of the data center you want your resource to be in.
      In this case, we used the `centralus` location. For other options, see the
-     [Azure list of locations that support AKS](https://docs.microsoft.com/en-us/azure/aks/quotas-skus-regions#region-availability).
+     [Azure list of locations that support AKS](https://learn.microsoft.com/en-us/azure/aks/quotas-skus-regions#region-availability).
      Note that not all locations offer all VM sizes. To see a list of recommended locations, go to
      [Azure Portal > Virtual Machines](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2FVirtualMachines),
      click on "create.." and see the list of recommended locations in the drop down list for `Region`.
@@ -123,9 +123,9 @@ If you prefer to use the Azure portal see the [Azure Kubernetes Service quicksta
    Kubernetes does not by default come with a controller that enforces `networkpolicy` resources.
    `networkpolicy` resources are important as they define how Kubernetes pods can securely communicate with one another and the outside sources, for example, the internet.
 
-   To enable this in Azure, we must first create a [Virtual Network](https://docs.microsoft.com/en-gb/azure/virtual-network/virtual-networks-overview) with Azure's own network policies enabled.
+   To enable this in Azure, we must first create a [Virtual Network](https://learn.microsoft.com/en-gb/azure/virtual-network/virtual-networks-overview) with Azure's own network policies enabled.
 
-   This section of the documentation is following the Microsoft Azure tutorial on [creating an AKS cluster and enabling network policy](https://docs.microsoft.com/en-us/azure/aks/use-network-policies#create-an-aks-cluster-and-enable-network-policy), which includes information on using [Calico](https://projectcalico.docs.tigera.io/) network policies.
+   This section of the documentation is following the Microsoft Azure tutorial on [creating an AKS cluster and enabling network policy](https://learn.microsoft.com/en-us/azure/aks/use-network-policies#create-an-aks-cluster-and-enable-network-policy), which includes information on using [Calico](https://docs.tigera.io/) network policies.
 
    ```
    az network vnet create \
@@ -160,7 +160,7 @@ If you prefer to use the Azure portal see the [Azure Kubernetes Service quicksta
       --output tsv)
    ```
 
-   We will create an Azure Active Directory (Azure AD) [service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) for use with the cluster, and assign the [Contributor role](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) for use with the VNet.
+   We will create an Azure Active Directory (Azure AD) [service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals) for use with the cluster, and assign the [Contributor role](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor) for use with the VNet.
    Make sure `SERVICE-PRINCIPAL-NAME` is something recognisable, for example, `binderhub-sp`.
 
    ```
@@ -215,7 +215,7 @@ If you prefer to use the Azure portal see the [Azure Kubernetes Service quicksta
    - `--node-count` is the number of nodes you want in your Kubernetes cluster
    - `--node-vm-size` is the size of the nodes you want to use, which varies based on
      what you are using your cluster for and how much RAM/CPU each of your users need.
-     There is a [list of all possible node sizes](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs)
+     There is a [list of all possible node sizes](https://learn.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs)
      for you to choose from, but not all might be available in your location.
      If you get an error whilst creating the cluster you can try changing either the region or the node size.
    - `--service-principal` is the application ID of the service principal we created
@@ -354,4 +354,4 @@ RBAC is enabled by default when using the command line tools.
 Congrats. Now that you have your Kubernetes cluster running, it's time to
 begin {ref}`setup-helm`.
 
-[azure resource group]: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#resource-groups
+[azure resource group]: https://learn.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#resource-groups

--- a/docs/source/resources/glossary.md
+++ b/docs/source/resources/glossary.md
@@ -78,7 +78,7 @@ Kubernetes
     for that cloud.
 
     - [The Illustrated Children's Guide to Kubernetes](https://www.youtube.com/watch?v=4ht22ReBjno)
-    - [The official "What is Kubernetes?" text](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/)
+    - [The official "What is Kubernetes?" text](https://kubernetes.io/docs/concepts/overview/)
 
 Kubernetes API server
     The [Kubernetes API](https://kubernetes.io/docs/concepts/overview/kubernetes-api/) server,

--- a/docs/source/resources/reference-docs.md
+++ b/docs/source/resources/reference-docs.md
@@ -6,6 +6,6 @@
   provides information about JupyterHub itself (not the Kubernetes deployment).
 - [Binder](https://mybinder.org) allows users to create sharable computational
   environments on-the-fly. It makes heavy use of JupyterHub.
-- The [2016 JupyterHub Workshop](https://github.com/jupyter-resources/jupyterhub-2016-workshop)
+- The [2016 JupyterHub Workshop](https://github.com/jupyter/jupyterhub-2016-workshop)
   was an informal gathering to share experience in deploying JupyterHub for various
   use-cases, including teaching and high-performance computing.


### PR DESCRIPTION
Replaces most `redirect ... - permanently to` reports from linkcheck with the destination, except for those where the redirect appears to be context dependent (e.g. country specific), and for anything in the changelog