### PR TITLE
Bump to 3.0.0dev

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -13,7 +13,7 @@ charts:
     # Dev: imagePrefix can be useful to override if you want to trial something
     #      locally developed in a remote k8s cluster.
     imagePrefix: jupyterhub/k8s-
-    baseVersion: "2.0.1-0.dev"
+    baseVersion: "3.0.0-0.dev"
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart


### PR DESCRIPTION
We're already on JupyterHub 4.x, so this 
makes sense from a semver perspective. Useful
in generating better versions in https://hub.jupyter.org/helm-chart/.

Credit to @pnasrat for pointing this out.