### PR TITLE
feature: create a separate secret for each file in singleusers.extraFiles

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -295,37 +295,25 @@ elif storage_type == "static":
 # the dedicated k8s Secret prepared to hold the extraFiles actual content.
 extra_files = get_config("singleuser.extraFiles", {})
 if extra_files:
-    volume = {
-        "name": "files",
-    }
-    items = []
     for file_key, file_details in extra_files.items():
-        # Each item is a mapping of a key in the k8s Secret to a path in this
-        # abstract volume, the goal is to enable us to set the mode /
-        # permissions only though so we don't change the mapping.
-        item = {
-            "key": file_key,
-            "path": file_key,
-        }
-        if "mode" in file_details:
-            item["mode"] = file_details["mode"]
-        items.append(item)
-    volume["secret"] = {
-        "secretName": get_name("singleuser"),
-        "items": items,
-    }
-    c.KubeSpawner.volumes.append(volume)
-
-    volume_mounts = []
-    for file_key, file_details in extra_files.items():
-        volume_mounts.append(
-            {
-                "mountPath": file_details["mountPath"],
-                "subPath": file_key,
-                "name": "files",
+        # Make the key RFC 1035 Label Naming compliant
+        file_key = file_key.lower().replace("_", "-").replace(".", "-")
+        c.KubeSpawner.volumes.append({
+            "name": file_key,
+            "secret": {
+                "secretName": f"singleuser-{file_key}",
+                "items": [{
+                    "key": file_key,
+                    "path": file_key,
+                    "mode": file_details.get("mode")
+                }]
             }
-        )
-    c.KubeSpawner.volume_mounts.extend(volume_mounts)
+        })
+        c.KubeSpawner.volume_mounts.append({
+            "mountPath": file_details["mountPath"],
+            "subPath": file_key,
+            "name": file_key,
+        })
 
 # Inject extraVolumes / extraVolumeMounts
 c.KubeSpawner.volumes.extend(get_config("singleuser.storage.extraVolumes", []))

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -7,6 +7,12 @@ metadata:
 type: Opaque
 data:
   {{- $values := merge dict .Values }}
+  {{- range $k, $v := dig "singleuser" "extraFiles" dict $values }}
+    {{- /* we must unset these large values as they result in us hitting the size limit of K8s Secrets */}}
+    {{- $_ := unset $v "data" }}
+    {{- $_ := unset $v "stringData" }}
+    {{- $_ := unset $v "binaryData" }}
+  {{- end }}
   {{- /* also passthrough subset of Chart / Release */}}
   {{- $_ := set $values "Chart" (dict "Name" .Chart.Name "Version" .Chart.Version) }}
   {{- $_ := set $values "Release" (pick .Release "Name" "Namespace" "Service") }}

--- a/jupyterhub/templates/singleuser/secret.yaml
+++ b/jupyterhub/templates/singleuser/secret.yaml
@@ -1,16 +1,19 @@
-{{- if .Values.singleuser.extraFiles }}
+{{- range $name, $details := .Values.singleuser.extraFiles }}
+{{- /* Make the key RFC 1035 Label Naming compliant */}}
+{{- $name = $name | lower | replace "_" "-" | replace "." "-" }}
+---
 kind: Secret
 apiVersion: v1
 metadata:
-  name: {{ include "jupyterhub.singleuser.fullname" . }}
+  name: {{ include "jupyterhub.singleuser.fullname" $ }}-{{ $name }}
   labels:
-    {{- include "jupyterhub.labels" . | nindent 4 }}
+    {{- include "jupyterhub.labels" $ | nindent 4 }}
 type: Opaque
-{{- with include "jupyterhub.extraFiles.data" .Values.singleuser.extraFiles }}
+{{- with include "jupyterhub.extraFiles.data" (dict $name $details) }}
 data:
   {{- . | nindent 2 }}
 {{- end }}
-{{- with include "jupyterhub.extraFiles.stringData" .Values.singleuser.extraFiles }}
+{{- with include "jupyterhub.extraFiles.stringData" (dict $name $details) }}
 stringData:
   {{- . | nindent 2 }}
 {{- end }}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -389,11 +389,10 @@ properties:
 
           1. File size
 
-             The files in `hub.extraFiles` and `singleuser.extraFiles` are
-             respectively stored in their own k8s Secret resource. As k8s
-             Secret's are limited, typically to 1MB, you will be limited to a
-             total file size of less than 1MB as there is also base64 encoding
-             that takes place reducing available capacity to 75%.
+             The files in `hub.extraFiles` is stored within a k8s Secret
+             resource. As k8s Secret's are limited, typically to 1MB, you will
+             be limited to a total file size of less than 1MB as there is also
+             base64 encoding that takes place reducing available capacity to 75%.
 
           2. File updates
 


### PR DESCRIPTION
### Summary:

Closes: #3172

Instead of placing every file from `singleuser.extraFiles` into a single K8s Secret, they are now placed into their own Secret and mounted as such.
