### PR TITLE
 Add config for k8s Services' `ipFamilies` and `ipFamilyPolicy`

### DIFF
--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -19,9 +19,6 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.hub.service.type }}
-  {{- with .Values.hub.service.loadBalancerIP }}
-  loadBalancerIP: {{ . }}
-  {{- end }}
   selector:
     {{- include "jupyterhub.matchLabels" . | nindent 4 }}
   ports:
@@ -38,3 +35,13 @@ spec:
     {{- with .Values.hub.service.extraPorts }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
+  {{- with .Values.hub.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- with .Values.hub.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.hub.service.ipFamilies }}
+  ipFamilies:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/service.yaml
+++ b/jupyterhub/templates/proxy/autohttps/service.yaml
@@ -22,4 +22,11 @@ spec:
   ports:
     - port: 8000
       targetPort: http
+  {{- with .Values.proxy.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.proxy.service.ipFamilies }}
+  ipFamilies:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -79,10 +79,8 @@ spec:
   ipFamilyPolicy: {{ . }}
   {{- end }}
   {{- with .Values.proxy.service.ipFamilies }}
-  ipFamilies: 
-    {{- range $family := . }}
-     - {{ $family }}
-    {{- end }}  
+  ipFamilies:
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
   {{- if eq .Values.proxy.service.type "LoadBalancer" }}
   {{- with .Values.proxy.service.loadBalancerSourceRanges }}

--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -75,6 +75,15 @@ spec:
   {{- with .Values.proxy.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
+  {{- with .Values.proxy.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.proxy.service.ipFamilies }}
+  ipFamilies: 
+    {{- range $family := . }}
+     - {{ $family }}
+    {{- end }}  
+  {{- end }}
   {{- if eq .Values.proxy.service.type "LoadBalancer" }}
   {{- with .Values.proxy.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1150,6 +1150,16 @@ properties:
               A public IP address the hub Kubernetes service should be exposed
               on. To expose the hub directly is not recommended. Instead route
               traffic through the proxy-public service towards the hub.
+          ipFamilyPolicy: &ipFamilyPolicy-spec
+            type: [string]
+            description: |
+              See the [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
+              for more info.
+          ipFamilies: &ipFamilies-spec
+            type: array
+            description: |
+              See the [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
+              for more info.
 
       pdb: &pdb-spec
         type: object
@@ -1774,6 +1784,8 @@ properties:
             description: |
               A list of IP CIDR ranges that are allowed to access the load balancer service.
               Defaults to allowing everyone to access it.
+          ipFamilyPolicy: *ipFamilyPolicy-spec
+          ipFamilies: *ipFamilies-spec
       https:
         type: object
         additionalProperties: false

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -44,6 +44,8 @@ hub:
       appProtocol:
     extraPorts: []
     loadBalancerIP:
+    ipFamilyPolicy: ""
+    ipFamilies: []
   baseUrl: /
   cookieSecret:
   initContainers: []

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -201,6 +201,8 @@ proxy:
     externalIPs: []
     loadBalancerIP:
     loadBalancerSourceRanges: []
+    ipFamilyPolicy: ""
+    ipFamilies: []
   # chp relates to the proxy pod, which is responsible for routing traffic based
   # on dynamic configuration sent from JupyterHub to CHP's REST API.
   chp:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -70,6 +70,9 @@ hub:
       - name: dummy-port-2
         port: 8182
         targetPort: string-named-target-port
+    ipFamilyPolicy: SingleStack
+    ipFamilies:
+      - IPv4
   baseUrl: /
   activeServerLimit: 3
   deploymentStrategy:
@@ -226,6 +229,10 @@ proxy:
     externalIPs:
       - 123.123.123.123
       - 123.123.123.124
+    ipFamilyPolicy: DualStack
+    ipFamilies:
+      - IPv4
+      - IPv6
   chp:
     revisionHistoryLimit: 1
     extraCommandLineFlags:


### PR DESCRIPTION
This pull request addresses issue #3484. It updates the service template to enable users to expose their JupyterHub on an IPv6 address if their cloud allows it. 

EDIT: adds `[hub|proxy].service.[ipFamilies|ipFamilyPolicy]` config