### PR TITLE
Move note box to before list of cloud providers.

### DIFF
--- a/docs/source/kubernetes/setup-kubernetes.md
+++ b/docs/source/kubernetes/setup-kubernetes.md
@@ -6,6 +6,12 @@ Kubernetes' documentation describes the many [ways to set up a cluster][ways to 
 We attempt to provide quick instructions for the most painless and popular ways of setting up
 a Kubernetes cluster on various cloud providers and on other infrastructure.
 
+```{note}
+During the process of setting up JupyterHub, you'll be creating some
+files for configuration purposes. It may be helpful to create a folder
+for your JuypterHub deployment to keep track of these files.
+```
+
 Choose one option and proceed.
 
 ```{toctree}
@@ -20,12 +26,6 @@ ibm/step-zero-ibm
 digital-ocean/step-zero-digital-ocean
 ovh/step-zero-ovh
 other-infrastructure/step-zero-other
-```
-
-```{note}
-During the process of setting up JupyterHub, you'll be creating some
-files for configuration purposes. It may be helpful to create a folder
-for your JuypterHub deployment to keep track of these files.
 ```
 
 [ways to set up a cluster]: https://kubernetes.io/docs/setup/


### PR DESCRIPTION
Because we expect the readers to click in one of the cloud providers, the note box should come before the list of links.