### PR TITLE
Add startup-delay workaround under https instructions in security.md

### DIFF
--- a/docs/source/administrator/security.md
+++ b/docs/source/administrator/security.md
@@ -52,6 +52,11 @@ changes to your `config.yaml` file:
          - <your-domain-name>
        letsencrypt:
          contactEmail: <your-email-address>
+     traefik:
+       extraInitContainers:
+         - name: startup-delay
+           image: busybox:stable
+           command: [ "sh", "-c", "sleep 20" ]
    ```
 
 2. Apply the config changes by running `helm upgrade ...`


### PR DESCRIPTION
Referencing https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2601, on some providers autohttps could be setting up certs with letsencrypt before proxy-public startup has completed, leading to failing challenge-response.

I was struggling with this for several hours before finding the discussion linked above, and it was this change that I'm proposing, to an otherwise vanilla z2jh on GKE, that solved the problem.