### PR TITLE
Let singleuser.cloudMetadata.blockWithIpTables only block TCP port 80

### DIFF
--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -279,23 +279,26 @@ only need one.
 
 (block-metadata-netpol)=
 
-### Block metadata with a NetworkPolicy enforced by a NetworkPolicy controller
+### Block cloud metadata API with a NetworkPolicy enforced by a NetworkPolicy controller
 
-If you have _NetworkPolicy controller_ such as Calico in the Kubernetes cluster,
-it will enforce the NetworkPolicy resource created by this chart
-(`singleuser.networkPolicy.*`) that blocks user access to the metadata server.
+If you have _NetworkPolicy controller_ such as Calico or Cilium in the
+Kubernetes cluster, it will enforce the NetworkPolicy resource created by this
+chart (`singleuser.networkPolicy.*`) that blocks (by never allowing) user access
+to the cloud metadata API exposed on TCP port 80 on the IP `169.254.169.254`.
+
 We recommend relying on this approach if you you had a NetworkPolicy controller,
 and then you can disable the other option.
 
 (block-metadata-iptables)=
 
-### Block metadata with a privileged initContainer running `iptables`
+### Block cloud metadata API with a privileged initContainer running `iptables`
 
-If you can't rely on the NetworkPolicy approach to block access to the metadata
-server, we suggest relying on this option. When
+If you can't rely on the NetworkPolicy approach to block access to the cloud
+metadata API on TCP port 80, we suggest relying on this option instead. When
 `singleuser.cloudMetadata.blockWithIptables` is true as it is by default, an
 `initContainer` is added to the user pods. It will run with elevated privileges
-and use the `iptables` command line tool to block access to the metadata server.
+and use the `iptables` command line tool to block access to the cloud metadata
+API on port 80.
 
 ```yaml
 # default configuration
@@ -303,6 +306,13 @@ singleuser:
   cloudMetadata:
     blockWithIptables: true
     ip: 169.254.169.254
+```
+
+```{versionchanged} 3.0.0
+Since 3.0.0 this rule only blocks TCP port 80, and this configuration is no longer allowed
+to be configured true at the same time as
+[`singleuser.networkPolicy.egressAllowRules.cloudMetadataServer`](schema_singleuser.networkPolicy.egressAllowRules.cloudMetadataServer)
+is configured true to avoid ambiguous configurations.
 ```
 
 (netpol)=

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -22,6 +22,10 @@ This is a beta release for testing before the 3.0.0 release.
 Since 3.0.0-beta.1 release 2023-06-12, another breaking change was made by
 upgrading OAuthenticator from version 15.1.0 to 16.0.0. Please read to the
 [OAuthenticator changelog]'s breaking changes before upgrading from 3.0.0-beta.1.
+
+Since 3.0.0-beta.3 release 2023-07-06, default networking rules related to the
+cloud metadata API and DNS ports has changed slightly as documented in the
+breaking changes below.
 ```
 
 #### Breaking changes
@@ -47,6 +51,13 @@ upgrading OAuthenticator from version 15.1.0 to 16.0.0. Please read to the
   - If you are using this JupyterHub Authenticator class, please read to the
     [TmpAuthenticator changelog]'s breaking changes before upgrading this Helm
     chart.
+- [`singleuser.cloudMetadata.blockWithIpTables`](schema_singleuser.cloudMetadata.blockWithIpTables)
+  now only blocks TCP port 80 instead of all protocols and ports.
+- Predefined NetworkPolicy egress allow rules
+  [`dnsPortsCloudMetadataServer`](schema_hub.networkPolicy.egressAllowRules.dnsPortsCloudMetadataServer)
+  and
+  [`dnsPortsKubeSystemNamespace`](schema_hub.networkPolicy.egressAllowRules.dnsPortsKubeSystemNamespace)
+  are introduced and enabled by default for the chart's NetworkPolicy resources.
 
 [jupyterhub changelog]: https://jupyterhub.readthedocs.io/en/stable/changelog.html
 [kubespawner changelog]: https://jupyterhub-kubespawner.readthedocs.io/en/stable/changelog.html

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -426,16 +426,21 @@ if cloud_metadata.get("blockWithIptables") == True:
     network_tools_image_name = get_config("singleuser.networkTools.image.name")
     network_tools_image_tag = get_config("singleuser.networkTools.image.tag")
     network_tools_resources = get_config("singleuser.networkTools.resources")
+    ip = cloud_metadata.get("ip", "169.254.169.254")
     ip_block_container = client.V1Container(
         name="block-cloud-metadata",
         image=f"{network_tools_image_name}:{network_tools_image_tag}",
         command=[
             "iptables",
-            "-A",
+            "--append",
             "OUTPUT",
-            "-d",
-            cloud_metadata.get("ip", "169.254.169.254"),
-            "-j",
+            "--protocol",
+            "tcp",
+            "--destination",
+            ip,
+            "--destination-port",
+            "80",
+            "--jump",
             "DROP",
         ],
         security_context=client.V1SecurityContext(

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -92,7 +92,7 @@
 
 
 {{- /*
-  Warnings for likely misconfiguration
+  Warnings for likely misconfigurations
 */}}
 
 {{- if and (not .Values.scheduling.podPriority.enabled) (and .Values.scheduling.userPlaceholder.enabled .Values.scheduling.userPlaceholder.replicas) }}
@@ -114,7 +114,7 @@
 
 
 {{- /*
-  Breaking changes.
+  Breaking changes and failures for likely misconfigurations.
 */}}
 
 {{- $breaking := "" }}
@@ -145,6 +145,11 @@
 
 {{- if hasKey .Values.hub "fsGid" }}
 {{- $breaking = print $breaking "\n\nCHANGED: hub.fsGid must as of version 2.0.0 be configured via hub.podSecurityContext.fsGroup." }}
+{{- end }}
+
+
+{{- if and .Values.singleuser.cloudMetadata.blockWithIptables (and .Values.singleuser.networkPolicy.enabled .Values.singleuser.networkPolicy.egressAllowRules.cloudMetadataServer) }}
+{{- $breaking = print $breaking "\n\nCHANGED: singleuser.cloudMetadata.blockWithIptables must as of version 3.0.0 not be configured together with singleuser.networkPolicy.egressAllowRules.cloudMetadataServer as it leads to an ambiguous configuration." }}
 {{- end }}
 
 

--- a/jupyterhub/templates/_helpers-netpol.tpl
+++ b/jupyterhub/templates/_helpers-netpol.tpl
@@ -67,12 +67,12 @@
     - ipBlock:
         cidr: 0.0.0.0/0
         except:
-          # As part of this rule, don't:
-          # - allow outbound connections to private IPs
+          # As part of this rule:
+          # - don't allow outbound connections to private IPs
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
-          # - allow outbound connections to the cloud metadata server
+          # - don't allow outbound connections to the cloud metadata server
           - {{ $root.Values.singleuser.cloudMetadata.ip }}/32
 {{- end }}
 

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -404,7 +404,7 @@ singleuser:
   networkPolicy:
     enabled: true
     egressAllowRules:
-      cloudMetadataServer: true
+      cloudMetadataServer: false
       dnsPortsPrivateIPs: true
       nonPrivateIPs: false
       privateIPs: false


### PR DESCRIPTION
- Closes #3180
  By blocking only TCP Port 80 on the cloud metadata server where the sensitive metadata API is exposed, as compared to all traffic which could include relevant DNS traffic for example when a GKE cluster is configured to use Cloud DNS instead of kube-dns (default).
- Closes #3184
  By adding a versionchanged note, and mentioning TCP Port 80 specifically in docs, and by failing if a config is ambiguous by both blocking via iptables and allowing access via NetworkPolicy.
  
### Notes thinking about this

- I've learned we can do `--destination-ports`, in plural instead of singular, allowing us to specify 80 and 443 (EDIT: didn't get this to work)
- Is the metadata API by GKE/EKS/AKS exposed only on TCP port 80? I'm not 100%, but it seems so.
  - EDIT: GKE, EKS, AKS doesn't have anything on port 443 in clusters I inspected
- Should we block UDP port 80 as well since there are things like QUIC protocol to send HTTP traffic also etc, or is it safe to just assume there is no other ports open etc?
- I've learned we can use an exclamation mark before a flag to say the opposite, like `! --destination-port 53` to block traffic except to port 53.
  - EDIT: But this makes us need to specify a --protocol, either tcp or udp, one at at the time, not `all` or similar.

I currently think that blocking only traffic to 169.254.169.254 TCP port 80 this is a clean solution thats easy to document, but I'd like quite good faith in that. Going to check this against GKE EKS AKS