### PR TITLE
ci: fix deprecation of set-output and use ubuntu 22.04 and py311

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,8 @@ jobs:
           ):
               publishing = "true"
               print("Publishing chart")
-          print(f"::set-output name=publishing::{publishing}")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"publishing={publishing}\n")
 
       - name: Set up QEMU (for docker buildx)
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,26 +46,20 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: store whether we are publishing the chart
+      - name: Decide to publish or not
         id: publishing
         shell: python
-        env:
-          REPO: ${{ github.repository }}
-          EVENT: ${{ github.event_name }}
-          REF: ${{ github.event.ref }}
         run: |
           import os
-          repo = os.environ["REPO"]
-          event = os.environ["EVENT"]
-          ref = os.environ["REF"]
+          repo = "${{ github.repository }}"
+          event = "${{ github.event_name }}"
+          ref = "${{ github.event.ref }}"
           publishing = ""
           if (
               repo == "jupyterhub/zero-to-jupyterhub-k8s"
               and event == "push"
               and (
-                  # any tag
                   ref.startswith("refs/tags/")
-                  # or default branch
                   or ref == "refs/heads/main"
               )
           ):

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
   # ref: https://hub.docker.com/orgs/jupyterhub
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.11"
 
       - name: Decide to publish or not
         id: publishing

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/support-bot.yml
+++ b/.github/workflows/support-bot.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   action:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: dessant/support-requests@v3
         with:

--- a/.github/workflows/test-docker-build.yaml
+++ b/.github/workflows/test-docker-build.yaml
@@ -29,7 +29,7 @@ jobs:
   # - https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/local-registry.md
   # - https://github.com/docker/build-push-action/blob/v2.3.0/docs/advanced/multi-platform.md
   build_images:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   linkcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/vuln-scan.yaml
+++ b/.github/workflows/vuln-scan.yaml
@@ -32,7 +32,7 @@ on:
 jobs:
   trivy_image_scan:
     if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: watch-dependencies
 
     strategy:

--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -32,7 +32,7 @@ jobs:
   update-image-dependencies:
     # Don't run this job on forks
     if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: watch-dependencies
 
     strategy:
@@ -202,7 +202,7 @@ jobs:
     # these dependencies every day is too much noise.
     #
     if: github.repository == 'jupyterhub/zero-to-jupyterhub-k8s' && github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: watch-dependencies
 
     steps:


### PR DESCRIPTION
- A deprecated `set-output` call was around apparently (https://github.com/jupyterhub/team-compass/issues/579)
- We used ubuntu-20.04, ubuntu-latest, and ubuntu-22.04, now ubuntu-22.04 systematically
- An small opionated refactoring of a script snippet