### PR TITLE
maint: restrict allowed config with blockWithIpTables, add misc docs

### DIFF
--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -279,23 +279,29 @@ only need one.
 
 (block-metadata-netpol)=
 
-### Block metadata with a NetworkPolicy enforced by a NetworkPolicy controller
+### Block cloud metadata API with a NetworkPolicy enforced by a NetworkPolicy controller
 
-If you have _NetworkPolicy controller_ such as Calico in the Kubernetes cluster,
-it will enforce the NetworkPolicy resource created by this chart
-(`singleuser.networkPolicy.*`) that blocks user access to the metadata server.
-We recommend relying on this approach if you you had a NetworkPolicy controller,
-and then you can disable the other option.
+If you have _NetworkPolicy controller_ such as Calico or Cilium in the
+Kubernetes cluster, it will enforce the NetworkPolicy resource created by this
+chart (`singleuser.networkPolicy.*`) that by default doesn't allow (and
+therefore blocks) user access to the cloud metadata API exposed on a specific IP
+(`169.254.169.254`).
+
+```{note}
+If you have a NetworkPolicy controller, we recommend relying on it and setting
+`singleuser.cloudMetadata.blockWithIptables` to `false`.
+```
 
 (block-metadata-iptables)=
 
-### Block metadata with a privileged initContainer running `iptables`
+### Block cloud metadata API with a privileged initContainer running `iptables`
 
-If you can't rely on the NetworkPolicy approach to block access to the metadata
-server, we suggest relying on this option. When
+If you can't rely on the NetworkPolicy approach to block access to the cloud
+metadata API, we suggest relying on this option instead. When
 `singleuser.cloudMetadata.blockWithIptables` is true as it is by default, an
 `initContainer` is added to the user pods. It will run with elevated privileges
-and use the `iptables` command line tool to block access to the metadata server.
+and use the `iptables` command line tool to block all network access to the
+cloud metadata server.
 
 ```yaml
 # default configuration
@@ -303,6 +309,12 @@ singleuser:
   cloudMetadata:
     blockWithIptables: true
     ip: 169.254.169.254
+```
+
+```{versionchanged} 3.0.0
+This configuration is not allowed to be configured true at the same time as
+[`singleuser.networkPolicy.egressAllowRules.cloudMetadataServer`](schema_singleuser.networkPolicy.egressAllowRules.cloudMetadataServer)
+to avoid an ambiguous configuration.
 ```
 
 (netpol)=

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -19,9 +19,14 @@ changes in pull requests], this list should be updated.
 This is a beta release for testing before the 3.0.0 release.
 
 ```{warning}
-Since 3.0.0-beta.1 release 2023-06-12, another breaking change was made by
+Since 3.0.0-beta.1 released 2023-06-12, another breaking change was made by
 upgrading OAuthenticator from version 15.1.0 to 16.0.0. Please read to the
-[OAuthenticator changelog]'s breaking changes before upgrading from 3.0.0-beta.1.
+[OAuthenticator changelog]'s breaking changes before upgrading from
+3.0.0-beta.1.
+
+Since 3.0.0-beta.3 released 2023-07-06, default networking rules related to
+establishing connections to DNS ports has changed slightly as documented in the
+breaking changes below.
 ```
 
 #### Breaking changes
@@ -47,6 +52,11 @@ upgrading OAuthenticator from version 15.1.0 to 16.0.0. Please read to the
   - If you are using this JupyterHub Authenticator class, please read to the
     [TmpAuthenticator changelog]'s breaking changes before upgrading this Helm
     chart.
+- Predefined NetworkPolicy egress allow rules
+  [`dnsPortsCloudMetadataServer`](schema_hub.networkPolicy.egressAllowRules.dnsPortsCloudMetadataServer)
+  and
+  [`dnsPortsKubeSystemNamespace`](schema_hub.networkPolicy.egressAllowRules.dnsPortsKubeSystemNamespace)
+  are introduced and enabled by default for the chart's NetworkPolicy resources.
 
 [jupyterhub changelog]: https://jupyterhub.readthedocs.io/en/stable/changelog.html
 [kubespawner changelog]: https://jupyterhub-kubespawner.readthedocs.io/en/stable/changelog.html

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -419,23 +419,28 @@ if specified_cmd is not _unspecified:
 
 set_config_if_not_none(c.Spawner, "default_url", "singleuser.defaultUrl")
 
-cloud_metadata = get_config("singleuser.cloudMetadata", {})
+cloud_metadata = get_config("singleuser.cloudMetadata")
 
 if cloud_metadata.get("blockWithIptables") == True:
     # Use iptables to block access to cloud metadata by default
     network_tools_image_name = get_config("singleuser.networkTools.image.name")
     network_tools_image_tag = get_config("singleuser.networkTools.image.tag")
     network_tools_resources = get_config("singleuser.networkTools.resources")
+    ip = cloud_metadata["ip"]
     ip_block_container = client.V1Container(
         name="block-cloud-metadata",
         image=f"{network_tools_image_name}:{network_tools_image_tag}",
         command=[
             "iptables",
-            "-A",
+            "--append",
             "OUTPUT",
-            "-d",
-            cloud_metadata.get("ip", "169.254.169.254"),
-            "-j",
+            "--protocol",
+            "tcp",
+            "--destination",
+            ip,
+            "--destination-port",
+            "80",
+            "--jump",
             "DROP",
         ],
         security_context=client.V1SecurityContext(

--- a/jupyterhub/templates/NOTES.txt
+++ b/jupyterhub/templates/NOTES.txt
@@ -92,7 +92,7 @@
 
 
 {{- /*
-  Warnings for likely misconfiguration
+  Warnings for likely misconfigurations
 */}}
 
 {{- if and (not .Values.scheduling.podPriority.enabled) (and .Values.scheduling.userPlaceholder.enabled .Values.scheduling.userPlaceholder.replicas) }}
@@ -114,7 +114,7 @@
 
 
 {{- /*
-  Breaking changes.
+  Breaking changes and failures for likely misconfigurations.
 */}}
 
 {{- $breaking := "" }}
@@ -145,6 +145,11 @@
 
 {{- if hasKey .Values.hub "fsGid" }}
 {{- $breaking = print $breaking "\n\nCHANGED: hub.fsGid must as of version 2.0.0 be configured via hub.podSecurityContext.fsGroup." }}
+{{- end }}
+
+
+{{- if and .Values.singleuser.cloudMetadata.blockWithIptables (and .Values.singleuser.networkPolicy.enabled .Values.singleuser.networkPolicy.egressAllowRules.cloudMetadataServer) }}
+{{- $breaking = print $breaking "\n\nCHANGED: singleuser.cloudMetadata.blockWithIptables must as of version 3.0.0 not be configured together with singleuser.networkPolicy.egressAllowRules.cloudMetadataServer as it leads to an ambiguous configuration." }}
 {{- end }}
 
 

--- a/jupyterhub/templates/_helpers-netpol.tpl
+++ b/jupyterhub/templates/_helpers-netpol.tpl
@@ -67,12 +67,12 @@
     - ipBlock:
         cidr: 0.0.0.0/0
         except:
-          # As part of this rule, don't:
-          # - allow outbound connections to private IPs
+          # As part of this rule:
+          # - don't allow outbound connections to private IPs
           - 10.0.0.0/8
           - 172.16.0.0/12
           - 192.168.0.0/16
-          # - allow outbound connections to the cloud metadata server
+          # - don't allow outbound connections to the cloud metadata server
           - {{ $root.Values.singleuser.cloudMetadata.ip }}/32
 {{- end }}
 

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -666,6 +666,13 @@ properties:
                   IP ranges but makes an exception for the cloud metadata
                   server, leaving this as the definitive configuration to allow
                   access to the cloud metadata server.
+
+                  ```{versionchanged} 3.0.0
+                  This configuration is not allowed to be configured true at the
+                  same time as
+                  [`singleuser.cloudMetadata.blockWithIptables`](schema_singleuser.cloudMetadata.blockWithIptables)
+                  to avoid an ambiguous configuration.
+                  ```
               dnsPortsCloudMetadataServer:
                 type: boolean
                 description: |
@@ -675,8 +682,10 @@ properties:
                   establish outbound connections to the cloud metadata server
                   via port 53.
 
-                  Relying on this rule should go hand in hand with disabling
-                  [`singleuser.cloudMetadata.blockWithIptables`](schema_singleuser.cloudMetadata.blockWithIptables).
+                  Relying on this rule for the singleuser config should go hand
+                  in hand with disabling
+                  [`singleuser.cloudMetadata.blockWithIptables`](schema_singleuser.cloudMetadata.blockWithIptables)
+                  to avoid an ambiguous configuration.
 
                   Known situations when this rule can be relevant:
 
@@ -2201,6 +2210,7 @@ properties:
       cloudMetadata:
         type: object
         additionalProperties: false
+        required: [blockWithIptables, ip]
         description: |
           Please refer to dedicated section in [the Helm chart
           documentation](block-metadata-iptables) for more information about

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -404,7 +404,7 @@ singleuser:
   networkPolicy:
     enabled: true
     egressAllowRules:
-      cloudMetadataServer: true
+      cloudMetadataServer: false
       dnsPortsPrivateIPs: true
       nonPrivateIPs: false
       privateIPs: false


### PR DESCRIPTION
Closes #3185 by superseding it. In practice, instead of making singeluser.cloudMetadata.blockWithIpTables more fine grained to not block port 53 etc, we instead let it remain a blunt tool that we recommend disabling if fine grained permissions via NetworkPolicy enforcement is available.

This PR tightens the schema to error on the ambigious configurations of blocking access to the cloud metadata server using IP tables while allowing it with a NetworkPolicy. This PR also documents breaking changes from #3179 - breaking because they add permissions that users in theory could want not to be added.

Marking this as breaking as we tighten the schema to error on ambigious configuration.

---

With this merged, I'd like to go for a 3.0.0 release!