### PR TITLE
Add changelog for 3.0.1

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -14,6 +14,25 @@ changes in pull requests], this list should be updated.
 
 ## 3.0
 
+### 3.0.1 - 2023-08-15
+
+#### Bugs fixed
+
+- Update oauthenticator from 16.0.4 to 16.0.5 and tornado from 6.3.2 to 6.3.3 [#3199](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3199) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
+
+#### Documentation improvements
+
+- docs: fix the jupyterhub managed service example's networking rules [#3200](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3200) ([@Ph0tonic](https://github.com/Ph0tonic), [@consideRatio](https://github.com/consideRatio))
+
+#### Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2023-08-11&to=2023-08-15&type=c))
+
+@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2023-08-11..2023-08-15&type=Issues)) | @Ph0tonic ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3APh0tonic+updated%3A2023-08-11..2023-08-15&type=Issues))
+
 ### 3.0.0 - 2023-08-11
 
 This release updates JupyterHub itself and several dependencies to a new major

--- a/docs/source/jupyterhub/customizing/user-storage.md
+++ b/docs/source/jupyterhub/customizing/user-storage.md
@@ -183,9 +183,12 @@ singleuser:
 This will request a `2Gi` volume per user. The default requests a `10Gi`
 volume per user.
 
-We recommend you use the [IEC Prefixes](https://en.wikipedia.org/wiki/Binary_prefix#Adoption_by_IEC,_NIST_and_ISO)
-(Ki, Mi, Gi, etc) for specifying how much storage you want. `2Gi` (IEC Prefix) is
-`(2 * 1024 * 1024 * 1024)` bytes, while `2G` (SI Prefix) is `(2 * 1000 * 1000 * 1000)` bytes.
+We recommend you use the [IEC binary prefixes] (Ki, Mi, Gi, etc) for specifying
+how much storage you want. `2Gi` (IEC binary prefix) is `(2 * 1024 * 1024 *
+1024)` bytes, while `2G` (SI decimal prefix) is `(2 * 1000 * 1000 * 1000)`
+bytes.
+
+[iec binary prefixes]: https://en.wikipedia.org/wiki/Binary_prefix
 
 ## Turn off per-user persistent storage
 


### PR DESCRIPTION
Oauthenticator had a bug that was breaking for users with Google / Globus OAuthenticator and users with `c.JupyterHub.load_roles` - but the latter is something we have use by default in z2jh because of jupyterhub-idle-culler's config.