### PR TITLE
Drop support for k8s 1.24, require k8s 1.25+

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -137,7 +137,7 @@ jobs:
               --set hub.image.name=quay.io/jupyterhub/k8s-hub-slim
               --set prePuller.hook.enabled=true
               --set prePuller.hook.pullOnlyOnChanges=true
-          - k3s-channel: v1.26 # also test hub.existingSecret
+          - k3s-channel: v1.28 # also test hub.existingSecret
             test: install
             local-chart-extra-args: >-
               --set hub.existingSecret=test-hub-existing-secret
@@ -160,7 +160,7 @@ jobs:
           # information from
           # https://hub.jupyter.org/helm-chart/info.json
           #
-          - k3s-channel: v1.26
+          - k3s-channel: v1.27
             test: upgrade
             upgrade-from: stable
             upgrade-from-extra-args: >-
@@ -173,7 +173,7 @@ jobs:
               --set hub.db.type=sqlite-pvc
               --set singleuser.storage.type=dynamic
             create-k8s-test-resources: true
-          - k3s-channel: v1.25
+          - k3s-channel: v1.26
             test: upgrade
             upgrade-from: dev
             upgrade-from-extra-args: >-
@@ -183,7 +183,7 @@ jobs:
             local-chart-extra-args: >-
               --set hub.db.type=sqlite-pvc
               --set singleuser.storage.type=dynamic
-          - k3s-channel: v1.24
+          - k3s-channel: v1.25
             test: upgrade
             # We're testing hub.db.upgrade with PostgreSQL so this version must be old
             # enough to require a DB upgrade
@@ -223,7 +223,7 @@ jobs:
       # kubectl and helm
       #
       # ref: https://github.com/jupyterhub/action-k3s-helm/
-      - uses: jupyterhub/action-k3s-helm@v3
+      - uses: jupyterhub/action-k3s-helm@v4
         with:
           k3s-channel: ${{ matrix.k3s-channel }}
           metrics-enabled: false

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -12,6 +12,8 @@ changes in pull requests], this list should be updated.
 [development releases]: https://hub.jupyter.org/helm-chart/#development-releases-jupyterhub
 [breaking changes in pull requests]: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking
 
+- K8s 1.25 is now required.
+
 ## 3.2
 
 ### 3.2.1 - 2023-11-27

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -8,7 +8,7 @@ keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org
 sources: [https://github.com/jupyterhub/zero-to-jupyterhub-k8s]
 icon: https://hub.jupyter.org/helm-chart/images/hublogo.svg
-kubeVersion: ">=1.24.0-0"
+kubeVersion: ">=1.25.0-0"
 maintainers:
   # Since it is a requirement of Artifact Hub to have specific maintainers
   # listed, we have added some below, but in practice the entire JupyterHub team


### PR DESCRIPTION
This is a routine requirement update along with the policy of supporting only the k8s version still supported by major cloud providers' services like GKE/EKS/AKS.

- Closes #3309
