### PR TITLE
Enhance keycloak configuration example

### DIFF
--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -397,6 +397,12 @@ hub:
       username_key: preferred_username
       userdata_params:
         state: state
+      # In order to use keycloak client's roles as autorisation layer
+      claim_groups_key: roles
+      allowed_groups:
+        - user
+      admin_groups:
+        - admin
     JupyterHub:
       authenticator_class: generic-oauth
 ```

--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -397,7 +397,7 @@ hub:
       username_key: preferred_username
       userdata_params:
         state: state
-      # In order to use keycloak client's roles as autorisation layer
+      # In order to use keycloak client's roles as authorization layer
       claim_groups_key: roles
       allowed_groups:
         - user


### PR DESCRIPTION
Hello everybody,

I just started using JupyterHub and I had hard times understanding how to configure keycloak autorisation in order to use keycloak's client roles as JupyterHub internal's groups.
What I wanted to achieve is to have only keycloak users which have `user` role assigned allowed to connect and use Jupyter and also defining Jupyter's administrator through keycloak via an `admin` role.

I have to sneak into a tons of threads and post and no one describing how to do this. 
I finally had to go through the OAuthenticator documentation to find an example of code which achieve this (see [the docs](https://github.com/jupyterhub/oauthenticator/tree/main/examples/generic#example-configuration-with-authorization-enabled)).

I think anybody who wants to deploy it in production alongside keycloak auth wants to have this type of authorization (maybe I'm wrong). So I just added the mandatory lines in the example in docs : 

```yaml
hub:
  config:
    GenericOAuthenticator:
      [ ... ]
      claim_groups_key: roles
      allowed_groups:
        - user
      admin_groups:
        - admin
```

Maybe in addition we can link this example in the zero-to-jupyterhub-k8s docs ? What do you think about this ?

Thanks in advance