### PR TITLE
ci: update kube-scheduler binary's minor version to bump

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -68,7 +68,7 @@ jobs:
             registry: registry.k8s.io
             repository: kube-scheduler
             values_path: scheduling.userScheduler.image.tag
-            version_startswith: "v1.26"
+            version_startswith: "v1.28"
             version_patch_regexp_group_suffix: ""
 
           - name: pause


### PR DESCRIPTION
A change I forgot to make in #3312 that led to the incorrect automated PR #3316 for example.