### PR TITLE
network-tools image: pin alpine 3.18 for legacy iptables

### DIFF
--- a/images/network-tools/Dockerfile
+++ b/images/network-tools/Dockerfile
@@ -1,4 +1,9 @@
-FROM alpine:3
+# FIXME: use of alpine:3.19 makes iptables work in "nf_tables" mode instead of
+#        "legacy" mode, and then our init container breaks.
+#
+#        ref: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3368
+#
+FROM alpine:3.18
 
 # VULN_SCAN_TIME=2024-01-29_05:13:22
 


### PR DESCRIPTION
- Workaround for #3368