### PR TITLE
Include shellcheck pre-commit in main pre-commit

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Install dependencies
         run: pip install pre-commit
 
-      - name: Run shellcheck linter
-        run: pre-commit run --all --config .pre-commit-config-shellcheck.yaml
+      - name: Run all stages including shellcheck (disabled by default)
+        run: pre-commit run --all --hook-stage manual
 
   lint_and_validate_rendered_templates:
     runs-on: ubuntu-22.04

--- a/.pre-commit-config-shellcheck.yaml
+++ b/.pre-commit-config-shellcheck.yaml
@@ -1,6 +1,0 @@
-# See .pre-commit-config.yaml for more details.
-repos:
-  - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.15
-    hooks:
-      - id: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,14 @@ repos:
     hooks:
       - id: flake8
 
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.22
+    hooks:
+      # This requires shellcheck to be installed manually so is disabled by default
+      - id: shellcheck
+        stages:
+          - manual
+
 # pre-commit.ci config reference: https://pre-commit.ci/#configuration
 ci:
   autoupdate_schedule: monthly


### PR DESCRIPTION
Disabled by default, run with `pre-commit run --all --hook-stage manual`
https://pre-commit.com/#confining-hooks-to-run-at-certain-stages