### PR TITLE
docs: fix the jupyterhub managed service example's networking rules

### DIFF
--- a/docs/source/administrator/services.md
+++ b/docs/source/administrator/services.md
@@ -69,7 +69,11 @@ hub:
         targetPort: 8181
         name: fastapi
 
-# Required if service should be publicly accessible
+# The proxy.chp.networkPolicy.egress configuration below is required if the
+# service should be accessible for users. If it shouldn't be, you should instead
+# set the chart configuration services.fastapi.display to false as otherwise
+# JupyterHub will provide a broken link in the Services menu for users to go to
+# /services/fastapi/.
 proxy:
   chp:
     networkPolicy:

--- a/docs/source/administrator/services.md
+++ b/docs/source/administrator/services.md
@@ -68,4 +68,17 @@ hub:
       - port: 8181
         targetPort: 8181
         name: fastapi
+
+# Required if service should be publicly accessible
+proxy:
+  chp:
+    networkPolicy:
+      egress:
+        - to:
+            - podSelector:
+                matchLabels:
+                  app: jupyterhub
+                  component: hub
+          ports:
+            - port: 8181
 ```


### PR DESCRIPTION
Add missing proxy egress for example of publicly available managed services.

Fixes #3187 