### PR TITLE
Use quay.io as source of docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,15 @@ jobs:
             export KUBECONFIG="$HOME/.kube/config"
             export HUB_URL=http://localhost:30080
             . ./ci/common
-            # Print out logs from all pods if the tests fail
+            # Print out logs & definition info from all pods if the tests fail
             pytest --verbose --color=yes ./tests -m 'not netpol' || \
                kubectl get pod -o name | \
                xargs -I {} /bin/bash -c \
-                "echo Logs for {} && kubectl logs --all-containers {} && echo --------------"
+                "echo Logs for {} && \
+                 kubectl get {} -o yaml && \
+                 kubectl describe {} && \
+                 kubectl logs --all-containers {} && \
+                 echo --------------------------------"
           name: Run tests
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             # Print out logs from all pods if the tests fail
             pytest --verbose --color=yes ./tests -m 'not netpol' || \
                kubectl get pod -o name | \
-               xargs -I {} -L1 /bin/bash -c \
+               xargs -I {} /bin/bash -c \
                 "echo Logs for {} && kubectl logs --all-containers {} && echo --------------"
           name: Run tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,11 @@ jobs:
             export KUBECONFIG="$HOME/.kube/config"
             export HUB_URL=http://localhost:30080
             . ./ci/common
-            pytest --verbose --color=yes ./tests -m 'not netpol'
+            # Print out logs from all pods if the tests fail
+            pytest --verbose --color=yes ./tests -m 'not netpol' || \
+               kubectl get pod -o name | \
+               xargs -I {} -L1 /bin/bash -c \
+                "echo Logs for {} && kubectl logs --all-containers {} && echo --------------"
           name: Run tests
 
       - run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,7 +108,7 @@ jobs:
         #    https://github.com/jupyterhub/zero-to-jupyterhub-k8s/settings/secrets/actions
         if: steps.publishing.outputs.publishing
         run: |
-          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
+          docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
 
       - name: Configure a git user
         # Having a user.email and user.name configured with git is required to

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
   # JupyterHub organization Helm chart repository.
   #
   # ref: https://github.com/jupyterhub/helm-chart
-  # ref: https://hub.docker.com/orgs/jupyterhub
+  # ref: https://quay.io/organization/jupyterhub
 
   publish:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -134,7 +134,7 @@ jobs:
           - k3s-channel: stable # also test hub-slim, and prePuller.hook
             test: install
             local-chart-extra-args: >-
-              --set hub.image.name=jupyterhub/k8s-hub-slim
+              --set hub.image.name=quay.io/jupyterhub/k8s-hub-slim
               --set prePuller.hook.enabled=true
               --set prePuller.hook.pullOnlyOnChanges=true
           - k3s-channel: v1.26 # also test hub.existingSecret

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,7 +331,7 @@ Did you get an error like one of these below?
 # while running apt-get install while building a docker image with chartpress
 E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-1_amd64.deb  Could not connect to archive.ubuntu.com:80 (91.189.88.174). - connect (113: No route to host) Could not connect to archive.ubuntu.com:80 (91.189.88.31). - connect (113: No route to host) [IP: 91.189.88.174 80]
 # [...]
-subprocess.CalledProcessError: Command '['docker', 'build', '-t', 'jupyterhub/k8s-hub:0.9-217f798', 'images/hub', '--build-arg', 'JUPYTERHUB_VERSION=git+https://github.com/jupyterhub/jupyterhub@master']' returned non-zero exit status 100.
+subprocess.CalledProcessError: Command '['docker', 'build', '-t', 'quay.io/jupyterhub/k8s-hub:0.9-217f798', 'images/hub', '--build-arg', 'JUPYTERHUB_VERSION=git+https://github.com/jupyterhub/jupyterhub@master']' returned non-zero exit status 100.
 
 # while installing a dependency for our k8s cluster
 Unable to connect to the server: dial tcp: lookup docs.projectcalico.org on 127.0.0.53:53: read udp 127.0.0.1:56409->127.0.0.53:53: i/o timeout

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,7 +28,7 @@ Also consider nudging dependent projects in the JupyterHub GitHub organization f
 These images version/tags are set in [values.yaml](jupyterhub/values.yaml), consider bumping the version of these as well.
 
 - [ ] [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
-  - [Available image tags](https://hub.docker.com/r/jupyterhub/configurable-http-proxy/tags)
+  - [Available image tags](https://quay.io/repository/jupyterhub/configurable-http-proxy?tab=tags)
   - values.yaml entry: `proxy.chp.image`
 - [ ] [traefik/traefik](https://github.com/traefik/traefik)
   - [Available image tags](https://hub.docker.com/_/traefik?tab=tags)

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -12,7 +12,7 @@ charts:
   - name: jupyterhub
     # Dev: imagePrefix can be useful to override if you want to trial something
     #      locally developed in a remote k8s cluster.
-    imagePrefix: jupyterhub/k8s-
+    imagePrefix: quay.io/jupyterhub/k8s-
     # baseVersion should be a -0.dev suffixed version, where the version should
     # be the next major, minor, or patch version depending on what we have
     # merged so far into the main branch. If for example we have merged a

--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -61,7 +61,7 @@ changes to your `config.yaml` file:
 
 **NOTE:**
 
-If the proxy service is of type `LoadBalancer`, which it is by default, then a specific static IP address can be requested (if available) instead of a dynamically acquired one.  
+If the proxy service is of type `LoadBalancer`, which it is by default, then a specific static IP address can be requested (if available) instead of a dynamically acquired one.
 Although not essential for HTTPS, using a static IP address is a recommended practice for domain names referencing fixed IPs.
 This ensures the same IP address for multiple deployments.
 The IP can be provided like:
@@ -179,7 +179,7 @@ hub:
     # when debugging something from the hub pod. To use it, apply this
     # configuration.
     #
-    name: jupyterhub/k8s-hub-slim
+    name: quay.io/jupyterhub/k8s-hub-slim
 ```
 
 ```{note}

--- a/docs/source/administrator/services.md
+++ b/docs/source/administrator/services.md
@@ -18,8 +18,9 @@ In the following snippet, I'm using a custom image that copies over the applicat
 
 ```Dockerfile
 # Dockerfile
-# 2.0.0 is latest stable release at the time of this writing
-FROM quay.io/jupyterhub/k8s-hub:2.0.0
+# 3.1.0 is latest stable release at the time of this writing
+# Find all tags in https://quay.io/repository/jupyterhub/k8s-hub?tab=tags
+FROM quay.io/jupyterhub/k8s-hub:3.1.0
 
 # Depending on version, the k8s-hub image may have installed
 # pip packages as root, forcing you to install as root as well

--- a/docs/source/administrator/services.md
+++ b/docs/source/administrator/services.md
@@ -8,7 +8,7 @@ Services can be run [externally](https://jupyterhub.readthedocs.io/en/stable/get
 
 ## Hub-managed services in z2jh
 
-A Hub-managed service will run in the same container/pod as the Hub itself. First, you'll need to install or copy the appropriate files for the service into your Hub image, either by creating a custom image derived from [`jupyterhub/k8s-hub`](https://hub.docker.com/r/jupyterhub/k8s-hub) or the [hub.extraFiles](schema_hub.extraFiles) configuration. Keep in mind that your Hub container may need to install dependency libraries like flask or fastapi, depending on the service. In those cases, you'll need a custom image.
+A Hub-managed service will run in the same container/pod as the Hub itself. First, you'll need to install or copy the appropriate files for the service into your Hub image, either by creating a custom image derived from [`jupyterhub/k8s-hub`](https://quay.io/repository/jupyterhub/k8s-hub) or the [hub.extraFiles](schema_hub.extraFiles) configuration. Keep in mind that your Hub container may need to install dependency libraries like flask or fastapi, depending on the service. In those cases, you'll need a custom image.
 
 In addition to the code for the service, you need to modify the Hub Kubernetes Service object to include [multiple ports](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services), and update the Hub Network Policy. If you want to allow access from all sources, you can use [hub.networkPolicy.allowedIngressPorts](schema_hub.networkPolicy.allowedIngressPorts). Otherwise if you want to more precisely control access, you can use [hub.networkPolicy.ingress](schema_hub.networkPolicy.ingress).
 
@@ -19,7 +19,7 @@ In the following snippet, I'm using a custom image that copies over the applicat
 ```Dockerfile
 # Dockerfile
 # 2.0.0 is latest stable release at the time of this writing
-FROM jupyterhub/k8s-hub:2.0.0
+FROM quay.io/jupyterhub/k8s-hub:2.0.0
 
 # Depending on version, the k8s-hub image may have installed
 # pip packages as root, forcing you to install as root as well

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -19,7 +19,7 @@ to [quay.io](https://quay.io). This move is to ensure our users are not [throttl
 and us maintainers don't have to apply for 'sponsored OSS Project' from docker each year. This
 should have no material impact on your experience.
 
-For the benefit of people running older versions of z2jh and are throttled by DockerHub,
+For the benefit of people running older versions of z2jh and are throttled by dockerhub,
 we have actually copied all our *released* images from dockerhub to quay.io as well.
 So you can opt in to using the images from quay.io with the following config:
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -14,14 +14,14 @@ changes in pull requests], this list should be updated.
 
 ### Default image registry moved to [quay.io](https://quay.io)
 
-We have moved the registry where we publish our docker images from [dockerhub](https://hub.docker.com)
-to [quay.io](https://quay.io). This move is to ensure our users are not [throttled by dockerhub](https://docs.docker.com/docker-hub/download-rate-limit/),
+We have moved the registry where we publish our docker images from [Docker Hub](https://hub.docker.com)
+to [Quay.io](https://quay.io). This move is to ensure our users are not [throttled by Docker Hub](https://docs.docker.com/docker-hub/download-rate-limit/),
 and us maintainers don't have to apply for 'sponsored OSS Project' from docker each year. This
 should have no material impact on your experience.
 
 For the benefit of people running older versions of z2jh and are throttled by dockerhub,
-we have actually copied all our _released_ images from dockerhub to quay.io as well.
-So you can opt in to using the images from quay.io with the following config:
+we have actually copied all our _released_ images from Docker Hub to Quay.io as well.
+So you can opt in to using the images from Quay.io with the following config:
 
 ```yaml
 hub:

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -12,6 +12,42 @@ changes in pull requests], this list should be updated.
 [development releases]: https://hub.jupyter.org/helm-chart/#development-releases-jupyterhub
 [breaking changes in pull requests]: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking
 
+### Default image registry moved to [quay.io](https://quay.io)
+
+We have moved the registry where we publish our docker images from [dockerhub](https://hub.docker.com)
+to [quay.io](https://quay.io). This move is to ensure our users are not [throttled by dockerhub](https://docs.docker.com/docker-hub/download-rate-limit/),
+and us maintainers don't have to apply for 'sponsored OSS Project' from docker each year. This
+should have no material impact on your experience.
+
+For the benefit of people running older versions of z2jh and are throttled by DockerHub,
+we have actually copied all our *released* images from dockerhub to quay.io as well.
+So you can opt in to using the images from quay.io with the following config:
+
+```yaml
+hub:
+  image:
+    name: quay.io/jupyterhub/k8s-hub
+proxy:
+  chp:
+    image:
+      name: quay.io/jupyterhub/configurable-http-proxy
+  secretSync:
+    image:
+        name: quay.io/jupyterhub/k8s-secret-sync
+singleuser:
+  networkTools:
+    image:
+      name: quay.io/jupyterhub/k8s-network-tools
+prePuller:
+  hook:
+    image:
+      name: quay.io/jupyterhub/k8s-image-awaiter
+```
+
+You don't have to explicitly specify the tag, as the existing tags
+will work. Note that this **only** works for *released* versions of
+z2jh - if you are using a *dev* version of z2jh, this will not work.
+
 ## 3.1
 
 ### 3.1.0 - 2023-09-29

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -20,7 +20,7 @@ and us maintainers don't have to apply for 'sponsored OSS Project' from docker e
 should have no material impact on your experience.
 
 For the benefit of people running older versions of z2jh and are throttled by dockerhub,
-we have actually copied all our *released* images from dockerhub to quay.io as well.
+we have actually copied all our _released_ images from dockerhub to quay.io as well.
 So you can opt in to using the images from quay.io with the following config:
 
 ```yaml
@@ -33,7 +33,7 @@ proxy:
       name: quay.io/jupyterhub/configurable-http-proxy
   secretSync:
     image:
-        name: quay.io/jupyterhub/k8s-secret-sync
+      name: quay.io/jupyterhub/k8s-secret-sync
 singleuser:
   networkTools:
     image:
@@ -45,8 +45,8 @@ prePuller:
 ```
 
 You don't have to explicitly specify the tag, as the existing tags
-will work. Note that this **only** works for *released* versions of
-z2jh - if you are using a *dev* version of z2jh, this will not work.
+will work. Note that this **only** works for _released_ versions of
+z2jh - if you are using a _dev_ version of z2jh, this will not work.
 
 ## 3.1
 

--- a/docs/source/repo2docker.md
+++ b/docs/source/repo2docker.md
@@ -72,9 +72,7 @@ to configure JupyterHub to build off of this image:
 4. **Get credentials for a docker repository.**
 
    The image you will build for your JupyterHub must be made available by being
-   published to some container registry. You could for example use [Docker Hub](https://hub.docker.com/) or [Google Container Registry](https://cloud.google.com/artifact-registry).
-
-   <!-- FIXME: We link to "google container registry", but its deprecated and they now redirect and promote artifact registry with small differences -->
+   published to some container registry. You could for example use [quay.io](https://quay.io) or [Docker Hub](https://hub.docker.com/).
 
    In the next step, you need an image reference for you and others to find your
    image with.
@@ -85,10 +83,10 @@ to configure JupyterHub to build off of this image:
    <dockerhub-username>/<image-name>:<image-tag>
    ```
 
-   An image reference on Google Container Registry:
+   An image reference on quay.io:
 
    ```
-   gcr.io/<cloud-project-name>/<image-name>:<image-tag>
+   quay.io/<quay-username>/<image-name>:<image-tag>
    ```
 
    - Your image name can be anything memorable.

--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
 
 # The final stage - slim version
 # ------------------------------
-# This stage is built and published as jupyterhub/k8s-hub-slim. It is meant to
+# This stage is built and published as quay.io/jupyterhub/k8s-hub-slim. It is meant to
 # provide no non-essential packages.
 #
 FROM python:3.11-slim-bullseye as slim-stage

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -45,8 +45,8 @@ RUN adduser \
         ${NB_USER}
 
 RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get install -y --no-install-recommends \
+ && apt-get upgrade --yes \
+ && apt-get install --yes --no-install-recommends \
         ca-certificates \
         dnsutils \
         iputils-ping \

--- a/images/singleuser-sample/README.md
+++ b/images/singleuser-sample/README.md
@@ -17,10 +17,10 @@ To quickly try out this Docker image on your computer:
 
 ```sh
 # with JupyterLab
-docker run  -it  --rm  -p 8888:8888 jupyterhub/k8s-singleuser-sample:2.0.0  -- jupyter lab  --ip 0.0.0.0
+docker run  -it  --rm  -p 8888:8888 quay.io/jupyterhub/k8s-singleuser-sample:2.0.0  -- jupyter lab  --ip 0.0.0.0
 ```
 
-This image available tags can be found [here](https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/tags/).
+This image available tags can be found [here](https://quay.io/repository/jupyterhub/k8s-singleuser-sample?tab=tags).
 
 ## In the base-notebook image
 

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -344,7 +344,7 @@ singleuser:
     preferred: []
   networkTools:
     image:
-      name: jupyterhub/k8s-network-tools
+      name: quay.io/jupyterhub/k8s-network-tools
       tag: "set-by-chartpress"
       pullPolicy:
       pullSecrets: []

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -83,7 +83,7 @@ hub:
   extraVolumes: []
   extraVolumeMounts: []
   image:
-    name: jupyterhub/k8s-hub
+    name: quay.io/jupyterhub/k8s-hub
     tag: "set-by-chartpress"
     pullPolicy:
     pullSecrets: []
@@ -201,7 +201,7 @@ proxy:
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
-      name: jupyterhub/configurable-http-proxy
+      name: quay.io/jupyterhub/configurable-http-proxy
       # tag is automatically bumped to new patch versions by the
       # watch-dependencies.yaml workflow.
       #
@@ -304,7 +304,7 @@ proxy:
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
     image:
-      name: jupyterhub/k8s-secret-sync
+      name: quay.io/jupyterhub/k8s-secret-sync
       tag: "set-by-chartpress"
       pullPolicy:
       pullSecrets: []
@@ -396,7 +396,7 @@ singleuser:
       volumeNameTemplate: volume-{username}{servername}
       storageAccessModes: [ReadWriteOnce]
   image:
-    name: jupyterhub/k8s-singleuser-sample
+    name: quay.io/jupyterhub/k8s-singleuser-sample
     tag: "set-by-chartpress"
     pullPolicy:
     pullSecrets: []
@@ -605,7 +605,7 @@ prePuller:
     pullOnlyOnChanges: true
     # image and the configuration below relates to the hook-image-awaiter Job
     image:
-      name: jupyterhub/k8s-image-awaiter
+      name: quay.io/jupyterhub/k8s-image-awaiter
       tag: "set-by-chartpress"
       pullPolicy:
       pullSecrets: []


### PR DESCRIPTION
While we do have 'sponsored OSS' status on dockerhub, @choldgraf (whose credit card is apparently tied to the dockerhub jupyterhub account) just got a surprise multi hundred dollar bill for that organization! While I'm sure this is a mistake and can be corrected, it's IMO enough incentive for us to move away for real.

See https://github.com/jupyterhub/team-compass/issues/688 for team-compass issue about this.

TODO:
- [x] Create appropriate CI robot account on quay.io
- [x] Set QUAY_USERNAME & QUAY_PASSWORD as environment variables
- [x] Create the repos and make them public
- [x] Make sure owners have push rights to repos 
- [x] Create READMEs for the repos pointing back to here
- [x] Get all tests to pass
- [x] Document this in changelog. It's not necessarily a breaking change though - existing images will still work, this is just for new images
- [x] Update all documentation that's pointing to dockerhub