### PR TITLE
unpin pycurl

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -21,9 +21,11 @@ FROM python:3.11-bullseye as build-stage
 COPY requirements.txt requirements.txt
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    pip install build \
- && pip wheel \
+    pip wheel \
         --wheel-dir=/tmp/wheels \
+        # pycurl 7.45.3 has wheels, but they aren't portable
+        # https://github.com/pycurl/pycurl/issues/834
+        --no-binary pycurl \
         -r requirements.txt \
         # Additional wheels for default-stage. Updates below should be repeated
         # in default-stage.
@@ -63,11 +65,13 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # install wheels built in the build stage
+# --no-index ensures _only_ wheels from the build stage are installed
 COPY requirements.txt /tmp/requirements.txt
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
     pip install \
+        --no-index \
         --find-links=/tmp/wheels/ \
         -r /tmp/requirements.txt
 
@@ -93,6 +97,7 @@ ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
     pip install \
+        --no-index \
         --find-links=/tmp/wheels/ \
         # Updates below should be repeated in build-stage.
         #

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -29,8 +29,7 @@ jupyterhub-kubespawner
 ## Other optional dependencies for additional features
 pymysql  # mysql
 psycopg2  # postgres
-# pycurl 7.45.3 is avoided because https://github.com/pycurl/pycurl/issues/834
-pycurl!=7.45.3  # internal http requests handle more load with pycurl
+pycurl  # internal http requests handle more load with pycurl
 sqlalchemy-cockroachdb # cocroachdb
 statsd  # statsd metrics collection (TODO: remove soon, since folks use prometheus)
 

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -129,7 +129,7 @@ pyasn1==0.5.1
     # via ldap3
 pycparser==2.21
     # via cffi
-pycurl==7.45.2
+pycurl==7.45.3
     # via -r requirements.in
 pyjwt[crypto]==2.8.0
     # via


### PR DESCRIPTION
and make sure we build it from source with `--no-binary pycurl`

Also make sure to use build-stage wheels by adding `--no-index` to pip install.

avoids installing higher-priority wheels from PyPI instead of what we built (i.e. pycurl)

`--no-index` was the part missing in #3365, because the `manylinux_2_28` wheel from PyPI was preferred at install time to the `linux_arch` wheel that we built. `--no-index` ensures no contact with PyPI at all at install time.

This is a low priority fix to unpin versions going forward, no need to trigger a new patch release.