### PR TITLE
Security context hardening

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -91,10 +91,14 @@ hub:
   podSecurityContext:
     runAsNonRoot: true
     fsGroup: 1000
+    seccompProfile:
+      type: "RuntimeDefault"
   containerSecurityContext:
     runAsUser: 1000
     runAsGroup: 1000
     allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
   lifecycle: {}
   loadRoles: {}
   services: {}
@@ -202,6 +206,10 @@ proxy:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     image:
       name: quay.io/jupyterhub/configurable-http-proxy
       # tag is automatically bumped to new patch versions by the
@@ -256,6 +264,10 @@ proxy:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     image:
       name: traefik
       # tag is automatically bumped to new patch versions by the
@@ -307,6 +319,10 @@ proxy:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     image:
       name: quay.io/jupyterhub/k8s-secret-sync
       tag: "set-by-chartpress"
@@ -488,6 +504,10 @@ scheduling:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     image:
       # IMPORTANT: Bumping the minor version of this binary should go hand in
       #            hand with an inspection of the user-scheduelr's RBAC
@@ -568,6 +588,10 @@ scheduling:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     resources: {}
   corePods:
     tolerations:
@@ -605,6 +629,10 @@ prePuller:
     runAsUser: 65534 # nobody user
     runAsGroup: 65534 # nobody group
     allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: "RuntimeDefault"
   extraTolerations: []
   # hook relates to the hook-image-awaiter Job and hook-image-puller DaemonSet
   hook:
@@ -621,6 +649,10 @@ prePuller:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     podSchedulingWaitDuration: 10
     nodeSelector: {}
     tolerations: []
@@ -639,6 +671,10 @@ prePuller:
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     image:
       name: registry.k8s.io/pause
       # tag is automatically bumped to new patch versions by the

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -89,6 +89,7 @@ hub:
     pullSecrets: []
   resources: {}
   podSecurityContext:
+    runAsNonRoot: true
     fsGroup: 1000
   containerSecurityContext:
     runAsUser: 1000
@@ -197,6 +198,7 @@ proxy:
   chp:
     revisionHistoryLimit:
     containerSecurityContext:
+      runAsNonRoot: true
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
@@ -250,6 +252,7 @@ proxy:
   traefik:
     revisionHistoryLimit:
     containerSecurityContext:
+      runAsNonRoot: true
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
@@ -300,6 +303,7 @@ proxy:
     extraPodSpec: {}
   secretSync:
     containerSecurityContext:
+      runAsNonRoot: true
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
@@ -480,6 +484,7 @@ scheduling:
                 weight: 1
             type: MostAllocated
     containerSecurityContext:
+      runAsNonRoot: true
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
@@ -559,6 +564,7 @@ scheduling:
     labels: {}
     annotations: {}
     containerSecurityContext:
+      runAsNonRoot: true
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
@@ -595,6 +601,7 @@ prePuller:
   annotations: {}
   resources: {}
   containerSecurityContext:
+    runAsNonRoot: true
     runAsUser: 65534 # nobody user
     runAsGroup: 65534 # nobody group
     allowPrivilegeEscalation: false
@@ -610,6 +617,7 @@ prePuller:
       pullPolicy:
       pullSecrets: []
     containerSecurityContext:
+      runAsNonRoot: true
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false
@@ -627,6 +635,7 @@ prePuller:
   extraImages: {}
   pause:
     containerSecurityContext:
+      runAsNonRoot: true
       runAsUser: 65534 # nobody user
       runAsGroup: 65534 # nobody group
       allowPrivilegeEscalation: false


### PR DESCRIPTION
This should allow running JupyterHub in a namespace with a `restricted` security profile according to the [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) (assuming an appropriate configuration for the singleuser pods in KubeSpawner).