### PR TITLE
Update changelog for 3.0.0-beta.1

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -158,7 +158,7 @@ jobs:
           #
           # The upgrade-from input should be a chart version, or match the version
           # information from
-          # https://jupyterhub.github.io/helm-chart/info.json
+          # https://hub.jupyter.org/helm-chart/info.json
           #
           - k3s-channel: v1.25
             test: upgrade
@@ -239,7 +239,7 @@ jobs:
       # reach the ACME client in our autohttps pod.
       - name: Install local ACME server
         run: |
-          helm install pebble --repo https://jupyterhub.github.io/helm-chart/ pebble --values dev-config-pebble.yaml
+          helm install pebble --repo https://hub.jupyter.org/helm-chart/ pebble --values dev-config-pebble.yaml
 
       # Build our images if needed and update values.yaml with the tags
       - name: Install and run chartpress
@@ -280,7 +280,7 @@ jobs:
         run: |
           . ./ci/common
           if [ ${{ matrix.upgrade-from }} = stable -o ${{ matrix.upgrade-from }} = dev ]; then
-            UPGRADE_FROM_VERSION=$(curl -sSL https://jupyterhub.github.io/helm-chart/info.json | jq -er '.jupyterhub.${{ matrix.upgrade-from }}')
+            UPGRADE_FROM_VERSION=$(curl -sSL https://hub.jupyter.org/helm-chart/info.json | jq -er '.jupyterhub.${{ matrix.upgrade-from }}')
           else
             UPGRADE_FROM_VERSION=${{ matrix.upgrade-from }}
           fi
@@ -294,7 +294,7 @@ jobs:
           #
           #        https://github.com/helm/helm/issues/9244
           cd ci
-          helm install jupyterhub --repo https://jupyterhub.github.io/helm-chart/ jupyterhub --values ../dev-config.yaml --version=$UPGRADE_FROM_VERSION ${{ matrix.upgrade-from-extra-args }}
+          helm install jupyterhub --repo https://hub.jupyter.org/helm-chart/ jupyterhub --values ../dev-config.yaml --version=$UPGRADE_FROM_VERSION ${{ matrix.upgrade-from-extra-args }}
 
       - name: "(Upgrade) Install helm diff"
         if: matrix.test == 'upgrade'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ For more information, see
 **Install Pebble**
 
 ```shell
-helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+helm repo add jupyterhub https://hub.jupyter.org/helm-chart/
 helm repo update
 helm upgrade --install pebble jupyterhub/pebble --cleanup-on-fail --values dev-config-pebble.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Documentation build status](https://img.shields.io/readthedocs/zero-to-jupyterhub?logo=read-the-docs)](https://zero-to-jupyterhub.readthedocs.io/en/latest/?badge=latest)
 [![GitHub Workflow Status - Test](https://img.shields.io/github/actions/workflow/status/jupyterhub/zero-to-jupyterhub-k8s/test-chart.yaml?logo=github&label=tests)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions)
 [![GitHub Workflow Status - Vuln. scan](https://img.shields.io/github/actions/workflow/status/jupyterhub/zero-to-jupyterhub-k8s/vuln-scan.yaml?logo=github&label=Vuln.%20scan)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions)
-[![Latest stable release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=stable&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.stable&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#jupyterhub)
-[![Latest pre-release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=pre&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.pre&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
-[![Latest development release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=dev&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.latest&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
+[![Latest stable release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=stable&url=https://hub.jupyter.org/helm-chart/info.json&query=$.jupyterhub.stable&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#jupyterhub)
+[![Latest pre-release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=pre&url=https://hub.jupyter.org/helm-chart/info.json&query=$.jupyterhub.pre&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
+[![Latest development release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=dev&url=https://hub.jupyter.org/helm-chart/info.json&query=$.jupyterhub.latest&colorB=orange&logo=helm)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
 <br/>
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues)
 [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub/z2jh-k8s)

--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -13,7 +13,7 @@ Before configuring this, you should have [setup HTTPS](https).
 
 ### Authenticator classes
 
-Z2JH defaults to a [DummyAuthenticator](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.DummyAuthenticator)
+Z2JH defaults to a [DummyAuthenticator](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.DummyAuthenticator)
 that allows anyone to login with any username and password.
 This should only be used for testing purposes.
 
@@ -39,10 +39,10 @@ authenticator class itself through this Helm chart's
 As all authenticator classes derive from the `Authenticator` base class, they
 share some configuration options. Below are some common configuration options,
 but please refer to the official [configuration
-reference](https://jupyterhub.readthedocs.io/en/stable/api/auth.html) for more
+reference](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html) for more
 details.
 
-### [allowed_users](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.allowed_users) / [admin_users](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.LocalAuthenticator.admin_users)
+### [allowed_users](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.Authenticator.allowed_users) / [admin_users](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.LocalAuthenticator.admin_users)
 
 Some authenticator classes may have dedicated logic in addition this this to
 authorize users.
@@ -70,7 +70,7 @@ In the above configuration, we have configured three things:
 2. anyone will be able to login with username `user1-4` and the password `a-shared-secret-password`
 3. `user1` and `user2` will have admin permissions, while `user3` and `user4` will be regular users.
 
-### [auto_login](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.auto_login)
+### [auto_login](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.Authenticator.auto_login)
 
 If you have configured authentication with GitHub for example, the page
 `/hub/login` will feature a single orange button that users are to press to
@@ -84,7 +84,7 @@ hub:
       auto_login: true
 ```
 
-### [enable_auth_state](https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.enable_auth_state)
+### [enable_auth_state](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.Authenticator.enable_auth_state)
 
 If you want JupyterHub to persist often sensitive information received as part
 of logging in, you need to enable it.
@@ -343,7 +343,7 @@ hub:
 
 [OpenID Connect](https://openid.net/connect) is an identity layer on top of the
 OAuth 2.0 protocol, implemented by [various servers and
-services](https://openid.net/developers/certified/#OPServices). While OpenID
+services](https://openid.net/certified-open-id-developer-tools/). While OpenID
 Connect endpoint discovery is not supported by oauthentiator, you can still
 configure JupyterHub to authenticate with OpenID Connect providers by specifying
 all endpoints in the GenericOAuthenticator class.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -14,11 +14,10 @@ this list should be updated.
 
 ## 3.0
 
-### 3.0.0-alpha.1 - 2023-06-04
+### 3.0.0-beta.1 - 2023-06-12
 
-This is an alpha release as additional breaking changes are still planned, see
-[this issue](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3091)
-for details.
+This is a beta release for testing before the 3.0.0 release, no further changes
+are planned.
 
 #### Breaking changes
 
@@ -35,25 +34,21 @@ for details.
     configure `KubeSpawner.environment`, and to configure
     [`singleuser.profileList`](schema_singleuser.profileList) is to configure
     `KubeSpawner.profile_list`.
-- OAuthenticator 15.1.0 _will be_ upgraded to 16.0.0, _but isn't yet in the alpha.1 release_
-  - If you are using an JupyterHub Authenticator class from this package, please
-    read to the [OAuthenticator changelog]'s breaking changes.
 - TmpAuthenticator 0.6 is upgraded to 1.0.0
   - If you are using this JupyterHub Authenticator class, please read to the
     [TmpAuthenticator changelog]'s breaking changes.
 
 [jupyterhub changelog]: https://jupyterhub.readthedocs.io/en/stable/changelog.html
 [kubespawner changelog]: https://jupyterhub-kubespawner.readthedocs.io/en/latest/changelog.html
-[oauthenticator changelog]: https://jupyterhub-kubespawner.readthedocs.io/en/latest/changelog.html
 [tmpauthenticator changelog]: https://jupyterhub-kubespawner.readthedocs.io/en/latest/changelog.html
 
 #### Notable dependencies updated
 
 | Dependency                                                                       | Version in 2.0.0 | Version in 3.0.0 | Changelog link                                                                            | Note                               |
 | -------------------------------------------------------------------------------- | ---------------- | ---------------- | ----------------------------------------------------------------------------------------- | ---------------------------------- |
-| [jupyterhub](https://github.com/jupyterhub/jupyterhub)                           | 3.0.0            | 4.0.0            | [Changelog](https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html)         | Run in the `hub` pod               |
+| [jupyterhub](https://github.com/jupyterhub/jupyterhub)                           | 3.0.0            | 4.0.1            | [Changelog](https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html)         | Run in the `hub` pod               |
 | [kubespawner](https://github.com/jupyterhub/kubespawner)                         | 4.2.0            | 6.0.0            | [Changelog](https://jupyterhub-kubespawner.readthedocs.io/en/latest/changelog.html)       | Run in the `hub` pod               |
-| [oauthenticator](https://github.com/jupyterhub/oauthenticator)                   | 15.1.0           | 15.1.0 (16 soon) | [Changelog](https://oauthenticator.readthedocs.io/en/latest/reference/changelog.html)     | Run in the `hub` pod               |
+| [oauthenticator](https://github.com/jupyterhub/oauthenticator)                   | 15.1.0           | 15.1.0           | [Changelog](https://oauthenticator.readthedocs.io/en/latest/reference/changelog.html)     | Run in the `hub` pod               |
 | [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)             | 1.3.2            | 1.3.2            | [Changelog](https://github.com/jupyterhub/ldapauthenticator/blob/HEAD/CHANGELOG.md)       | Run in the `hub` pod               |
 | [ltiauthenticator](https://github.com/jupyterhub/ltiauthenticator)               | 1.2.0            | 1.5.1            | [Changelog](https://github.com/jupyterhub/ltiauthenticator/blob/HEAD/CHANGELOG.md)        | Run in the `hub` pod               |
 | [nativeauthenticator](https://github.com/jupyterhub/nativeauthenticator)         | 1.1.0            | 1.2.1            | [Changelog](https://github.com/jupyterhub/nativeauthenticator/blob/HEAD/CHANGELOG.md)     | Run in the `hub` pod               |
@@ -98,6 +93,7 @@ For a detailed list of Python dependencies in the `hub` Pod's Docker image, insp
 
 - Helm chart url has changed [#3122](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3122) ([@manics](https://github.com/manics))
 - Remove double word cluster in installation.md [#3119](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3119) ([@cbowman0](https://github.com/cbowman0))
+- Clarify `hub.config` can configure KubeSpawner and more [#3104](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3104) ([@JunaidChaudry](https://github.com/JunaidChaudry))
 - docs: fix readme badge for tests [#3094](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3094) ([@consideRatio](https://github.com/consideRatio))
 - doc: singleuser.uid default is always 1000 [#3079](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3079) ([@manics](https://github.com/manics))
 - Replace IEC prefixes link [#3073](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3073) ([@manics](https://github.com/manics))

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -7,7 +7,7 @@ Here you can find upgrade changes in between releases and upgrade instructions.
 ## Unreleased breaking changes
 
 This Helm chart provides [development
-releases](https://jupyterhub.github.io/helm-chart/#development-releases-jupyterhub),
+releases](https://hub.jupyter.org/helm-chart/#development-releases-jupyterhub),
 and as we merge [breaking changes in pull
 requests](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking),
 this list should be updated.
@@ -2392,7 +2392,7 @@ Helm cannot upgrade from the labelling scheme in 0.6 to that in 0.7 without `--f
 RELEASE_NAME=<YOUR-RELEASE-NAME>
 NAMESPACE=<YOUR-NAMESPACE>
 
-helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
+helm repo add jupyterhub https://hub.jupyter.org/helm-chart/
 helm repo update
 
 # NOTE: We need the --force flag to allow recreation of resources that can't be
@@ -3182,7 +3182,7 @@ but this is a good start!
 
 ##### Better Azure support
 
-Azure's new managed Kubernetes service ([AKS](https://docs.microsoft.com/en-us/azure/aks/)) is much
+Azure's new managed Kubernetes service ([AKS](https://learn.microsoft.com/en-us/azure/aks/)) is much
 better supported by this version!
 
 - We have much better documentation on using z2jh with Azure!
@@ -3279,7 +3279,7 @@ In alphabetical order,
 
 ## 0.5
 
-### 0.5 - [Hamid Hassan](https://www.espncricinfo.com/player/hamid-hassan-311427) - 2017-12-05
+### 0.5 - [Hamid Hassan](https://www.espncricinfo.com/cricketers/hamid-hassan-311427) - 2017-12-05
 
 JupyterHub 0.8, HTTPS & scalability.
 

--- a/docs/source/jupyterhub/customizing/user-management.md
+++ b/docs/source/jupyterhub/customizing/user-management.md
@@ -84,7 +84,7 @@ are being used as expected.
 ## Admin Users
 
 JupyterHub has the concept of
-[admin users](https://jupyterhub.readthedocs.io/en/stable/getting-started/authenticators-users-basics.html#configure-admins-admin-users)
+[admin users](https://jupyterhub.readthedocs.io/en/stable/tutorial/getting-started/authenticators-users-basics.html#configure-admins-admin-users)
 who have special rights. They can start / stop other user's servers, and
 optionally access user's notebooks. They will see a new **Admin** button in
 their Control Panel which will take them to an **Admin Panel** where they can

--- a/docs/source/jupyterhub/installation.md
+++ b/docs/source/jupyterhub/installation.md
@@ -35,7 +35,7 @@ just create a `config.yaml` file with some helpful comments.
 # Introduction to YAML:     https://www.youtube.com/watch?v=cdLNKUoMc6c
 # Chart config reference:   https://zero-to-jupyterhub.readthedocs.io/en/stable/resources/reference.html
 # Chart default values:     https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/HEAD/jupyterhub/values.yaml
-# Available chart versions: https://jupyterhub.github.io/helm-chart/
+# Available chart versions: https://hub.jupyter.org/helm-chart/
 #
 ```
 
@@ -101,7 +101,7 @@ can try with `nano config.yaml`.
      Helm chart is paired with a specific version of JupyterHub. E.g.,
      `0.11.1` of the Helm chart runs JupyterHub `1.3.0`.
      For a list of which JupyterHub version is installed in each version
-     of the JupyterHub Helm Chart, see the [Helm Chart repository](https://jupyterhub.github.io/helm-chart/).
+     of the JupyterHub Helm Chart, see the [Helm Chart repository](https://hub.jupyter.org/helm-chart/).
 
 3. While Step 2 is running, you can see the pods being created by entering in
    a different terminal:

--- a/docs/source/kubernetes/amazon/step-zero-aws-eks.md
+++ b/docs/source/kubernetes/amazon/step-zero-aws-eks.md
@@ -87,6 +87,5 @@ This guide uses AWS to set up a cluster. This mirrors the steps found at [Gettin
 
 ## Cluster Autoscaler
 
-If you'd like to do some {ref}`optimizations <efficient-cluster-autoscaling>`, you need to deploy Cluster Autoscaler (CA) first.
-
-See <https://archive.eksworkshop.com/beginner/080_scaling/deploy_ca/>
+If you'd like to do some {ref}`optimizations <efficient-cluster-autoscaling>`,
+you need to deploy Cluster Autoscaler (CA) first.

--- a/docs/source/kubernetes/microsoft/step-zero-azure.md
+++ b/docs/source/kubernetes/microsoft/step-zero-azure.md
@@ -30,7 +30,7 @@ If you prefer to use the Azure portal see the [Azure Kubernetes Service quicksta
    - **Install command-line tools locally**. You can access the Azure CLI via
      a package that you can install locally.
 
-     To do so, first follow the [installation instructions](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) in the
+     To do so, first follow the [installation instructions](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) in the
      Azure documentation. Then run the following command to connect your local
      CLI with your account:
 
@@ -85,7 +85,7 @@ If you prefer to use the Azure portal see the [Azure Kubernetes Service quicksta
      format, rather than the default JSON output. We shall use this with most
      commands when executing them by hand.
 
-   Consider [setting a cloud budget](https://docs.microsoft.com/en-us/partner-center/set-an-azure-spending-budget-for-your-customers)
+   Consider [setting a cloud budget](https://learn.microsoft.com/en-us/partner-center/set-an-azure-spending-budget-for-your-customers)
    for your Azure account in order to make sure you don't accidentally
    spend more than you wish to.
 

--- a/docs/source/repo2docker.md
+++ b/docs/source/repo2docker.md
@@ -72,7 +72,9 @@ to configure JupyterHub to build off of this image:
 4. **Get credentials for a docker repository.**
 
    The image you will build for your JupyterHub must be made available by being
-   published to some container registry. You could for example use [Docker Hub](https://hub.docker.com/) or [Google Container Registry](https://cloud.google.com/container-registry/).
+   published to some container registry. You could for example use [Docker Hub](https://hub.docker.com/) or [Google Container Registry](https://cloud.google.com/artifact-registry).
+
+   <!-- FIXME: We link to "google container registry", but its deprecated and they now redirect and promote artifact registry with small differences -->
 
    In the next step, you need an image reference for you and others to find your
    image with.

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -7,7 +7,7 @@ description: Multi-user Jupyter installation
 keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org
 sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
-icon: https://jupyterhub.github.io/helm-chart/images/hublogo.svg
+icon: https://hub.jupyter.org/helm-chart/images/hublogo.svg
 kubeVersion: ">=1.23.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers

--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -5,9 +5,9 @@
 [![Discourse](https://img.shields.io/badge/Help_forum-discourse-blue?logo=discourse&logoColor=white)](https://discourse.jupyter.org/c/jupyterhub/z2jh-k8s)
 [![Gitter](https://img.shields.io/badge/Social_chat-gitter-blue?logo=gitter&logoColor=white)](https://gitter.im/jupyterhub/jupyterhub)
 <br>
-[![Latest stable release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20stable%20release&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.stable&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#jupyterhub)
-[![Latest pre-release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20pre-release&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.pre&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
-[![Latest development release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20dev%20release&url=https://jupyterhub.github.io/helm-chart/info.json&query=$.jupyterhub.latest&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
+[![Latest stable release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20stable%20release&url=https://hub.jupyter.org/helm-chart/info.json&query=$.jupyterhub.stable&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#jupyterhub)
+[![Latest pre-release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20pre-release&url=https://hub.jupyter.org/helm-chart/info.json&query=$.jupyterhub.pre&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
+[![Latest development release of the Helm chart](https://img.shields.io/badge/dynamic/json.svg?label=Latest%20dev%20release&url=https://hub.jupyter.org/helm-chart/info.json&query=$.jupyterhub.latest&logo=helm&logoColor=white)](https://jupyterhub.github.io/helm-chart#development-releases-jupyterhub)
 
 The JupyterHub Helm chart is accompanied with an installation guide at [z2jh.jupyter.org](https://z2jh.jupyter.org). Together they enable you to deploy [JupyterHub](https://jupyterhub.readthedocs.io) in a Kubernetes cluster that can make Jupyter environments available to several thousands of simultaneous users.
 

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1135,7 +1135,7 @@ properties:
         type: [integer, "null"]
         description: &jupyterhub-native-config-description |
           JupyterHub native configuration, see the [JupyterHub
-          documentation](https://jupyterhub.readthedocs.io/en/stable/api/app.html)
+          documentation](https://jupyterhub.readthedocs.io/en/stable/reference/api/app.html)
           for more information.
       allowNamedServers:
         type: [boolean, "null"]
@@ -1241,7 +1241,7 @@ properties:
           This is where you register JupyterHub services. For details on how to
           configure these services in this Helm chart just keep reading but for
           details on services themselves instead read [JupyterHub's
-          documentation](https://jupyterhub.readthedocs.io/en/stable/api/service.html).
+          documentation](https://jupyterhub.readthedocs.io/en/stable/reference/api/service.html).
 
           ```{note}
           Only a selection of JupyterHub's configuration options that can be


### PR DESCRIPTION
We made an alpha.1 release, and I was thinking it should be alpha.1 because we were to also add oauthenticator 16 to that later - another breaking change.

I figure now, in order to unblock this release and let's not force a timeline on oauthenticator 16 and instead do another major version release once oauthenticator 16 lands.

I'd like to see us release 3.0.0 or so this friday or early next week.