### PR TITLE
Drop support for k8s 1.22

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -131,16 +131,13 @@ jobs:
         include:
           - k3s-channel: latest
             test: install
-          - k3s-channel: stable # also test hub-slim
+          - k3s-channel: stable # also test hub-slim, and prePuller.hook
             test: install
             local-chart-extra-args: >-
               --set hub.image.name=jupyterhub/k8s-hub-slim
-          - k3s-channel: v1.26 # also test prePuller.hook
-            test: install
-            local-chart-extra-args: >-
               --set prePuller.hook.enabled=true
               --set prePuller.hook.pullOnlyOnChanges=true
-          - k3s-channel: v1.25 # also test hub.existingSecret
+          - k3s-channel: v1.26 # also test hub.existingSecret
             test: install
             local-chart-extra-args: >-
               --set hub.existingSecret=test-hub-existing-secret
@@ -153,7 +150,7 @@ jobs:
           # Helm chart version and then upgrade to the version we are now
           # testing:
           # - latest stable version (like 1.2.3)
-          # - latest dev version (like 1.2.3-n012.h1234abc),
+          # - latest dev version (like 1.2.3-0.dev.git.5810.hf475e7a4),
           # - and an old version that requires a JupyterHub DB upgrade
           #
           # It can be very useful to see the "Helm diff" step's output from the
@@ -163,7 +160,7 @@ jobs:
           # information from
           # https://jupyterhub.github.io/helm-chart/info.json
           #
-          - k3s-channel: v1.24
+          - k3s-channel: v1.25
             test: upgrade
             upgrade-from: stable
             upgrade-from-extra-args: >-
@@ -176,7 +173,7 @@ jobs:
               --set hub.db.type=sqlite-pvc
               --set singleuser.storage.type=dynamic
             create-k8s-test-resources: true
-          - k3s-channel: v1.23
+          - k3s-channel: v1.24
             test: upgrade
             upgrade-from: dev
             upgrade-from-extra-args: >-
@@ -186,7 +183,7 @@ jobs:
             local-chart-extra-args: >-
               --set hub.db.type=sqlite-pvc
               --set singleuser.storage.type=dynamic
-          - k3s-channel: v1.22
+          - k3s-channel: v1.23
             test: upgrade
             # We're testing hub.db.upgrade with PostgreSQL so this version must be old
             # enough to require a DB upgrade

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -12,9 +12,9 @@ and as we merge [breaking changes in pull
 requests](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking),
 this list should be updated.
 
-- K8s 1.22 is now required.
+- K8s 1.23 is now required.
 - The Helm chart's provided images now use Python 3.11 instead of Python 3.9.
-- JupyterHub 3.0.0 is upgraded to 4.0.0b1.
+- JupyterHub 3.0.0 is upgraded to 4.0.0b2.
   - Although it is not officially supported to run a JupyterHub server with a
     major version different from the singleuser servers' `jupyterhub-singleuser`
     version, it seems possible during this upgrade. We recommend your singleuser

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org
 sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
 icon: https://jupyterhub.github.io/helm-chart/images/hublogo.svg
-kubeVersion: ">=1.22.0-0"
+kubeVersion: ">=1.23.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team


### PR DESCRIPTION
Ready to be merged!

- Closes #3040 

Note that the `kubeVersion` constraint we declare in Chart.yaml doesn't stop a chart depending on the jupyterhub chart to be installed - only the chart directly installed's `kubeVersion` constraints are respected.