### PR TITLE
ci: fetch stable/dev releases using helm show to avoid cache issues

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -278,7 +278,6 @@ jobs:
       - name: "(Upgrade) Install ${{ matrix.upgrade-from }} chart"
         if: matrix.test == 'upgrade'
         run: |
-          . ./ci/common
           # NOTE: We change the directory so jupyterhub the chart name won't be
           #       misunderstood as the local folder name.
           #

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -279,8 +279,16 @@ jobs:
         if: matrix.test == 'upgrade'
         run: |
           . ./ci/common
-          if [ ${{ matrix.upgrade-from }} = stable -o ${{ matrix.upgrade-from }} = dev ]; then
-            UPGRADE_FROM_VERSION=$(curl -sSL https://hub.jupyter.org/helm-chart/info.json | jq -er '.jupyterhub.${{ matrix.upgrade-from }}')
+          # NOTE: We change the directory so jupyterhub the chart name won't be
+          #       misunderstood as the local folder name.
+          #
+          #       https://github.com/helm/helm/issues/9244
+          cd ci
+
+          if [ ${{ matrix.upgrade-from }} = stable ]; then
+            UPGRADE_FROM_VERSION=$(helm show chart --repo=https://hub.jupyter.org/helm-chart/ jupyterhub | yq e '.version' -)
+          elif [ ${{ matrix.upgrade-from }} = dev ]; then
+            UPGRADE_FROM_VERSION=$(helm show chart --devel --repo=https://hub.jupyter.org/helm-chart/ jupyterhub | yq e '.version' -)
           else
             UPGRADE_FROM_VERSION=${{ matrix.upgrade-from }}
           fi
@@ -289,11 +297,6 @@ jobs:
           echo ""
           echo "Installing already released jupyterhub version $UPGRADE_FROM_VERSION"
 
-          # FIXME: We change the directory so jupyterhub the chart name won't be
-          #        misunderstood as the local folder name.
-          #
-          #        https://github.com/helm/helm/issues/9244
-          cd ci
           helm install jupyterhub --repo https://hub.jupyter.org/helm-chart/ jupyterhub --values ../dev-config.yaml --version=$UPGRADE_FROM_VERSION ${{ matrix.upgrade-from-extra-args }}
 
       - name: "(Upgrade) Install helm diff"


### PR DESCRIPTION
- ci: fetch stable/dev releases using helm show to avoid cache issues

> Previously we fetched the latest stable and dev release from metadata we
have maintained, but doing that and then using `helm install` of that
version made us use two sources of data, where one could be relatively
outdated due to hitting a cache while the other may not.
>
>Using `helm show`, we rely on the helm chart repository website
returning a index.yaml listing versions etc both when checking whats the
latest versions, and when installing - like that we avoid a cache issue
I think.

- ci: cleanup unused sourcing of ci/common

---

Sibling PR to https://github.com/jupyterhub/binderhub/pull/1785
