### PR TITLE
satisfy flake8 in jupyterhub_config.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# Ignore style and complexity
+# E: style errors
+# W: style warnings
+# C: complexity
+# D: docstring warnings (unused pydocstyle extension)
+ignore = E, C, W, D

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,14 +69,6 @@ repos:
     rev: "6.0.0"
     hooks:
       - id: flake8
-        # Ignore style and complexity
-        # E: style errors
-        # W: style warnings
-        # C: complexity
-        #
-        args:
-          - --ignore=E,C,W
-          - --builtins=c
 
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration
 ci:

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -1,3 +1,6 @@
+# load the config object (satisfies linters)
+c = get_config()  # noqa
+
 import glob
 import os
 import re


### PR DESCRIPTION
there shouldn't be any lint config in pre-commit config, because then the same linters run via other means (e.g. editor plugins) will have different results.

Config is unchanged, except for trading the flake8 config to ignore `c` as a global in favor of defining c explicitly on a single `# noqa` line.