### PR TITLE
Pull images from `singleuser.profileList` found in `profile_options.choices`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -175,6 +175,7 @@ with open("resources/reference.md", "w") as f:
 intersphinx_mapping = {
     "jupyterhub": ("https://jupyterhub.readthedocs.io/en/stable/", None),
     "oauthenticator": ("https://oauthenticator.readthedocs.io/en/stable/", None),
+    "kubespawner": ("https://jupyterhub-kubespawner.readthedocs.io/en/stable/", None),
 }
 
 # intersphinx_disabled_reftypes set based on recommendation in

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -134,6 +134,7 @@ spec:
         {{- /* --- Conditionally pull profileList images --- */}}
         {{- if .Values.prePuller.pullProfileListImages }}
         {{- range $k, $container := .Values.singleuser.profileList }}
+        {{- /* profile's kubespawner_override */}}
         {{- if $container.kubespawner_override }}
         {{- if $container.kubespawner_override.image }}
         - name: image-pull-singleuser-profilelist-{{ $k }}
@@ -150,6 +151,33 @@ spec:
           securityContext:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- /* kubespawner_override in profile's profile_options */}}
+        {{- if $container.profile_options }}
+        {{- range $option, $option_spec := $container.profile_options }}
+        {{- if $option_spec.choices }}
+        {{- range $choice, $choice_spec := $option_spec.choices }}
+        {{- if $choice_spec.kubespawner_override }}
+        {{- if $choice_spec.kubespawner_override.image }}
+        - name: image-pull-profile-{{ $k }}-option-{{ $option }}-{{ $choice }}
+          image: {{ $choice_spec.kubespawner_override.image }}
+          command:
+            - /bin/sh
+            - -c
+            - echo "Pulling complete"
+          {{- with $.Values.prePuller.resources }}
+          resources:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.prePuller.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | nindent 12 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2850,9 +2850,12 @@ properties:
       pullProfileListImages:
         type: boolean
         description: |
-          The singleuser.profileList configuration can let the user choose an
-          image through the selection of a profile. This option determines if
-          those images will be pulled, both by the hook and continuous pullers.
+          The singleuser.profileList configuration can provide a selection of
+          images. This option determines if all images identified there should
+          be pulled, both by the hook and continuous pullers.
+
+          Images are looked for under `kubespawner_override`, and also
+          `profile_options.choices.kubespawner_override` since version 3.2.0.
 
           The reason to disable this, is that if you have for example 10 images
           which start pulling in order from 1 to 10, a user that arrives and

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -364,7 +364,7 @@ singleuser:
             display_name: "image ZZZ tag"
             kubespawner_override:
               image: "ZZZ:{value}"
- nodeSelector:
+  nodeSelector:
     mock-node-selector: mock
   extraTolerations:
     - effect: NoSchedule

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -344,7 +344,27 @@ singleuser:
         mock description 2
       kubespawner_override:
         image: XYZ:XYZ
-  nodeSelector:
+    - display_name: "mock display name 3"
+      description: |
+        mock description 3
+      profile_options:
+        image:
+          display_name: Image
+          choices:
+            image1:
+              display_name: "image 1"
+              kubespawner_override:
+                image: XXX:XXX
+            image2:
+              display_name: "image 2"
+              kubespawner_override:
+                image: YYY:YYY
+          unlisted_choice:
+            enabled: true
+            display_name: "image ZZZ tag"
+            kubespawner_override:
+              image: "ZZZ:{value}"
+ nodeSelector:
     mock-node-selector: mock
   extraTolerations:
     - effect: NoSchedule


### PR DESCRIPTION
Currently prePuller, when it comes to obtaining list of images from `singleuser.profileList`, does not support the [profile_options](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.profile_list) way of redefining the images. 

This PR aims to add such a support. 

Current mitigation without such a support, is to define images second time in `prePuller.extraImages`, but this is not really convenient and overcomplicates maintenance of the actual profile list.