### PR TITLE
Add changelog for 3.3.0

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -12,7 +12,54 @@ changes in pull requests], this list should be updated.
 [development releases]: https://hub.jupyter.org/helm-chart/#development-releases-jupyterhub
 [breaking changes in pull requests]: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking
 
-- K8s 1.25 is now required.
+- Drop support for k8s 1.24, require k8s 1.25+ [#3319](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3319) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+- user-scheduler: update to use kube-scheduler 1.28, from 1.26 - require k8s 1.24+ [#3312](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3312) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+
+## 3.3
+
+### 3.3.0 - 2024-03-20
+
+This release updates JupyterHub from 4.0.2 to 4.1.0 and OAuthenticator from
+16.2.1 to 16.3.0. Both updates provide security patches. For more information,
+see [JupyterHub's changelog] and [OAuthenticator's changelog].
+
+[JupyterHub's changelog]: https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html
+
+[OAuthenticator's changelog]: https://oauthenticator.readthedocs.io/en/latest/reference/changelog.html
+
+([full changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/3.2.1...3.3.0))
+
+#### Bugs fixed
+
+- Fix previously ignored revisionHistoryLimit config [#3357](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3357) ([@SchutteJan](https://github.com/SchutteJan), [@consideRatio](https://github.com/consideRatio))
+
+#### Maintenance and upkeep improvements
+
+- Update oauthenticator from 16.2.1 to 16.3.0 [#3363](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3363) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
+- Update jupyterhub from 4.0.2 to 4.1.0 [#3362](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3362) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
+- Remove additional comma in compare-values-schema-content.py [#3350](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3350) ([@ya0guang](https://github.com/ya0guang), [@consideRatio](https://github.com/consideRatio))
+- Update kube-scheduler version from v1.26.11 to v1.26.15 [#3301](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3301),[#3312](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3312),[#3324](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3324),[#3344](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3344),[#3359](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3359),[d83ae04b](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/commit/d83ae04b5111cf2968d07f0f38db082589e28cd3) ([@consideRatio](https://github.com/consideRatio), [@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
+- Update library/traefik version from v2.10.5 to v2.11.0 [#3283](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3283),[#3295](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3295),[#3343](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3343) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
+
+#### Documentation improvements
+
+- Fix documented example for proxy.chp.extraCommandLineFlags [#3337](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3337) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+- docs: fix storageclass link's anchor [#3322](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3322) ([@consideRatio](https://github.com/consideRatio))
+- update openshift documentation [#3273](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3273) ([@WilliamHoltam](https://github.com/WilliamHoltam), [@manics](https://github.com/manics))
+
+#### Continuous integration improvements
+
+- ci: update kube-scheduler binary's minor version to bump [#3323](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3323) ([@consideRatio](https://github.com/consideRatio))
+- ci: update circleci workflow for arm64, test with latest k3s [#3313](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3313) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+
+#### Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2023-11-27&to=2024-03-20&type=c))
+
+@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2023-11-27..2024-03-20&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2023-11-27..2024-03-20&type=Issues)) | @Kyrremann ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AKyrremann+updated%3A2023-11-27..2024-03-20&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Amanics+updated%3A2023-11-27..2024-03-20&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2023-11-27..2024-03-20&type=Issues)) | @SchutteJan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3ASchutteJan+updated%3A2023-11-27..2024-03-20&type=Issues)) | @StefanVanDyck ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AStefanVanDyck+updated%3A2023-11-27..2024-03-20&type=Issues)) | @WilliamHoltam ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AWilliamHoltam+updated%3A2023-11-27..2024-03-20&type=Issues)) | @ya0guang ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aya0guang+updated%3A2023-11-27..2024-03-20&type=Issues)) | @yuvipanda ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ayuvipanda+updated%3A2023-11-27..2024-03-20&type=Issues))
 
 ## 3.2
 


### PR DESCRIPTION
This is a release with everything in main branch, but with the breaking change PRs #3312 and #3319 reverted.

I'll cherry-pick the changelog into the 3.x branch if this is merged and then cut a release from there with 3.3.0.

---

Screenshot of docs preview:

![image](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/assets/3837114/dbe24192-d4b5-468d-89af-ce4596f22005)
