### PR TITLE
docs: let auth docs link to authenticator specific docs

### DIFF
--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -3,44 +3,45 @@
 # Authentication and authorization
 
 Authentication is about identity, while _authorization_ is about permissions. In
-this section you will learn how to configure both. As an example, you can
-configure authentication using GitHub accounts and restrict what users are
-authorized based on membership of a GitHub organization.
+this section you will learn how to configure both by choosing and configuring a
+_JupyterHub Authenticator class_.
 
-Before configuring this, you should have [setup HTTPS](https).
+As an example, you can configure JupyterHub to delegate authentication and
+authorization to the GitHubOAuthenticator. It enable users to login with GitHub
+accounts, where perhaps only a few specific users and other users users part of
+a specific GitHub organization is allowed access.
+
+Before configuring authentication with an external identity provider, you must
+have [setup HTTPS](https).
 
 ## Useful understanding
 
 ### Authenticator classes
 
-Z2JH defaults to a [DummyAuthenticator](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.DummyAuthenticator)
-that allows anyone to login with any username and password.
-This should only be used for testing purposes.
+By default a Z2JH deployment use the
+{external:py:class}`jupyterhub.auth.DummyAuthenticator` JupyterHub authenticator
+class that allows anyone to login with any username and password. This should
+only be used for initial testing purposes.
 
-To use other sources of authentication, choose _one_ [_authenticator
-class_](https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html) to use.
-Several such classes are already available in the hub image through [installed
-Python
-packages](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/HEAD/images/hub/requirements.txt).
+You should decide on a [jupyterhub authenticator class] to use. Several such
+classes are available in the hub image through [installed Python packages], and
+a few of them are described below.
 
-JupyterHub provides a base class,
-[`Authenticator`](https://github.com/jupyterhub/jupyterhub/blob/HEAD/jupyterhub/auth.py),
-that all other authenticator classes are supposed to derive from. By configuring
-this base class, we influence the behavior of the derived class as well.
+[authenticator class]: https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html
+[installed python packages]: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/HEAD/images/hub/requirements.txt
 
 ### The configuration system
 
-We configure JupyterHub to use our chosen authenticator class and the
-authenticator class itself through this Helm chart's
+First we should configure JupyterHub to use our chosen authenticator class and
+the authenticator class itself through this Helm chart's
 [`hub.config`](schema_hub.config) configuration.
 
 ## General configuration
 
-As all authenticator classes derive from the `Authenticator` base class, they
-share some configuration options. Below are some common configuration options,
-but please refer to the official [configuration
-reference](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html) for more
-details.
+As all authenticator classes derive from the
+{external:py:class}`jupyterhub.auth.Authenticator` base class, they share some
+configuration options. Below are some common configuration options from the base
+class.
 
 ### [allowed_users](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.Authenticator.allowed_users) / [admin_users](https://jupyterhub.readthedocs.io/en/stable/reference/api/auth.html#jupyterhub.auth.LocalAuthenticator.admin_users)
 
@@ -129,16 +130,27 @@ documentation.
 
 ### OAuth2 based authentication
 
-JupyterHub's [oauthenticator](https://github.com/jupyterhub/oauthenticator) has
-support for enabling your users to authenticate via a third-party OAuth2
-_identity provider_ such as GitHub, Google, and CILogon. All of these will
-require an OAuth2 _client id_ and _client secret_.
+JupyterHub's [oauthenticator](https://github.com/jupyterhub/oauthenticator)
+project has support for enabling your users to authenticate via a third-party
+OAuth2 _identity provider_ such as GitHub, Google, and CILogon. All of these
+will require an OAuth2 _client id_ and _client secret_.
 
 For details on how to acquire a client id and client secret, please refer to
 [oauthenticator's
 documentation](https://oauthenticator.readthedocs.io/en/stable/tutorials/general-setup.html).
 
 #### GitHub
+
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [GitHubOAuthenticator documentation].
+
+[githuboauthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/github.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
 
 GitHub is the largest hosting service for git repositories. It is free to create
 an account at GitHub, and relatively straightforward to set up OAuth credentials
@@ -203,6 +215,17 @@ For details about GitHub scopes, see [GitHub's documentation](https://docs.githu
 
 #### Google
 
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [GoogleOAuthenticator documentation].
+
+[googleoauthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/google.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 Google authentication is used by many universities (it is part of "G Suite").
 
 If your institution is a [G Suite customer](https://workspace.google.com) that
@@ -252,6 +275,17 @@ users which account they are using to login.
 
 #### CILogon
 
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [CILogonOAuthenticator documentation].
+
+[ciLogonoauthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/cilogon.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 Please see CyberInfrastructure Logon's [website](https://www.cilogon.org) for
 more information about what kind of identity is managed by CILogon.
 
@@ -266,18 +300,18 @@ hub:
       authenticator_class: cilogon
 ```
 
-Based on [this
-caveat](https://github.com/jupyterhub/oauthenticator/blob/6f239bebecbb3fb0242de7f753ae1c93ed101340/oauthenticator/cilogon.py#L5-L14),
-you may need to also set the following.
-
-```yaml
-hub:
-  config:
-    CILogonOAuthenticator:
-      username_claim: email
-```
-
 #### Globus
+
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [GlobusOAuthenticator documentation].
+
+[globusoauthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/globus.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
 
 Globus Auth is a foundational identity and access management platform
 service designed to address unique needs of the science and engineering
@@ -300,6 +334,17 @@ hub:
 
 #### Azure Active Directory
 
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [AzureAdOAuthenticator documentation].
+
+[azureadoauthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/azuread.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 [Azure Active Directory](https://learn.microsoft.com/en-us/azure/active-directory/)
 is an identity provider from Microsoft Azure. Apart from needing a OAuth2
 _client id_ and _client secret_, you will also need a _tenant id_.
@@ -318,6 +363,17 @@ hub:
 
 #### Auth0
 
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [Auth0OAuthenticator documentation].
+
+[auth0oauthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/auth0.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
+
 [Auth0](https://auth0.com/) is a commercial provider of identity management.
 
 ```yaml
@@ -327,19 +383,26 @@ hub:
       client_id: client-id-from-auth0-here
       client_secret: client-secret-from-auth0-here
       oauth_callback_url: https://your-jupyterhub-domain/hub/oauth_callback
+      auth0_domain: prod-8ua-1yy9.auth0.com
       scope:
         - openid
         - email
-      auth0_subdomain: prod-8ua-1yy9
-    Authenticator:
-      admin_users:
-        - devops@example.com
-      auto_login: true
     JupyterHub:
       authenticator_class: auth0
 ```
 
 #### GenericOAuthenticator - OpenID Connect
+
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [GenericOAuthenticator documentation].
+
+[genericoauthenticator documentation]: https://oauthenticator.readthedocs.io/en/latest/tutorials/provider-specific-setup/providers/generic.html
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
 
 [OpenID Connect](https://openid.net/connect) is an identity layer on top of the
 OAuth 2.0 protocol, implemented by [various servers and
@@ -348,32 +411,16 @@ Connect endpoint discovery is not supported by oauthentiator, you can still
 configure JupyterHub to authenticate with OpenID Connect providers by specifying
 all endpoints in the GenericOAuthenticator class.
 
-##### Auth0
-
-Below is an example on how you can configure the GenericOAuthenticator to
-authenticate against Auth0.
-
-```yaml
-hub:
-  config:
-    GenericOAuthenticator:
-      client_id: your-client-id
-      client_secret: your-client-secret
-      oauth_callback_url: https://your-jupyterhub-domain/hub/oauth_callback
-      authorize_url: https://your-domain.us.auth0.com/authorize
-      token_url: https://your-domain.us.auth0.com/oauth/token
-      userdata_url: https://your-domain.us.auth0.com/userinfo
-      scope:
-        - openid
-        - name
-        - profile
-        - email
-      username_key: name
-    JupyterHub:
-      authenticator_class: generic-oauth
-```
-
 ##### KeyCloak
+
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [GenericOAuthenticator documentation].
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
 
 [KeyCloak](https://www.keycloak.org) is an open source based provider of
 identity management that you can host yourself. Below is an example on how you
@@ -394,7 +441,7 @@ hub:
       token_url: https://${host}/realms/${realm}/protocol/openid-connect/token
       userdata_url: https://${host}/realms/${realm}/protocol/openid-connect/userinfo
       login_service: keycloak
-      username_key: preferred_username
+      username_claim: preferred_username
       userdata_params:
         state: state
       # In order to use keycloak client's roles as authorization layer
@@ -408,6 +455,17 @@ hub:
 ```
 
 ### LDAP and Active Directory
+
+```{warning}
+This documentation may not have been updated recently. Due to that, please only use this
+_as a complement_ to the official [LDAPAuthenticator documentation].
+
+[ldapauthenticator documentation]: https://github.com/jupyterhub/ldapauthenticator#readme
+
+Going onwards, the goal is to ensure we have good documentation in the
+OAuthenticator project and reference that instead of maintaining similar
+documentation in this project also.
+```
 
 JupyterHub supports LDAP and Active Directory authentication. Read the
 [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@ author = "Project Jupyter Contributors"
 extensions = [
     "myst_parser",
     "sphinx_copybutton",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinxext.opengraph",
     "sphinxext.rediraffe",
@@ -156,6 +157,29 @@ schema_md = parse_schema(data)
 reference_md = header_md + schema_md
 with open("resources/reference.md", "w") as f:
     f.write("\n".join(reference_md))
+
+
+# -- Options for intersphinx extension ---------------------------------------
+# ref: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
+#
+# The extension makes us able to link like to other projects like below.
+#
+#     rST  - :external:py:class:`tornado.httpclient.AsyncHTTPClient`
+#     MyST - {external:py:class}`tornado.httpclient.AsyncHTTPClient`
+#
+# To see what we can link to, do the following where "objects.inv" is appended
+# to the sphinx based website:
+#
+#     python -m sphinx.ext.intersphinx https://jupyterhub.readthedocs.io/en/stable/objects.inv
+#
+intersphinx_mapping = {
+    "jupyterhub": ("https://jupyterhub.readthedocs.io/en/stable/", None),
+    "oauthenticator": ("https://oauthenticator.readthedocs.io/en/stable/", None),
+}
+
+# intersphinx_disabled_reftypes set based on recommendation in
+# https://docs.readthedocs.io/en/stable/guides/intersphinx.html#using-intersphinx
+intersphinx_disabled_reftypes = ["*"]
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
As part of upgrading to OAuthenticator 16, is our authentication documentation up to date? I skimmed through it and concluded its largely relevant still, but to not burden ourselves with updating it perfectly - which is impossible anyhow - I've added a disclaimer like this.

![image](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/assets/3837114/d58ea50d-a776-4c2b-90ea-5ad3eae7f86f)
