### PR TITLE
refactor: rename schema.yaml to values.schema.yaml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: build chart with chartpress
         run: |
-          # Create values.schema.yaml from schema.yaml.
+          # Create values.schema.json from values.schema.yaml.
           ./tools/generate-json-schema.py
 
           # Append annotations to Chart.yaml with current images so that

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -252,8 +252,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: "1"
 
-      # Generate values.schema.json from schema.yaml
-      - name: Generate values.schema.json from schema.yaml
+      - name: Generate values.schema.json from values.schema.yaml
         run: |
           tools/generate-json-schema.py
 

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -9,12 +9,12 @@ on:
   pull_request:
     paths:
       - "docs/**"
-      - "**/schema.yaml"
+      - "**/values.schema.yaml"
       - "**/test-docs.yaml"
   push:
     paths:
       - "docs/**"
-      - "**/schema.yaml"
+      - "**/values.schema.yaml"
       - "**/test-docs.yaml"
     branches-ignore:
       - "dependabot/**"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -27,7 +27,7 @@ help:
 # - builds and rebuilds html on changes to source
 # - starts a livereload enabled webserver and opens up a browser
 devenv:
-	sphinx-autobuild -b html --open-browser --ignore "*/reference.md" --watch "../jupyterhub/schema.yaml" "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS)
+	sphinx-autobuild -b html --open-browser --ignore "*/reference.md" --watch "../jupyterhub/values.schema.yaml" "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS)
 
 # For local development and CI:
 # - verifies that links are valid

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -39,7 +39,7 @@ if errorlevel 9009 (
 	echo.The 'sphinx-autobuild' command was not found. Open and read README.md!
 	exit /b 1
 )
-sphinx-autobuild -b html --open-browser --ignore "*/reference.md" --watch "../jupyterhub/schema.yaml" "%SOURCEDIR%" "%BUILDDIR%/html" %SPHINXOPTS%
+sphinx-autobuild -b html --open-browser --ignore "*/reference.md" --watch "../jupyterhub/values.schema.yaml" "%SOURCEDIR%" "%BUILDDIR%/html" %SPHINXOPTS%
 goto end
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,14 +89,14 @@ header_md = header_md[1:]
 header_md = [ln.strip("\n") for ln in header_md]
 
 # schema
-with open("../../jupyterhub/schema.yaml") as f:
+with open("../../jupyterhub/values.schema.yaml") as f:
     data = yaml.safe_load(f)
 
 
 def parse_schema(d, md=[], depth=0, pre=""):
     """
     Generate markdown headers from a passed python dictionary created by
-    parsing a schema.yaml file.
+    parsing a values.schema.yaml file.
     """
     if "then" in d:
         d = d["then"]

--- a/jupyterhub/.helmignore
+++ b/jupyterhub/.helmignore
@@ -6,7 +6,7 @@
 #
 # Here are files that we intentionally ignore to avoid them being packaged,
 # because we don't want to reference them from our templates anyhow.
-schema.yaml
+values.schema.yaml
 
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -3,8 +3,8 @@
     parent charts to reference these dynamic resource names.
 
     To avoid duplicating documentation, for more information, please see the the
-    fullnameOverride entry in schema.yaml or the configuration reference that
-    schema.yaml renders to.
+    fullnameOverride entry in values.schema.yaml or the configuration reference
+    that values.schema.yaml renders to.
 
     https://z2jh.jupyter.org/en/latest/resources/reference.html#fullnameOverride
 */}}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1,6 +1,6 @@
 # This schema (a jsonschema in YAML format) is used to generate
 # values.schema.json which is packaged with the Helm chart for client side
-# validation by Helm of values before template rendering.
+# validation by helm of values before template rendering.
 #
 # This schema is also used by our documentation system to build the
 # configuration reference section based on the description fields. See

--- a/tools/compare-values-schema-content.py
+++ b/tools/compare-values-schema-content.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-This script is meant to help compare the entries in schema.yaml with the entries
-in values.yaml and lint-and-validate-values.yaml.
+This script is meant to help compare the entries in values.schema.yaml with the
+entries in values.yaml and lint-and-validate-values.yaml.
 
 Running this script can result in output like:
 
-    schema.yaml entries not found in values.yaml:
+    values.schema.yaml entries not found in values.yaml:
     - hub.deploymentStrategy.rollingUpdate
     - hub.fsGid
     - rbac.enabled
@@ -17,7 +17,7 @@ from collections.abc import MutableMapping
 import yaml
 
 here_dir = os.path.abspath(os.path.dirname(__file__))
-schema_yaml = os.path.join(here_dir, os.pardir, "jupyterhub", "schema.yaml")
+schema_yaml = os.path.join(here_dir, os.pardir, "jupyterhub", "values.schema.yaml")
 values_yaml = os.path.join(here_dir, os.pardir, "jupyterhub", "values.yaml")
 lint_values_yaml = os.path.join(here_dir, "templates", "lint-and-validate-values.yaml")
 
@@ -96,7 +96,7 @@ def run():
 
     schema_values_diff = get_schema_values_diff(values_yaml, schema, schema_wildcards)
     if schema_values_diff:
-        print("schema.yaml entries not found in values.yaml:")
+        print("values.schema.yaml entries not found in values.yaml:")
         for l in sorted(schema_values_diff):
             print(f"- {l}")
 
@@ -104,7 +104,7 @@ def run():
         lint_values_yaml, schema, schema_wildcards
     )
     if lint_schema_values_diff:
-        print("schema.yaml entries not found in lint-and-validate-values.yaml:"),
+        print("values.schema.yaml entries not found in lint-and-validate-values.yaml:"),
         for l in sorted(lint_schema_values_diff):
             print(f"- {l}")
 

--- a/tools/generate-json-schema.py
+++ b/tools/generate-json-schema.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-This script reads schema.yaml and generates a values.schema.json that we can
-package with the Helm chart, allowing helm the CLI perform validation.
+This script reads values.schema.yaml and generates a values.schema.json that we
+can package with the Helm chart, allowing helm the CLI perform validation.
 
-While we can directly generate a values.schema.json from schema.yaml, it
+While we can directly generate a values.schema.json from values.schema.yaml, it
 contains a lot of description text we use to generate our configuration
 reference that isn't helpful to ship along the validation schema. Due to that,
 we trim away everything that isn't needed.
@@ -16,7 +16,7 @@ from collections.abc import MutableMapping
 import yaml
 
 here_dir = os.path.abspath(os.path.dirname(__file__))
-schema_yaml = os.path.join(here_dir, os.pardir, "jupyterhub", "schema.yaml")
+schema_yaml = os.path.join(here_dir, os.pardir, "jupyterhub", "values.schema.yaml")
 values_schema_json = os.path.join(
     here_dir, os.pardir, "jupyterhub", "values.schema.json"
 )

--- a/tools/validate-against-schema.py
+++ b/tools/validate-against-schema.py
@@ -5,7 +5,7 @@ import jsonschema
 import yaml
 
 here_dir = os.path.abspath(os.path.dirname(__file__))
-schema_yaml = os.path.join(here_dir, os.pardir, "jupyterhub", "schema.yaml")
+schema_yaml = os.path.join(here_dir, os.pardir, "jupyterhub", "values.schema.yaml")
 values_yaml = os.path.join(here_dir, os.pardir, "jupyterhub", "values.yaml")
 lint_and_validate_values_yaml = os.path.join(
     here_dir, "templates", "lint-and-validate-values.yaml"
@@ -19,12 +19,12 @@ with open(lint_and_validate_values_yaml) as f:
     lint_and_validate_values = yaml.safe_load(f)
 
 # Validate values.yaml against schema
-print("Validating values.yaml against schema.yaml...")
+print("Validating values.yaml against values.schema.yaml...")
 jsonschema.validate(values, schema)
 print("OK!")
 print()
 
 # Validate lint-and-validate-values.yaml against schema
-print("Validating lint-and-validate-values.yaml against schema.yaml...")
+print("Validating lint-and-validate-values.yaml against values.schema.yaml...")
 jsonschema.validate(lint_and_validate_values, schema)
 print("OK!")


### PR DESCRIPTION
We generate a file called `values.schema.json` from the `.yaml` equivalent file, so naming it like this seemed a bit more self-explanatory. This is a pure refactoring PR without any change in behavior.