### PR TITLE
Add and enable two egressAllowRules to ensure DNS access

### DIFF
--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -667,6 +667,49 @@ properties:
                   IP ranges but makes an exception for the cloud metadata
                   server, leaving this as the definitive configuration to allow
                   access to the cloud metadata server.
+              dnsPortsCloudMetadataServer:
+                type: boolean
+                description: |
+                  Defaults to `true` for all network policies.
+
+                  When enabled this rule allows the respective pod(s) to
+                  establish outbound connections to the cloud metadata server
+                  via port 53.
+
+                  Relying on this rule should go hand in hand with disabling
+                  [`singleuser.cloudMetadata.blockWithIptables`](schema_singleuser.cloudMetadata.blockWithIptables).
+
+                  Known situations when this rule can be relevant:
+
+                  - In GKE clusters with Cloud DNS that is reached at the
+                    cloud metadata server's non-private IP.
+
+                  ```{note}
+                  This chart doesn't know how to identify the DNS server that
+                  pods will rely on due to variations between how k8s clusters
+                  have been setup. Due to that, multiple rules are enabled by
+                  default to ensure DNS connectivity.
+                  ```
+              dnsPortsKubeSystemNamespace:
+                type: boolean
+                description: |
+                  Defaults to `true` for all network policies.
+
+                  When enabled this rule allows the respective pod(s) to
+                  establish outbound connections to pods in the kube-system
+                  namespace via port 53.
+
+                  Known situations when this rule can be relevant:
+
+                  - GKE, EKS, AKS, and other clusters relying directly on
+                    `kube-dns` or `coredns` pods in the `kube-system` namespace.
+
+                  ```{note}
+                  This chart doesn't know how to identify the DNS server that
+                  pods will rely on due to variations between how k8s clusters
+                  have been setup. Due to that, multiple rules are enabled by
+                  default to ensure DNS connectivity.
+                  ```
               dnsPortsPrivateIPs:
                 type: boolean
                 description: |
@@ -675,10 +718,23 @@ properties:
                   When enabled this rule allows the respective pod(s) to
                   establish outbound connections to private IPs via port 53.
 
-                  Note that we can't reliably identify the k8s internal DNS
-                  server due to variations between k8s clusters. Due to that,
-                  this rule which is critical for core functionality, can be
-                  disabled for a more refined custom rule.
+                  Known situations when this rule can be relevant:
+
+                  - GKE clusters relying on a DNS server indirectly via a a node
+                    local DNS cache at an unknown private IP.
+
+                  ```{note}
+                  This chart doesn't know how to identify the DNS server that
+                  pods will rely on due to variations between how k8s clusters
+                  have been setup. Due to that, multiple rules are enabled by
+                  default to ensure DNS connectivity.
+
+                  ```{warning}
+                  This rule is not expected to work in clusters relying on
+                  Cilium to enforce the NetworkPolicy rules (includes GKE
+                  clusters with Dataplane v2), this is due to a [known
+                  limitation](https://github.com/cilium/cilium/issues/9209).
+                  ```
               nonPrivateIPs:
                 type: boolean
                 description: |
@@ -713,6 +769,13 @@ properties:
                   If possible, try to avoid setting this to true as it gives
                   broad permissions that could be specified more directly via
                   the [`.egress`](schema_singleuser.networkPolicy.egress).
+
+                  ```{warning}
+                  This rule is not expected to work in clusters relying on
+                  Cilium to enforce the NetworkPolicy rules (includes GKE
+                  clusters with Dataplane v2), this is due to a [known
+                  limitation](https://github.com/cilium/cilium/issues/9209).
+                  ```
           interNamespaceAccessLabels:
             enum: [accept, ignore]
             description: |

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -651,7 +651,6 @@ properties:
               ```
 
               ```{versionadded} 2.0.0
-              All `egressAllowRules` are new in JupyterHub Helm chart 2.0.0.
               ```
             properties:
               cloudMetadataServer:
@@ -690,6 +689,9 @@ properties:
                   have been setup. Due to that, multiple rules are enabled by
                   default to ensure DNS connectivity.
                   ```
+
+                  ```{versionadded} 3.0.0
+                  ```
               dnsPortsKubeSystemNamespace:
                 type: boolean
                 description: |
@@ -709,6 +711,9 @@ properties:
                   pods will rely on due to variations between how k8s clusters
                   have been setup. Due to that, multiple rules are enabled by
                   default to ensure DNS connectivity.
+                  ```
+
+                  ```{versionadded} 3.0.0
                   ```
               dnsPortsPrivateIPs:
                 type: boolean

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -107,6 +107,8 @@ hub:
     egress: []
     egressAllowRules:
       cloudMetadataServer: true
+      dnsPortsCloudMetadataServer: true
+      dnsPortsKubeSystemNamespace: true
       dnsPortsPrivateIPs: true
       nonPrivateIPs: true
       privateIPs: true
@@ -231,6 +233,8 @@ proxy:
       egress: []
       egressAllowRules:
         cloudMetadataServer: true
+        dnsPortsCloudMetadataServer: true
+        dnsPortsKubeSystemNamespace: true
         dnsPortsPrivateIPs: true
         nonPrivateIPs: true
         privateIPs: true
@@ -278,6 +282,8 @@ proxy:
       egress: []
       egressAllowRules:
         cloudMetadataServer: true
+        dnsPortsCloudMetadataServer: true
+        dnsPortsKubeSystemNamespace: true
         dnsPortsPrivateIPs: true
         nonPrivateIPs: true
         privateIPs: true
@@ -354,6 +360,8 @@ singleuser:
     egress: []
     egressAllowRules:
       cloudMetadataServer: false
+      dnsPortsCloudMetadataServer: true
+      dnsPortsKubeSystemNamespace: true
       dnsPortsPrivateIPs: true
       nonPrivateIPs: true
       privateIPs: false

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -177,6 +177,8 @@ hub:
     enabled: true
     egressAllowRules:
       cloudMetadataServer: true
+      dnsPortsCloudMetadataServer: true
+      dnsPortsKubeSystemNamespace: true
       dnsPortsPrivateIPs: true
       nonPrivateIPs: true
       privateIPs: false


### PR DESCRIPTION
This chart ships with togglable predefined networking rules declared in NetworkPolicy resources that may or may not be enforced in a k8s cluster, and if they are enforced they are enforced by varying projects such as [Calico](https://www.tigera.io/project-calico/) or [Cilium](https://cilium.io/).

We have previously had a single rule ([`dnsPortsPrivateIPs`](https://zero-to-jupyterhub--3179.org.readthedocs.build/en/3179/resources/reference.html#hub-networkpolicy-egressallowrules-dnsportsprivateips)) to ensure pods have access to a k8s cluster's DNS server, but it seems that this rule isn't enogh in two known situations. This PR is adding two rules ([`dnsPortsCloudMetadataServer`](https://zero-to-jupyterhub--3179.org.readthedocs.build/en/3179/resources/reference.html#hub-networkpolicy-egressallowrules-dnsportscloudmetadataserver) and [`dnsPortsKubeSystemNamespace`](https://zero-to-jupyterhub--3179.org.readthedocs.build/en/3179/resources/reference.html#hub-networkpolicy-egressallowrules-dnsportskubesystemnamespace)) to handle those situations.

The new rules are described in the [configuration reference](https://zero-to-jupyterhub--3179.org.readthedocs.build/en/3179/resources/reference.html#hub-networkpolicy-egressallowrules), screenshotted below.

![image](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/assets/3837114/c73ac9c7-b8d2-4a55-86c6-307558e6af90)

---

This PR is based on insights gathered by @vizeit in #3167 and https://www.vizeit.com/jupyterhub-on-gke-autopilot/, thank you soo much @vizeit for digging into this!!!

- Closes #3167