### PR TITLE
Revert https://app.gitter.im/#/room/#jupyterhub_jupyterhub:gitter.im …

### DIFF
--- a/docs/source/administrator/upgrading/index.md
+++ b/docs/source/administrator/upgrading/index.md
@@ -11,7 +11,7 @@ then follow [](helm-upgrade-command).
 Major releases may contain breaking changes, and will often require changes to your configuration.
 They have dedicated instructions for upgrading your deployment in addition to the general instructions on this page.
 
-For additional help, feel free to reach out to us on [gitter](https://app.gitter.im/#/room/#jupyterhub_jupyterhub:gitter.im)
+For additional help, feel free to reach out to us on [gitter](https://gitter.im/jupyterhub/jupyterhub)
 or the [Discourse forum](https://discourse.jupyter.org/).
 
 (upgrading-major-upgrades)=


### PR DESCRIPTION
…redirect

https://gitter.im/jupyterhub/jupyterhub is a 301 permanent redirect to https://app.gitter.im/#/room/#jupyterhub_jupyterhub:gitter.im but the linkchecker can't handle the destination since it's client-side dynamic content:

`(administrator/upgrading/index: line   14) broken    https://app.gitter.im/#/room/#jupyterhub_jupyterhub:gitter.im - Anchor '/room/#jupyterhub_jupyterhub:gitter.im' not found`