### PR TITLE
ci: configure automatic bump of kube-scheduler to version 1.30.x

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -68,7 +68,7 @@ jobs:
             registry: registry.k8s.io
             repository: kube-scheduler
             values_path: scheduling.userScheduler.image.tag
-            version_startswith: "v1.28"
+            version_startswith: "v1.30"
             version_patch_regexp_group_suffix: ""
 
           - name: pause


### PR DESCRIPTION
- closes #3515 