### PR TITLE
Replace IEC prefixes link

### DIFF
--- a/docs/source/jupyterhub/customizing/user-storage.md
+++ b/docs/source/jupyterhub/customizing/user-storage.md
@@ -183,7 +183,7 @@ singleuser:
 This will request a `2Gi` volume per user. The default requests a `10Gi`
 volume per user.
 
-We recommend you use the [IEC Prefixes](https://physics.nist.gov/cuu/Units/binary.html)
+We recommend you use the [IEC Prefixes](https://en.wikipedia.org/wiki/Binary_prefix#Adoption_by_IEC,_NIST_and_ISO)
 (Ki, Mi, Gi, etc) for specifying how much storage you want. `2Gi` (IEC Prefix) is
 `(2 * 1024 * 1024 * 1024)` bytes, while `2G` (SI Prefix) is `(2 * 1000 * 1000 * 1000)` bytes.
 


### PR DESCRIPTION
The old URL intermittently fails the linkcheck