### PR TITLE
update openshift documentation

### DIFF
--- a/docs/source/kubernetes/redhat/step-zero-openshift.md
+++ b/docs/source/kubernetes/redhat/step-zero-openshift.md
@@ -4,10 +4,12 @@
 
 [OpenShift](https://www.okd.io/) from RedHat is a cluster manager based on Kubernetes.
 
-For setting up JupyterHub on OpenShift, check out the [JupyterHub on OpenShift](https://github.com/jupyter-on-openshift/jupyterhub-quickstart)
-project. It provides an OpenShift template based JupyterHub deployment. Zero to JupyterHub uses
-[helm](https://helm.sh) which is currently usable with OpenShift; yet deploying helm on OpenShift
-is somewhat complicated (see RedHat's blog post on [Getting Started with Helm on OpenShift](https://cloud.redhat.com/blog/getting-started-helm-openshift)).
+For running Z2JH on openshift, check out the [z2jh-openshift](https://github.com/gembaadvantage/z2jh-openshift) project. It customizes the provided helm chart with security configuration required by OpenShift, and makes minor alterations to network policies to enable networking with the weave NPC and openshift-dns.
+
+Otherwise for setting up alternative notebook environments, checkout:
+
+- [RedHat OpenShift Data Science](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-data-science) or the OpenShift
+- [OpenDataHub](https://opendatahub.io/) operator.
 
 ## Additional resources about Jupyter on OpenShift
 

--- a/docs/source/kubernetes/redhat/step-zero-openshift.md
+++ b/docs/source/kubernetes/redhat/step-zero-openshift.md
@@ -6,7 +6,4 @@
 
 For running Z2JH on openshift, check out the [z2jh-openshift](https://github.com/gembaadvantage/z2jh-openshift) project. It customizes the containers used by the helm chart with security configuration required by OpenShift, and makes minor alterations to network policies to enable networking with the Weave NPC and the default OpenShift DNS.
 
-Otherwise for setting up alternative notebook environments, checkout:
-
-- [RedHat OpenShift Data Science](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-data-science) operator.
-- [OpenDataHub](https://opendatahub.io/) operator.
+For more information please see the [ongoing discourse discussion](https://discourse.jupyter.org/t/zero-to-jupyterhub-and-red-hat-openshift/12656).

--- a/docs/source/kubernetes/redhat/step-zero-openshift.md
+++ b/docs/source/kubernetes/redhat/step-zero-openshift.md
@@ -4,15 +4,9 @@
 
 [OpenShift](https://www.okd.io/) from RedHat is a cluster manager based on Kubernetes.
 
-For running Z2JH on openshift, check out the [z2jh-openshift](https://github.com/gembaadvantage/z2jh-openshift) project. It customizes the provided helm chart with security configuration required by OpenShift, and makes minor alterations to network policies to enable networking with the weave NPC and openshift-dns.
+For running Z2JH on openshift, check out the [z2jh-openshift](https://github.com/gembaadvantage/z2jh-openshift) project. It customizes the containers used by the helm chart with security configuration required by OpenShift, and makes minor alterations to network policies to enable networking with the Weave NPC and the default OpenShift DNS.
 
 Otherwise for setting up alternative notebook environments, checkout:
 
-- [RedHat OpenShift Data Science](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-data-science) or the OpenShift
+- [RedHat OpenShift Data Science](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-data-science) operator.
 - [OpenDataHub](https://opendatahub.io/) operator.
-
-## Additional resources about Jupyter on OpenShift
-
-- An excellent series of OpenShift blog posts on Jupyter and OpenShift
-  authored by Red Hat developer, Graham Dumpleton, are
-  available on the [OpenShift blog](https://cloud.redhat.com/blog/jupyter-openshift-using-openshift-data-analytics).


### PR DESCRIPTION
Hi, I have a working deployment of the Z2JH working with OpenShift. The [docs for deploying JupyterHub to OpenShift](https://z2jh.jupyter.org/en/stable/kubernetes/redhat/step-zero-openshift.html) link to a [repo abandoned in 2019](https://github.com/jupyter-on-openshift/jupyterhub-quickstart/issues/38#issuecomment-900629681).

I am amending the documentation to point to my working repository [here](https://github.com/gembaadvantage/z2jh-openshift) as a way to start this conversation :).

Please let me know if you would prefer that I attempt to merge these changes into the trunk of the Z2JH project, and create documentation for that; or if you would prefer for them to be separate due to the additional requirements OpenShift enforces.