### PR TITLE
DOC: Fix invalid names in configuration examples

### DIFF
--- a/docs/source/administrator/optimization.md
+++ b/docs/source/administrator/optimization.md
@@ -164,7 +164,7 @@ singleuser:
 
 prePuller:
   extraImages:
-    myOtherImageIWantPulled:
+    my-other-image-i-want-pulled:
       name: jupyter/all-spark-notebook
       tag: 2343e33dec46
 ```

--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2776,7 +2776,7 @@ properties:
           ```yaml
           prePuller:
             extraImages:
-              myExtraImageIWantPulled:
+              my-extra-image-i-want-pulled:
                 name: jupyter/all-spark-notebook
                 tag: 2343e33dec46
           ```


### PR DESCRIPTION
The example names in `prePuller.extraImages` in the examples [1](https://z2jh.jupyter.org/en/latest/resources/reference.html#prepuller-extraimages) and [2](https://z2jh.jupyter.org/en/latest/administrator/optimization.html#additional-sources) are invalid. When using them the following error occurs:

```output
Error: UPGRADE FAILED: pre-upgrade hooks failed: warning:
Hook pre-upgrade jupyterhub/templates/image-puller/daemonset-hook.yaml failed:
DaemonSet.apps "hook-image-puller" is invalid: spec.template.spec.initContainers[2].name:
Invalid value: "image-pull-myExtraImageIWantPulled":
a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-',
and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc',
regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```

This PR fixes both examples.