### PR TITLE
compile psycopg2 in hub image

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -55,6 +55,8 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         # requirement for pycurl
         libcurl4 \
+        # requirement for using postgres database
+        libpq5 \
         # requirement for using a local sqlite database
         sqlite3 \
         tini \

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -28,7 +28,7 @@ jupyterhub-kubespawner
 
 ## Other optional dependencies for additional features
 pymysql  # mysql
-psycopg2-binary  # postgres
+psycopg2  # postgres
 pycurl  # internal http requests handle more load with pycurl
 sqlalchemy-cockroachdb # cocroachdb
 statsd  # statsd metrics collection (TODO: remove soon, since folks use prometheus)

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -118,7 +118,7 @@ pamela==1.0.0
     # via jupyterhub
 prometheus-client==0.16.0
     # via jupyterhub
-psycopg2-binary==2.9.5
+psycopg2==2.9.5
     # via -r requirements.in
 pyasn1==0.4.8
     # via ldap3


### PR DESCRIPTION
psycopg2-binary is [not recommended for production](https://www.psycopg.org/docs/install.html#change-in-binary-packages-between-psycopg-2-7-and-2-8), so compile and link to the host libpq.

I expected to need `libpq-dev` in build, too, but apparently it's already in the non-slim base image for some reason.