### PR TITLE
Adding support for extraManifests for the chart

### DIFF
--- a/jupyterhub/templates/extraManifests.yaml
+++ b/jupyterhub/templates/extraManifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2926,7 +2926,7 @@ properties:
           deprecation message that contain censored content that you wish to
           reveal.
 
-  extraObjects: 
+  extraObjects:
     type: array
     description: |
       Any additional K8s manifests to deploy with the chart

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2925,3 +2925,8 @@ properties:
           A flag that should only be set to true temporarily when experiencing a
           deprecation message that contain censored content that you wish to
           reveal.
+
+  extraObjects: 
+    type: array
+    description: |
+      Any additional K8s manifests to deploy with the chart

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -662,23 +662,23 @@ global:
 
 # -- Array of extra K8s manifests to deploy
 extraObjects: []
-  # example: 
-    # - apiVersion: secrets-store.csi.x-k8s.io/v1
-    #   kind: SecretProviderClass
-    #   metadata:
-    #     name: singleuser-hub-secrets-store
-    #   spec:
-    #     provider: aws
-    #     parameters:
-    #       objects: |
-    #         - objectName: "singleuser-secret"
-    #           objectType: "secretsmanager"
-    #           jmesPath:
-    #               - path: "somevar"
-    #                 objectAlias: "somevalue"
-    #     secretObjects:
-    #     - data:
-    #       - key: somevalue
-    #         objectName: somevalue
-    #       secretName: singleuser-secret
-    #       type: Opaque
+  # example:
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: singleuser-hub-secrets-store
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "singleuser-secret"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "somevar"
+  #                 objectAlias: "somevalue"
+  #     secretObjects:
+  #     - data:
+  #       - key: somevalue
+  #         objectName: somevalue
+  #       secretName: singleuser-secret
+  #       type: Opaque

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -659,3 +659,26 @@ debug:
 
 global:
   safeToShowValues: false
+
+# -- Array of extra K8s manifests to deploy
+extraObjects: []
+  # example: 
+    # - apiVersion: secrets-store.csi.x-k8s.io/v1
+    #   kind: SecretProviderClass
+    #   metadata:
+    #     name: singleuser-hub-secrets-store
+    #   spec:
+    #     provider: aws
+    #     parameters:
+    #       objects: |
+    #         - objectName: "singleuser-secret"
+    #           objectType: "secretsmanager"
+    #           jmesPath:
+    #               - path: "somevar"
+    #                 objectAlias: "somevalue"
+    #     secretObjects:
+    #     - data:
+    #       - key: somevalue
+    #         objectName: somevalue
+    #       secretName: singleuser-secret
+    #       type: Opaque


### PR DESCRIPTION
Adding an additional feature to support `extraManifests`, which allows end-users to deploy any additional k8s resources that they may want to manage along with the helm chart deployment. 

Some of the really common use-cases include creating a secret (or secretProviderClass) which the users might be passing on to the hub, or a configmap creation which might then be used with `extraVolume`, or anything else for that matter.