### PR TITLE
doc: singleuser.uid default is always 1000

### DIFF
--- a/jupyterhub/schema.yaml
+++ b/jupyterhub/schema.yaml
@@ -2343,6 +2343,8 @@ properties:
           root, enabling it from the container in a startup script, and then
           transitioning to the normal user.
 
+          Default is 1000, set to null to use the container's default.
+
   scheduling:
     type: object
     additionalProperties: false


### PR DESCRIPTION
The `singleuser.uid` documentation refers to https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.uid which says
> If set to None, the user specified with the USER directive in the container metadata is used.

In Z2JH the UID always defaults to 1000.

Alternatively, could we unset
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/26fb33da64b4914a192e37e03156eb0f9e72d863/jupyterhub/values.yaml#L367
so it uses the image's default?