### PR TITLE
Support creating HTTPRoute resources as an alternative to Ingress resources

### DIFF
--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -220,6 +220,14 @@
     {{- end }}
 {{- end }}
 
+{{- /* HTTPRoute */}}
+{{- define "jupyterhub.httpRoute.fullname" -}}
+    {{- if (include "jupyterhub.fullname" .) }}
+        {{- include "jupyterhub.fullname" . }}
+    {{- else -}}
+        jupyterhub
+    {{- end }}
+{{- end }}
 
 
 {{- /*

--- a/jupyterhub/templates/httproute.yaml
+++ b/jupyterhub/templates/httproute.yaml
@@ -8,7 +8,10 @@ spec:
     - kind: Gateway
       name: {{ .Values.httpRoute.Gateway.Name }}
       namespace: {{ .Values.httpRoute.Gateway.Namespace }}
-  hostnames: {{ .Values.httpRoute.Hostnames }}
+  {{- with .Values.httpRoute.Hostnames }}
+  hostnames:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   rules:
     - backendRefs:
         - name: proxy-public

--- a/jupyterhub/templates/httproute.yaml
+++ b/jupyterhub/templates/httproute.yaml
@@ -2,7 +2,9 @@
 kind: HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1beta1
 metadata:
-  name: jupyterhub
+  name: {{ include "jupyterhub.httpRoute.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
   parentRefs:
     - kind: Gateway
@@ -21,7 +23,9 @@ spec:
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:
-  name: jupyterhub
+  name: {{ include "jupyterhub.httpRoute.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
   default:
     config:

--- a/jupyterhub/templates/httproute.yaml
+++ b/jupyterhub/templates/httproute.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.httpRoute.enabled -}}
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: jupyterhub
+spec:
+  parentRefs:
+    - kind: Gateway
+      name: {{ .Values.httpRoute.Gateway.Name }}
+      namespace: {{ .Values.httpRoute.Gateway.Namespace }}
+  hostnames: {{ .Values.httpRoute.Hostnames }}
+  rules:
+    - backendRefs:
+        - name: proxy-public
+          port: 80
+
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: jupyterhub
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /hub/login
+  targetRef:
+    group: ""
+    kind: Service
+    name: proxy-public
+{{- end }}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2776,14 +2776,15 @@ properties:
           List of hosts to route requests to the proxy.
       gateway:
         type: object
+        additionalProperties: false
         required: [name, namespace]
         properties:
           name:
-            type: [string, "null"]
+            type: string
             description: |
               The name of your Gateway for this route.
           namespace:
-            type: [string, "null"]
+            type: string
             description: |
               The namespace the Gateway is running in.
 

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2770,7 +2770,7 @@ properties:
           HTTPRoute depends on Gateway API is enabled in your cluster.
 
           See [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) for more details.
-      hosts:
+      hostnames:
         type: array
         description: |
           List of hosts to route requests to the proxy.

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2779,11 +2779,11 @@ properties:
         required: [name, namespace]
         properties:
           name:
-            type: string
+            type: [string, "null"]
             description: |
               The name of your Gateway for this route.
           namespace:
-            type: string
+            type: [string, "null"]
             description: |
               The namespace the Gateway is running in.
 

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2757,6 +2757,36 @@ properties:
           documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
           for more details about annotations.
 
+  httpRoute:
+    type: object
+    additionalProperties: false
+    required: [enabled]
+    properties:
+      enabled:
+        type: boolean
+        description: |
+          Enable the creation of a Kubernetes HTTPRoute and HealthCheckPolicy to proxy-public service.
+
+          HTTPRoute depends on Gateway API is enabled in your cluster.
+
+          See [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) for more details.
+      hosts:
+        type: array
+        description: |
+          List of hosts to route requests to the proxy.
+      gateway:
+        type: object
+        required: [name, namespace]
+        properties:
+          name:
+            type: string
+            description: |
+              The name of your Gateway for this route.
+          namespace:
+            type: string
+            description: |
+              The namespace the Gateway is running in.
+
   prePuller:
     type: object
     additionalProperties: false

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -650,6 +650,13 @@ ingress:
   pathType: Prefix
   tls: []
 
+httpRoute:
+  enabled: false
+  gateway:
+    name:
+    namespace:
+  hostnames: []
+
 # cull relates to the jupyterhub-idle-culler service, responsible for evicting
 # inactive singleuser pods.
 #

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -652,10 +652,10 @@ ingress:
 
 httpRoute:
   enabled: false
-  gateway:
-    name:
-    namespace:
   hostnames: []
+  gateway:
+    name: your-gateway
+    namespace: namespace-for-your-gateway
 
 # cull relates to the jupyterhub-idle-culler service, responsible for evicting
 # inactive singleuser pods.


### PR DESCRIPTION
We are moving to Gateway API with HTTPRoute instead of using regular Ingress resources. It would be nice if this chart would allow us to make the two resources needed so we don't have to make them manually before installing the chart.

From https://gateway-api.sigs.k8s.io/

> When using the Gateway API to manage ingress traffic, the Gateway resource defines a point of access at which traffic can be routed across multiple contexts -- for example, from outside the cluster to inside the cluster (north/south traffic).