### PR TITLE
Conditionally set resourceLock to prevent chart incompatibilities with 1.27+ binary of kube-scheduler

### DIFF
--- a/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/configmap.yaml
@@ -29,7 +29,11 @@ data:
     {{- end }}
     kind: KubeSchedulerConfiguration
     leaderElection:
+      {{- if semverCompare ">=1.27.0-0" .Capabilities.KubeVersion.Version }}
+      resourceLock: leases
+      {{- else }}
       resourceLock: endpointsleases
+      {{- end }}
       resourceName: {{ include "jupyterhub.user-scheduler-lock.fullname" . }}
       resourceNamespace: "{{ .Release.Namespace }}"
     profiles:


### PR DESCRIPTION
This PR aims to prevent an issue with the installation of the Chart with a `kube-scheduler` version that removes the `endpointsleases` resource lock (which is in 1.27+), which is the current default in the Chart. For reference, the resource lock can only be `leases` as referenced here https://github.com/kubernetes/kubernetes/blob/v1.27.0/pkg/scheduler/apis/config/validation/validation.go#L48, otherwise this function errors.