### PR TITLE
Fix previously ignored revisionHistoryLimit config

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if typeIs "int" .Values.hub.revisionHistoryLimit }}
+  {{- if not (typeIs "<nil>" .Values.hub.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.hub.revisionHistoryLimit }}
   {{- end }}
   replicas: 1

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -34,7 +34,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 100%
-  {{- if typeIs "int" .Values.prePuller.revisionHistoryLimit }}
+  {{- if not (typeIs "<nil>" .Values.prePuller.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.prePuller.revisionHistoryLimit }}
   {{- end }}
   template:

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if typeIs "int" .Values.proxy.traefik.revisionHistoryLimit }}
+  {{- if not (typeIs "<nil>" .Values.proxy.traefik.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.proxy.traefik.revisionHistoryLimit }}
   {{- end }}
   replicas: 1

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if typeIs "int" .Values.proxy.chp.revisionHistoryLimit }}
+  {{- if not (typeIs "<nil>" .Values.proxy.chp.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.proxy.chp.revisionHistoryLimit }}
   {{- end }}
   replicas: 1

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
   podManagementPolicy: Parallel
-  {{- if typeIs "int" .Values.scheduling.userPlaceholder.revisionHistoryLimit }}
+  {{- if not (typeIs "<nil>" .Values.scheduling.userPlaceholder.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.scheduling.userPlaceholder.revisionHistoryLimit }}
   {{- end }}
   replicas: {{ .Values.scheduling.userPlaceholder.replicas }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 spec:
-  {{- if typeIs "int" .Values.scheduling.userScheduler.revisionHistoryLimit }}
+  {{- if not (typeIs "<nil>" .Values.scheduling.userScheduler.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.scheduling.userScheduler.revisionHistoryLimit }}
   {{- end }}
   replicas: {{ .Values.scheduling.userScheduler.replicas }}


### PR DESCRIPTION
Sometimes Helm reports type float64 for integer numbers set in `values.yaml`. See this Helm issue for an example:
https://github.com/helm/helm/issues/4982

This fix replaces the type check with a simple check + integer cast.