### PR TITLE
Add changelog for 4.0.0-beta.1

### DIFF
--- a/docs/source/administrator/upgrading/index.md
+++ b/docs/source/administrator/upgrading/index.md
@@ -22,6 +22,7 @@ or the [Discourse forum](https://discourse.jupyter.org/).
 :maxdepth: 1
 :caption: Major releases guides
 
+upgrade-3-to-4
 upgrade-2-to-3
 upgrade-1-to-2
 ```

--- a/docs/source/administrator/upgrading/upgrade-1-to-2.md
+++ b/docs/source/administrator/upgrading/upgrade-1-to-2.md
@@ -1,3 +1,5 @@
+(upgrade-1-to-2)=
+
 # Major upgrade: 1.\* to 2.\*
 
 Z2JH 2 contains several breaking changes, including some that affect the security of your deployment.

--- a/docs/source/administrator/upgrading/upgrade-2-to-3.md
+++ b/docs/source/administrator/upgrading/upgrade-2-to-3.md
@@ -1,3 +1,5 @@
+(upgrade-2-to-3)=
+
 # Major upgrade: 2.\* to 3.\*
 
 Z2JH 3 contains some small breaking changes.

--- a/docs/source/administrator/upgrading/upgrade-3-to-4.md
+++ b/docs/source/administrator/upgrading/upgrade-3-to-4.md
@@ -1,0 +1,5 @@
+(upgrade-3-to-4)=
+
+# Major upgrade: 3.\* to 4.\*
+
+This is currently just a placeholder file for until we have written upgrade docs.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -12,16 +12,101 @@ changes in pull requests], this list should be updated.
 [development releases]: https://hub.jupyter.org/helm-chart/#development-releases-jupyterhub
 [breaking changes in pull requests]: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking
 
-- Update jupyterhub from 4.1.6 to 5.1.0 [#3405](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3405), [#3416](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3416), [#3425](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3425), [#3472](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3472)
-- Drop support for k8s 1.23-1.27, require k8s 1.28+ [#3312](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3312), [#3403](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3403), [#3319](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3319), [#3508](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3508)
-- `jupyterhub-kubespawner` is upgraded one major version from 6.2.0 to 7.0.0,
-  please read [KubeSpawner's changelog]
-  [#3520](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3520)
-- `oauthenticator` is upgraded one major version from 16.3.1 to 17.0.0, please
-  read [OAuthenticator's changelog] if you are using one if its authenticator
-  classes [#3519](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3519)
+## 4.0
 
-[kubespawner's changelog]: https://jupyterhub-kubespawner.readthedocs.io/en/stable/changelog.html
+### 4.0.0-beta.1 - 2024-10-01
+
+This release updates JupyterHub itself from version 4 to 5, and the dependencies
+`jupyterhub-kubespawner`, `oauthenticator`, and `ldapauthenticator` to a new
+major version.
+
+We will provide an [upgrade guide for 3 to 4](upgrade-3-to-4) before the final release, but for now please read the summary of breaking changes below, and the linked changelogs.
+
+#### Breaking changes
+
+- The chart now require Kubernetes 1.28+, up from 1.23+
+- KubeSpawner is upgraded one major version from 6.2.0 to 7.0.0b1
+  - Refer to the [KubeSpawner changelog] for details and pay attention to the
+    entries for KubeSpawner version 7.0.0b1.
+- JupyterHub 4.1.6 has been upgraded to 5.1.0
+  - Refer to the [JupyterHub changelog] for details and pay attention to the
+    entries for JupyterHub version 5.0.0.
+- OAuthenticator 16.3.1 has been upgraded to 17.0.0
+  - If you are using an OAuthenticator based authenticator class
+    (GitHubOAuthenticator, GoogleOAuthenticator, ...), refer to the
+    [OAuthenticator changelog] for details and pay attention to the entries for
+    JupyterHub version 17.0.0.
+- LDAPAuthenticator 1.3.2 has been upgraded to 2.0.0b2
+  - If you are using this authenticator class, refer to the [LDAPAuthenticator
+    changelog] for details and pay attention to the entries for
+    LDAPAuthenticator version 2.0.0.
+
+[ldapauthenticator changelog]: https://github.com/jupyterhub/ldapauthenticator/blob/HEAD/CHANGELOG.md
+
+#### Notable dependencies updated
+
+| Dependency                                                                       | Version in 3.3.8 | Version in 4.0.0-beta.1 | Changelog link                                                                            | Note                               |
+| -------------------------------------------------------------------------------- | ---------------- | ----------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------- |
+| [jupyterhub](https://github.com/jupyterhub/jupyterhub)                           | 4.1.6            | 5.1.0                   | [Changelog](https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html)         | Run in the `hub` pod               |
+| [kubespawner](https://github.com/jupyterhub/kubespawner)                         | 6.2.0            | 7.0.0b1                 | [Changelog](https://jupyterhub-kubespawner.readthedocs.io/en/stable/changelog.html)       | Run in the `hub` pod               |
+| [oauthenticator](https://github.com/jupyterhub/oauthenticator)                   | 16.3.1           | 17.0.0                  | [Changelog](https://oauthenticator.readthedocs.io/en/stable/reference/changelog.html)     | Run in the `hub` pod               |
+| [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)             | 1.3.2            | 2.0.0b2                 | [Changelog](https://github.com/jupyterhub/ldapauthenticator/blob/HEAD/CHANGELOG.md)       | Run in the `hub` pod               |
+| [ltiauthenticator](https://github.com/jupyterhub/ltiauthenticator)               | 1.6.2            | 1.6.2                   | [Changelog](https://github.com/jupyterhub/ltiauthenticator/blob/HEAD/CHANGELOG.md)        | Run in the `hub` pod               |
+| [nativeauthenticator](https://github.com/jupyterhub/nativeauthenticator)         | 1.2.0            | 1.3.0                   | [Changelog](https://github.com/jupyterhub/nativeauthenticator/blob/HEAD/CHANGELOG.md)     | Run in the `hub` pod               |
+| [tmpauthenticator](https://github.com/jupyterhub/tmpauthenticator)               | 1.0.0            | 1.0.0                   | [Changelog](https://github.com/jupyterhub/tmpauthenticator/blob/HEAD/CHANGELOG.md)        | Run in the `hub` pod               |
+| [jupyterhub-idle-culler](https://github.com/jupyterhub/jupyterhub-idle-culler)   | 1.3.1            | 1.4.0                   | [Changelog](https://github.com/jupyterhub/jupyterhub-idle-culler/blob/main/CHANGELOG.md)  | Run in the `hub` pod               |
+| [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy) | 4.6.1            | 4.6.2                   | [Changelog](https://github.com/jupyterhub/configurable-http-proxy/blob/HEAD/CHANGELOG.md) | Run in the `proxy` pod             |
+| [traefik](https://github.com/traefik/traefik)                                    | v2.11.0          | v3.1.4                  | [Changelog](https://github.com/traefik/traefik/blob/HEAD/CHANGELOG.md)                    | Run in the `autohttps` pod         |
+| [kube-scheduler](https://github.com/kubernetes/kube-scheduler)                   | v1.26.15         | v1.30.5                 | [Changelog](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG)               | Run in the `user-scheduler` pod(s) |
+
+For a detailed list of Python dependencies in the `hub` Pod's Docker image,
+inspect the [images/hub/requirements.txt] file and use its git history to see
+what changes between tagged versions.
+
+#### New features added
+
+- Add oauthenticator googlegroups extras and cleanup dependencies [#3523](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3523) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+- Add `ingress.extraPaths` config [#3492](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3492) ([@alxyok](https://github.com/alxyok), [@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+- Add `singleuser.storage.dynamic.subPath` config [#3468](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3468) ([@benz0li](https://github.com/benz0li), [@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+- Add recommended chart labels alongside old labels (`app.kubernetes.io/...`, `helm.sh/chart`) [#3404](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3404) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+
+#### Enhancements made
+
+- Security context hardening [#3464](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3464) ([@lahwaacz](https://github.com/lahwaacz), [@manics](https://github.com/manics))
+
+#### Maintenance and upkeep improvements
+
+- user-scheduler: update kube-scheduler binary from 1.28.14 to 1.30.5 [#3514](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3514) ([@consideRatio](https://github.com/consideRatio))
+- Drop support for k8s 1.26-1.27 [#3508](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3508) ([@consideRatio](https://github.com/consideRatio))
+- Bump debian distribution for images [#3457](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3457) ([@SchutteJan](https://github.com/SchutteJan), [@manics](https://github.com/manics))
+- Bump pip-tools to v7 used by ci/refreeze script updating requirements.txt files [#3455](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3455) ([@consideRatio](https://github.com/consideRatio))
+
+#### Documentation improvements
+
+- Add backdated upgrade guide for 2 to 3 [#3521](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3521) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
+- debugging: remove old (now misleading) example [#3487](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3487) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
+- RTD custom domain changes [#3461](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3461) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
+- docs: small fixes [#3415](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3415) ([@buti1021](https://github.com/buti1021), [@consideRatio](https://github.com/consideRatio))
+
+#### Continuous integration improvements
+
+- ci: configure automatic bump of kube-scheduler to version 1.30.x [#3517](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3517) ([@consideRatio](https://github.com/consideRatio))
+
+#### Other merged PRs
+
+This changelog entry omits automated PRs, for example those updating
+dependencies in: images, github actions, pre-commit hooks. For a full list of
+changes, see the [full
+comparison](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/3.3.8...4.0.0-beta.1).
+
+#### Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2024-03-20&to=2024-10-01&type=c))
+
+@alxyok ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aalxyok+updated%3A2024-03-20..2024-10-01&type=Issues)) | @benz0li ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Abenz0li+updated%3A2024-03-20..2024-10-01&type=Issues)) | @buti1021 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Abuti1021+updated%3A2024-03-20..2024-10-01&type=Issues)) | @consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2024-03-20..2024-10-01&type=Issues)) | @jash2105 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajash2105+updated%3A2024-03-20..2024-10-01&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2024-03-20..2024-10-01&type=Issues)) | @Khoi16 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AKhoi16+updated%3A2024-03-20..2024-10-01&type=Issues)) | @lahwaacz ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Alahwaacz+updated%3A2024-03-20..2024-10-01&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Amanics+updated%3A2024-03-20..2024-10-01&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2024-03-20..2024-10-01&type=Issues)) | @samyuh ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asamyuh+updated%3A2024-03-20..2024-10-01&type=Issues)) | @SchutteJan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3ASchutteJan+updated%3A2024-03-20..2024-10-01&type=Issues)) | @snickell ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asnickell+updated%3A2024-03-20..2024-10-01&type=Issues))
 
 ## 3.3
 
@@ -1288,7 +1373,6 @@ For a detailed list of how Python dependencies have change in the `hub` Pod's Do
 - dep: bump kube-scheduler from 1.19.2 to 1.19.7 [#1981](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1981) ([@consideRatio](https://github.com/consideRatio))
 - singleuser-sample image: bump jupyerhub to 1.3.0 [#1961](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1961) ([@consideRatio](https://github.com/consideRatio))
 - build(deps): bump jupyterhub from 1.2.2 to 1.3.0 in /images/hub [#1959](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1959) ([@dependabot](https://github.com/dependabot))
-- Vulnerability patch in network-tools [#1947](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1947) ([@github-actions](https://github.com/github-actions))
 - hub image: bump jupyterhub-kubespawner from 0.14.1 to 0.15.0 in /images/hub [#1946](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1946) ([@dependabot](https://github.com/dependabot))
 - Helm template linting - remove extra space [#1945](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1945) ([@DArtagan](https://github.com/DArtagan))
 - hub image: bump jupyterhub-hmacauthenticator from 0.1 to 1.0 in /images/hub [#1944](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1944) ([@dependabot](https://github.com/dependabot))


### PR DESCRIPTION
## Omitted PRs

<details><summary>Click to expand</summary>

- Bump kubespawner from 6.2.0 to 7.0.0b1 [#3520](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3520) ([@consideRatio](https://github.com/consideRatio))
- Bump oauthenticator from 16.3.1 to 17.0.0 [#3519](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3519) ([@consideRatio](https://github.com/consideRatio))
- Update jupyterhub/configurable-http-proxy version from 4.6.1 to 4.6.2 [#3431](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3431) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- Update library/traefik version from v3.1.3 to v3.1.4 [#3504](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3504) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Update library/traefik version from v3.1.2 to v3.1.3 [#3503](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3503) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update library/traefik version from v3.1.1 to v3.1.2 [#3477](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3477) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Update library/traefik version from v3.1.0 to v3.1.1 [#3469](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3469) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Update library/traefik version from v3.0.4 to v3.1.0 [#3460](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3460) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Update library/traefik version from v3.0.3 to v3.0.4 [#3451](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3451) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- Update library/traefik version from v3.0.2 to v3.0.3 [#3438](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3438) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- Update library/traefik version from v3.0.1 to v3.0.2 [#3432](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3432) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Update library/traefik version from v3.0.0 to v3.0.1 [#3421](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3421) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Update library/traefik version from v2.11.2 to v3.0.0 [#3410](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3410) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update library/traefik version from v2.11.0 to v2.11.2 [#3393](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3393) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update kube-scheduler version from v1.28.13 to v1.28.14 [#3496](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3496) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update kube-scheduler version from v1.28.12 to v1.28.13 [#3482](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3482) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- Update kube-scheduler version from v1.28.11 to v1.28.12 [#3462](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3462) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update kube-scheduler version from v1.28.10 to v1.28.11 [#3433](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3433) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Update kube-scheduler version from v1.28.9 to v1.28.10 [#3417](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3417) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Update kube-scheduler version from v1.28.8 to v1.28.9 [#3399](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3399) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update jupyterhub from 5.0.0 to 5.1.0 [#3472](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3472) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update jupyterhub from 5.0.0b1 to 5.0.0b2 [#3416](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3416) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- Update jupyterhub from 5.0.0b2 to 5.0.0 [#3425](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3425) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update jupyterhub from 4.1.5 to 4.1.6 [#3471](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3471) ([@consideRatio](https://github.com/consideRatio))
- Update jupyterhub from 4.1.4 to 4.1.5 [#3390](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3390) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update jupyterhub from 4.1.3 to 4.1.4 [#3384](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3384) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update jupyterhub from 4.1.2 to 4.1.3 [#3381](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3381) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update jupyterhub from 4.1.1 to 4.1.2 [#3378](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3378) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update jupyterhub from 4.1.0 to 4.1.1 [#3375](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3375) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Update pause version from 3.9 to 3.10 [#3423](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3423) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Add changelog for 3.3.8 [#3473](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3473) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
- Add changelog for 3.3.7 [#3392](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3392) ([@consideRatio](https://github.com/consideRatio))
- Add changelog for 3.3.7 [#3391](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3391) ([@consideRatio](https://github.com/consideRatio))
- Add changelog for 3.3.6 [#3385](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3385) ([@consideRatio](https://github.com/consideRatio))
- Add changelog for 3.3.5 [#3382](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3382) ([@consideRatio](https://github.com/consideRatio))
- Add changelog for 3.3.4 [#3379](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3379) ([@consideRatio](https://github.com/consideRatio))
- Add changelog for 3.3.3 [#3376](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3376) ([@consideRatio](https://github.com/consideRatio), [@minrk](https://github.com/minrk))
- Add changelog for 3.3.2 [#3370](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3370) ([@consideRatio](https://github.com/consideRatio))
- Add changelog for 3.3.1 [#3367](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3367) ([@consideRatio](https://github.com/consideRatio))
- Bump peter-evans/create-pull-request from 6 to 7 [#3524](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3524) ([@consideRatio](https://github.com/consideRatio))
- Bump aquasecurity/trivy-action from 0.23.0 to 0.24.0 [#3474](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3474) ([@minrk](https://github.com/minrk))
- Bump aquasecurity/trivy-action from 0.21.0 to 0.23.0 [#3449](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3449) ([@manics](https://github.com/manics))
- Bump aquasecurity/trivy-action from 0.19.0 to 0.21.0 [#3428](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3428) ([@manics](https://github.com/manics))
- build(deps): bump aquasecurity/trivy-action from 0.18.0 to 0.19.0 [#3388](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3388) ([@consideRatio](https://github.com/consideRatio))
- Bump oauthenticator from 16.3.0 to 16.3.1 in /images/hub [#3518](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3518) ([@minrk](https://github.com/minrk))
- Bump cryptography from 43.0.0 to 43.0.1 in /images/singleuser-sample [#3491](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3491) ([@manics](https://github.com/manics))
- Bump jupyterlab from 4.2.4 to 4.2.5 in /images/singleuser-sample [#3486](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3486) ([@manics](https://github.com/manics))
- Bump aiohttp from 3.10.0 to 3.10.2 in /images/hub [#3479](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3479) ([@manics](https://github.com/manics))
- Bump certifi from 2024.6.2 to 2024.7.4 in /images/singleuser-sample [#3453](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3453) ([@manics](https://github.com/manics))
- Bump certifi from 2024.6.2 to 2024.7.4 in /images/hub [#3452](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3452) ([@manics](https://github.com/manics))
- Bump urllib3 from 2.2.1 to 2.2.2 in /images/hub [#3445](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3445) ([@manics](https://github.com/manics))
- Bump github.com/hashicorp/go-retryablehttp from 0.7.1 to 0.7.7 in /images/image-awaiter [#3444](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3444) ([@manics](https://github.com/manics))
- Bump urllib3 from 2.2.1 to 2.2.2 in /images/singleuser-sample [#3437](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3437) ([@manics](https://github.com/manics))
- Bump tornado from 6.4 to 6.4.1 in /images/singleuser-sample [#3430](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3430) ([@manics](https://github.com/manics))
- Bump tornado from 6.4 to 6.4.1 in /images/hub [#3429](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3429) ([@manics](https://github.com/manics))
- build(deps): bump pymysql from 1.1.0 to 1.1.1 in /images/hub [#3420](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3420) ([@manics](https://github.com/manics))
- hub image: refreeze requirements.txt [#3525](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3525) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- hub image: refreeze requirements.txt [#3516](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3516) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- hub image: refreeze requirements.txt [#3456](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3456) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- hub image: refreeze requirements.txt [#3435](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3435) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- hub image: refreeze requirements.txt [#3434](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3434) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- hub image: refreeze requirements.txt [#3414](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3414) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- hub image: refreeze requirements.txt [#3409](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3409) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- hub image: refreeze requirements.txt [#3408](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3408) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- hub image: refreeze requirements.txt [#3402](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3402) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Vulnerability patch in singleuser-sample [#3500](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3500) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in hub [#3499](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3499) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in network-tools [#3498](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3498) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in hub [#3495](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3495) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in secret-sync [#3494](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3494) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- Vulnerability patch in singleuser-sample [#3489](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3489) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in hub [#3488](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3488) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in hub [#3480](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3480) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- Vulnerability patch in network-tools [#3475](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3475) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in singleuser-sample [#3467](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3467) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in hub [#3466](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3466) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in secret-sync [#3454](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3454) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in singleuser-sample [#3448](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3448) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in hub [#3447](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3447) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in network-tools [#3446](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3446) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in secret-sync [#3443](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3443) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@minrk](https://github.com/minrk))
- Vulnerability patch in secret-sync [#3436](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3436) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
- Vulnerability patch in secret-sync [#3397](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3397) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
- Vulnerability patch in network-tools [#1947](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1947) ([@github-actions](https://github.com/github-actions))
- [pre-commit.ci] pre-commit autoupdate [#3476](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3476) ([@minrk](https://github.com/minrk))
- [pre-commit.ci] pre-commit autoupdate [#3450](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3450) ([@minrk](https://github.com/minrk))
- [pre-commit.ci] pre-commit autoupdate [#3413](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3413) ([@consideRatio](https://github.com/consideRatio))
- [pre-commit.ci] pre-commit autoupdate [#3389](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3389) ([@consideRatio](https://github.com/consideRatio))

</details>