### PR TITLE
Publish to Docker Hub alongside Quay.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,6 +109,7 @@ jobs:
         if: steps.publishing.outputs.publishing
         run: |
           docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}" docker.io
 
       - name: Configure a git user
         # Having a user.email and user.name configured with git is required to

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@
 #
 #   https://github.com/koalaman/shellcheck#installing
 #
-#   pre-commit run --config .pre-commit-config-shellcheck.yaml --all-files
+#   pre-commit run --hook-stage=manual shellcheck --all-files
 #
 repos:
   # Autoformat: Python code, syntax patterns are modernized
@@ -37,6 +37,7 @@ repos:
           - --target-version=py39
           - --target-version=py310
           - --target-version=py311
+          - --target-version=py312
 
   # Autoformat: Python code
   - repo: https://github.com/pycqa/isort

--- a/ci/publish
+++ b/ci/publish
@@ -6,10 +6,10 @@
 # Exit on errors, assert env vars, log commands
 set -eux
 
-PUBLISH_ARGS="--push --publish-chart \
+PUBLISH_ARGS="--push \
     --builder docker-buildx \
     --platform linux/amd64 --platform linux/arm64 \
-    "
+"
 
 # chartpress use git to push to our Helm chart repository, which is the gh-pages
 # branch of jupyterhub/helm-chart. We have installed a private SSH key within
@@ -33,13 +33,17 @@ if [[ $GITHUB_REF != refs/tags/* ]]; then
     EXTRA_MESSAGE="${GITHUB_REPOSITORY}${PR_OR_HASH} ${LATEST_COMMIT_TITLE}"
 
     # shellcheck disable=SC2086
-    chartpress $PUBLISH_ARGS --extra-message "${EXTRA_MESSAGE}"
+    chartpress $PUBLISH_ARGS --extra-message "${EXTRA_MESSAGE}" --publish-chart
+    # shellcheck disable=SC2086
+    chartpress $PUBLISH_ARGS --extra-message "${EXTRA_MESSAGE}" --image-prefix=jupyterhub/k8s-
 else
     # Setting a tag explicitly enforces a rebuild if this tag had already been
     # built and we wanted to override it.
 
     # shellcheck disable=SC2086
-    chartpress $PUBLISH_ARGS --tag "${GITHUB_REF:10}"
+    chartpress $PUBLISH_ARGS --tag "${GITHUB_REF:10}" --publish-chart
+    # shellcheck disable=SC2086
+    chartpress $PUBLISH_ARGS --tag "${GITHUB_REF:10}" --image-prefix=jupyterhub/k8s-
 fi
 
 # Let us log the changes chartpress did, it should include replacements for

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -12,41 +12,21 @@ changes in pull requests], this list should be updated.
 [development releases]: https://hub.jupyter.org/helm-chart/#development-releases-jupyterhub
 [breaking changes in pull requests]: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking
 
-### Default image registry moved to [quay.io](https://quay.io)
+### Default image registry changed to Quay.io
 
-We have moved the registry where we publish our docker images from [Docker Hub](https://hub.docker.com)
-to [Quay.io](https://quay.io). This move is to ensure our users are not [throttled by Docker Hub](https://docs.docker.com/docker-hub/download-rate-limit/),
-and us maintainers don't have to apply for 'sponsored OSS Project' from docker each year. This
-should have no material impact on your experience.
+We now publish the chart's docker images to both [Quay.io] and [Docker Hub] and
+the chart is from now configured to use the images at Quay.io by default.
+Previous releases of images (excluding pre-releases) has been copied over to
+Quay.io as well.
 
-For the benefit of people running older versions of z2jh and are throttled by dockerhub,
-we have actually copied all our _released_ images from Docker Hub to Quay.io as well.
-So you can opt in to using the images from Quay.io with the following config:
+The change is to ensure that images can be pulled without a [Docker Hub rate
+limit] even if the [JupyterHub organization on Docker Hub] wouldn't be sponsored
+by Docker Hub in the future, something we need to apply for each year.
 
-```yaml
-hub:
-  image:
-    name: quay.io/jupyterhub/k8s-hub
-proxy:
-  chp:
-    image:
-      name: quay.io/jupyterhub/configurable-http-proxy
-  secretSync:
-    image:
-      name: quay.io/jupyterhub/k8s-secret-sync
-singleuser:
-  networkTools:
-    image:
-      name: quay.io/jupyterhub/k8s-network-tools
-prePuller:
-  hook:
-    image:
-      name: quay.io/jupyterhub/k8s-image-awaiter
-```
-
-You don't have to explicitly specify the tag, as the existing tags
-will work. Note that this **only** works for _released_ versions of
-z2jh - if you are using a _dev_ version of z2jh, this will not work.
+[docker hub]: https://hub.docker.com
+[docker hub rate limit]: https://docs.docker.com/docker-hub/download-rate-limit/
+[jupyterhub organization on docker hub]: https://hub.docker.com/u/jupyterhub
+[quay.io]: https://quay.io
 
 ## 3.1
 


### PR DESCRIPTION
This is a followup to #3254 where we switched to rely on quay.io over docker hub.

## Related

- Links to other related PRs: https://github.com/jupyterhub/team-compass/issues/688#issuecomment-1825675990