### PR TITLE
Add `ingress.extraPaths` config

### DIFF
--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -24,6 +24,15 @@ spec:
                 name: {{ include "jupyterhub.proxy-public.fullname" $ }}
                 port:
                   name: http
+          {{- range $path := $.Values.ingress.customPaths }}
+          - path: {{ $path.path }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $path.backend.serviceName }}
+                port:
+                  number: {{ $path.backend.servicePort }}
+          {{- end }}
       {{- if $host }}
       host: {{ $host | quote }}
       {{- end }}

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -26,12 +26,16 @@ spec:
                   name: http
           {{- range $path := $.Values.ingress.customPaths }}
           - path: {{ $path.path }}
-            pathType: {{ $.Values.ingress.pathType }}
+            pathType: {{ $path.pathType }}
             backend:
               service:
-                name: {{ $path.backend.serviceName }}
+                name: {{ $path.backend.service.name }}
                 port:
-                  number: {{ $path.backend.servicePort }}
+                  {{- if $path.backend.service.port.number }}
+                  number: {{ $path.backend.service.port.number }}
+                  {{- else if $path.backend.service.port.name }}
+                  name: {{ $path.backend.service.port.name }}
+                  {{- end }}
           {{- end }}
       {{- if $host }}
       host: {{ $host | quote }}

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
                 name: {{ include "jupyterhub.proxy-public.fullname" $ }}
                 port:
                   name: http
-          {{- range $path := $.Values.ingress.customPaths }}
+          {{- range $path := $.Values.ingress.extraPaths }}
           - path: {{ $path.path }}
             pathType: {{ $path.pathType }}
             backend:

--- a/jupyterhub/templates/ingress.yaml
+++ b/jupyterhub/templates/ingress.yaml
@@ -24,19 +24,9 @@ spec:
                 name: {{ include "jupyterhub.proxy-public.fullname" $ }}
                 port:
                   name: http
-          {{- range $path := $.Values.ingress.extraPaths }}
-          - path: {{ $path.path }}
-            pathType: {{ $path.pathType }}
-            backend:
-              service:
-                name: {{ $path.backend.service.name }}
-                port:
-                  {{- if $path.backend.service.port.number }}
-                  number: {{ $path.backend.service.port.number }}
-                  {{- else if $path.backend.service.port.name }}
-                  name: {{ $path.backend.service.port.name }}
-                  {{- end }}
-          {{- end }}
+          {{- with $.Values.ingress.extraPaths }}  
+          {{- . | toYaml | nindent 10 }}  
+          {{- end }}  
       {{- if $host }}
       host: {{ $host | quote }}
       {{- end }}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2761,8 +2761,6 @@ properties:
         type: array
         description: |
           A list of custom paths to be added to the ingress configuration. 
-          Each custom path allows traffic to be routed to a specific backend service.
-          For each path, you can specify the service name, and either a service port number or a service port name.
 
           See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types)
           for more details about paths.

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2757,6 +2757,12 @@ properties:
           See [the Kubernetes
           documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
           for more details about annotations.
+      customPaths:
+        type: array
+        description: |
+          A list of custom paths to be added to the ingress configuration. 
+          Each custom path allows traffic to be routed to a specific backend service.
+          For each path, you can specify the service name, and either a service port number or a service port name.
 
   prePuller:
     type: object

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2757,12 +2757,15 @@ properties:
           See [the Kubernetes
           documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls)
           for more details about annotations.
-      customPaths:
+      extraPaths:
         type: array
         description: |
           A list of custom paths to be added to the ingress configuration. 
           Each custom path allows traffic to be routed to a specific backend service.
           For each path, you can specify the service name, and either a service port number or a service port name.
+
+          See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types)
+          for more details about paths.
 
   prePuller:
     type: object

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -695,7 +695,7 @@ ingress:
   pathSuffix:
   pathType: Prefix
   tls: []
-  customPaths: []
+  extraPaths: []
 
 # cull relates to the jupyterhub-idle-culler service, responsible for evicting
 # inactive singleuser pods.

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -695,6 +695,7 @@ ingress:
   pathSuffix:
   pathType: Prefix
   tls: []
+  customPaths: []
 
 # cull relates to the jupyterhub-idle-culler service, responsible for evicting
 # inactive singleuser pods.

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -574,6 +574,21 @@ ingress:
     - mocked2.domain.name
   pathSuffix: dummy-pathSuffix
   pathType: ImplementationSpecific
+  extraPaths:
+    - pathType: Prefix
+      path: "/foo"
+      backend:
+        service:
+          name: foo
+          port:
+            number: 80
+    - pathType: Prefix
+      path: "/bar"
+      backend:
+        service:
+          name: bar
+          port:
+            name: barPort
   tls:
     - secretName: jupyterhub-tls
       hosts:


### PR DESCRIPTION
Introduces the ability to configure custom paths for the Ingress resource in the Helm chart, allowing users to define additional paths and corresponding backend services directly in the values.yaml file. 