### PR TITLE
Helm chart url has changed

### DIFF
--- a/docs/source/jupyterhub/installation.md
+++ b/docs/source/jupyterhub/installation.md
@@ -44,11 +44,11 @@ can try with `nano config.yaml`.
 
 ## Install JupyterHub
 
-1. Make Helm aware of the [JupyterHub Helm chart repository](https://jupyterhub.github.io/helm-chart/) so you can install the
+1. Make Helm aware of the [JupyterHub Helm chart repository](https://hub.jupyter.org/helm-chart/) so you can install the
    JupyterHub chart from it without having to use a long URL name.
 
    ```
-   helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+   helm repo add jupyterhub https://hub.jupyter.org/helm-chart/
    helm repo update
    ```
 


### PR DESCRIPTION
Relying on clients to follow a redirect may not be robust.

https://discourse.jupyter.org/t/helm-chart-certificate-x509-error-when-deploying-on-eks-using-aws-cdk/19524