### PR TITLE
Use jupyterhub docs `stable` instead of `latest`

### DIFF
--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -39,10 +39,10 @@ authenticator class itself through this Helm chart's
 As all authenticator classes derive from the `Authenticator` base class, they
 share some configuration options. Below are some common configuration options,
 but please refer to the official [configuration
-reference](https://jupyterhub.readthedocs.io/en/latest/api/auth.html) for more
+reference](https://jupyterhub.readthedocs.io/en/stable/api/auth.html) for more
 details.
 
-### [allowed_users](https://jupyterhub.readthedocs.io/en/latest/api/auth.html#jupyterhub.auth.Authenticator.allowed_users) / [admin_users](https://jupyterhub.readthedocs.io/en/latest/api/auth.html#jupyterhub.auth.LocalAuthenticator.admin_users)
+### [allowed_users](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.allowed_users) / [admin_users](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.LocalAuthenticator.admin_users)
 
 Some authenticator classes may have dedicated logic in addition this this to
 authorize users.
@@ -70,7 +70,7 @@ In the above configuration, we have configured three things:
 2. anyone will be able to login with username `user1-4` and the password `a-shared-secret-password`
 3. `user1` and `user2` will have admin permissions, while `user3` and `user4` will be regular users.
 
-### [auto_login](https://jupyterhub.readthedocs.io/en/latest/api/auth.html#jupyterhub.auth.Authenticator.auto_login)
+### [auto_login](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.auto_login)
 
 If you have configured authentication with GitHub for example, the page
 `/hub/login` will feature a single orange button that users are to press to
@@ -84,7 +84,7 @@ hub:
       auto_login: true
 ```
 
-### [enable_auth_state](https://jupyterhub.readthedocs.io/en/latest/api/auth.html#jupyterhub.auth.Authenticator.enable_auth_state)
+### [enable_auth_state](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.enable_auth_state)
 
 If you want JupyterHub to persist often sensitive information received as part
 of logging in, you need to enable it.
@@ -97,7 +97,7 @@ hub:
 ```
 
 For more information about authentication state, see [JupyterHub's own
-documentation](https://jupyterhub.readthedocs.io/en/latest/reference/authenticators.html#authentication-state)
+documentation](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#authentication-state)
 about authentication state.
 
 ````{note}

--- a/docs/source/administrator/upgrading/upgrade-1-to-2.md
+++ b/docs/source/administrator/upgrading/upgrade-1-to-2.md
@@ -51,7 +51,7 @@ and the configuration reference entries under
 
 Z2JH 2.0.0 upgrades from JupyterHub 1 directly to JupyterHub 3, and also upgrades all hub components.
 If you are using any custom JupyterHub services, addons, API integrations, or extra configuration, you should review the breaking changes in the
-major releases of JupyterHub 2 and 3 in the [JupyterHub changelog](https://jupyterhub.readthedocs.io/en/latest/changelog.html).
+major releases of JupyterHub 2 and 3 in the [JupyterHub changelog](https://jupyterhub.readthedocs.io/en/stable/changelog.html).
 
 JupyterHub 2 and 3 updates the database schema, which means a migration takes place when you upgrade JupyterHub.
 Z2JH automatically handles the upgrade if you are using sqlite (`hub.db.type = 'sqlite-pvc'`, the default), but it may not be possible to downgrade to older releases after this.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -21,7 +21,7 @@ this list should be updated.
     images are upgraded as soon as practical, before or after the JupyterHub
     chart is upgraded. We expect running user servers to be able to keep running
     during the upgrade.
-  - Changelog available at https://jupyterhub.readthedocs.io/en/latest/changelog.html
+  - Changelog available at https://jupyterhub.readthedocs.io/en/stable/changelog.html
 
 ## 2.0
 

--- a/docs/source/resources/glossary.md
+++ b/docs/source/resources/glossary.md
@@ -16,7 +16,7 @@ details.
     A user who can access the JupyterHub admin panel. They can start/stop user
     pods, and potentially access their notebooks.
 
-[authenticator](https://jupyterhub.readthedocs.io/en/latest/reference/authenticators.html)
+[authenticator](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html)
     The way in which users are authenticated to log into JupyterHub. There
     are many authenticators available, like GitHub, Google, MediaWiki,
     Dummy (anyone can log in), etc.

--- a/docs/source/resources/reference-docs.md
+++ b/docs/source/resources/reference-docs.md
@@ -2,7 +2,7 @@
 
 # Related Projects
 
-- The [JupyterHub Documentation](https://jupyterhub.readthedocs.io/en/latest/)
+- The [JupyterHub Documentation](https://jupyterhub.readthedocs.io/en/stable/)
   provides information about JupyterHub itself (not the Kubernetes deployment).
 - [Binder](https://mybinder.org) allows users to create sharable computational
   environments on-the-fly. It makes heavy use of JupyterHub.

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -1329,7 +1329,7 @@ properties:
           permissions as defined in JupyterHub's RBAC system.
 
           Complement this documentation with [JupyterHub's
-          documentation](https://jupyterhub.readthedocs.io/en/latest/rbac/roles.html#defining-roles)
+          documentation](https://jupyterhub.readthedocs.io/en/stable/rbac/roles.html#defining-roles)
           about `load_roles`.
 
           Note that while JupyterHub's native configuration `load_roles` accepts


### PR DESCRIPTION
https://jupyterhub.readthedocs.io/en/stable/ should be the most recent release, whereas latest will include unreleased changes on the main branch

It'd be even nicer if we could use `{{jupyterhub_version}}` since Z2JH is tied to particular versions of JupyterHub but unfortunately we can't https://github.com/executablebooks/MyST-Parser/issues/279