### PR TITLE
Add `hub.customScopes` directly mapping to `c.JupyterHub.custom_scopes`

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -335,6 +335,7 @@ c.KubeSpawner.volume_mounts.extend(
 
 c.JupyterHub.services = []
 c.JupyterHub.load_roles = []
+c.JupyterHub.custom_scopes = get_config("hub.customScopes", {})
 
 # jupyterhub-idle-culler's permissions are scoped to what it needs only, see
 # https://github.com/jupyterhub/jupyterhub-idle-culler#permissions.

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1410,6 +1410,31 @@ properties:
               An alias for api_token provided for backward compatibility by
               the JupyterHub Helm chart that will be transformed to
               api_token.
+      customScopes:
+        type: object
+        additionalProperties: true
+        description: |
+          This is where you should define JupyterHub custom scopes and apply them to
+          JupyterHub users, groups, and services to grant them additional
+          permissions as defined in JupyterHub's RBAC system.
+
+          Complement this documentation with [JupyterHub's
+          documentation](https://jupyterhub.readthedocs.io/en/stable/rbac/scopes.html#custom-scopes)
+          about `custom_scopes`.
+
+          ```yaml
+          hub:
+            customScopes:
+              "custom:myservice:read":
+                description: read-only access to myservice
+
+              "custom:myservice:write":
+                description: write access to myservice 
+                subscopes: ["custom:myservice:read"]
+          ```
+
+          When configuring JupyterHub custom scopes via this Helm chart, the `name`
+          field can be omitted as it can be implied by the dictionary key.
       loadRoles:
         type: object
         additionalProperties: true

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1432,9 +1432,6 @@ properties:
                 description: write access to myservice 
                 subscopes: ["custom:myservice:read"]
           ```
-
-          When configuring JupyterHub custom scopes via this Helm chart, the `name`
-          field can be omitted as it can be implied by the dictionary key.
       loadRoles:
         type: object
         additionalProperties: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -95,6 +95,7 @@ hub:
     runAsGroup: 1000
     allowPrivilegeEscalation: false
   lifecycle: {}
+  customScopes: {}
   loadRoles: {}
   services: {}
   pdb:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -161,6 +161,12 @@ hub:
       oauth_roles: [dummy]
       info:
         key1: value1
+  customScopes:
+    "custom:myservice:read":
+      description: read-only access to myservice
+    "custom:myservice:write":
+      description: write access to myservice
+      subscopes: ["custom:myservice:read"]
   loadRoles:
     test-role-1:
       name: test-role-1


### PR DESCRIPTION
This is a first draft to support `custom_scopes`, I am not sure how to test it. Any feedback and help is welcome. 

Fixes #3265

\cc @consideRatio and @minrk 