### PR TITLE
Add `singleuser.storage.dynamic.subPath` config

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -276,6 +276,7 @@ if storage_type == "dynamic":
         {
             "name": volume_name_template,
             "persistentVolumeClaim": {"claimName": pvc_name_template},
+            "subPath": get_config("singleuser.storage.dynamic.subPath"),
         }
     ]
     c.KubeSpawner.volume_mounts = [

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -276,13 +276,13 @@ if storage_type == "dynamic":
         {
             "name": volume_name_template,
             "persistentVolumeClaim": {"claimName": pvc_name_template},
-            "subPath": get_config("singleuser.storage.dynamic.subPath"),
         }
     ]
     c.KubeSpawner.volume_mounts = [
         {
             "mountPath": get_config("singleuser.storage.homeMountPath"),
             "name": volume_name_template,
+            "subPath": get_config("singleuser.storage.dynamic.subPath"),
         }
     ]
 elif storage_type == "static":

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2373,6 +2373,14 @@ properties:
 
                   There is of a default StorageClass available in k8s clusters
                   for use if this is unspecified.
+              subPath: &subPath-spec
+                type: [string, "null"]
+                description: |
+                  Configures the `subPath` field of a
+                  `KubeSpawner.volume_mounts` entry added by the Helm chart.
+
+                  Path within the volume from which the container's volume
+                  should be mounted. Defaults to "" (volume's root).
               volumeNameTemplate:
                 type: [string, "null"]
                 description: |
@@ -2402,14 +2410,7 @@ properties:
                 description: |
                   Configures `KubeSpawner.pvc_claim_name` to reference
                   pre-existing storage.
-              subPath:
-                type: [string, "null"]
-                description: |
-                  Configures the `subPath` field of a
-                  `KubeSpawner.volume_mounts` entry added by the Helm chart.
-
-                  Path within the volume from which the container's volume
-                  should be mounted.
+              subPath: *subPath-spec
           type:
             enum: [dynamic, static, none]
             description: |

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -395,6 +395,7 @@ singleuser:
       pvcNameTemplate: claim-{username}{servername}
       volumeNameTemplate: volume-{username}{servername}
       storageAccessModes: [ReadWriteOnce]
+      subPath:
   image:
     name: quay.io/jupyterhub/k8s-singleuser-sample
     tag: "set-by-chartpress"


### PR DESCRIPTION
Some [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes) (e.g. [vSphere](https://kubernetes.io/docs/concepts/storage/storage-classes/#vsphere)) provide volumes that contain a `lost+found` directory at its root (`/`) by default.