### PR TITLE
hub image: downgrade to use pycurl with functional wheel

### DIFF
--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -29,7 +29,8 @@ jupyterhub-kubespawner
 ## Other optional dependencies for additional features
 pymysql  # mysql
 psycopg2  # postgres
-pycurl  # internal http requests handle more load with pycurl
+# pycurl 7.45.3 is avoided because https://github.com/pycurl/pycurl/issues/834
+pycurl!=7.45.3  # internal http requests handle more load with pycurl
 sqlalchemy-cockroachdb # cocroachdb
 statsd  # statsd metrics collection (TODO: remove soon, since folks use prometheus)
 

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -129,7 +129,7 @@ pyasn1==0.5.1
     # via ldap3
 pycparser==2.21
     # via cffi
-pycurl==7.45.3
+pycurl==7.45.2
     # via -r requirements.in
 pyjwt[crypto]==2.8.0
     # via


### PR DESCRIPTION
- Fixes #3366, described in https://discourse.jupyter.org/t/suddenly-getting-oath-cert-error/24217, by pinning to an older functional version.

I tried to do `--no-binary=pycurl` etc, but we have multistage builds etc making things a bit complicated, and I didn't got it working.