### PR TITLE
Add oauthenticator googlegroups extras and cleanup dependencies

### DIFF
--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -16,7 +16,7 @@ jupyterhub-ldapauthenticator
 jupyterhub-ltiauthenticator!=1.3.0
 jupyterhub-nativeauthenticator
 jupyterhub-tmpauthenticator
-oauthenticator[mediawiki]
+oauthenticator[googlegroups,mediawiki]
 
 ## Kubernetes spawner
 jupyterhub-kubespawner==7.0.0b1

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -16,7 +16,6 @@ jupyterhub-ldapauthenticator
 jupyterhub-ltiauthenticator!=1.3.0
 jupyterhub-nativeauthenticator
 jupyterhub-tmpauthenticator
-nullauthenticator
 oauthenticator
 
 # Authenticator optional dependencies

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -16,10 +16,7 @@ jupyterhub-ldapauthenticator
 jupyterhub-ltiauthenticator!=1.3.0
 jupyterhub-nativeauthenticator
 jupyterhub-tmpauthenticator
-oauthenticator
-
-# Authenticator optional dependencies
-mwoauth
+oauthenticator[mediawiki]
 
 ## Kubernetes spawner
 jupyterhub-kubespawner==7.0.0b1

--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -20,7 +20,6 @@ oauthenticator
 
 # Authenticator optional dependencies
 mwoauth
-pyjwt
 
 ## Kubernetes spawner
 jupyterhub-kubespawner==7.0.0b1

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    Use the "Run workflow" button at https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions/workflows/watch-dependencies.yaml
 #
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.2
     # via aiohttp
-aiohttp==3.10.5
+aiohttp==3.10.8
     # via kubernetes-asyncio
 aiosignal==1.3.1
     # via aiohttp
-alembic==1.13.2
+alembic==1.13.3
     # via jupyterhub
 annotated-types==0.7.0
     # via pydantic
@@ -25,6 +25,8 @@ bcrypt==4.2.0
     # via
     #   jupyterhub-firstuseauthenticator
     #   jupyterhub-nativeauthenticator
+cachetools==5.5.0
+    # via google-auth
 certifi==2024.8.30
     # via
     #   kubernetes-asyncio
@@ -49,8 +51,28 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
+google-api-core==2.20.0
+    # via google-api-python-client
+google-api-python-client==2.147.0
+    # via oauthenticator
+google-auth==2.35.0
+    # via
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-auth-oauthlib
+google-auth-httplib2==0.2.0
+    # via google-api-python-client
+google-auth-oauthlib==1.2.1
+    # via oauthenticator
+googleapis-common-protos==1.65.0
+    # via google-api-core
 greenlet==3.1.1
     # via sqlalchemy
+httplib2==0.22.0
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
 idna==3.10
     # via
     #   jsonschema
@@ -81,7 +103,6 @@ jupyterhub==5.1.0
     #   jupyterhub-ldapauthenticator
     #   jupyterhub-ltiauthenticator
     #   jupyterhub-nativeauthenticator
-    #   nullauthenticator
     #   oauthenticator
 jupyterhub-firstuseauthenticator==1.1.0
     # via -r requirements.in
@@ -114,9 +135,7 @@ multidict==6.1.0
     #   aiohttp
     #   yarl
 mwoauth==0.4.0
-    # via -r requirements.in
-nullauthenticator==1.0.0
-    # via -r requirements.in
+    # via oauthenticator
 oauthenticator==17.0.0
     # via -r requirements.in
 oauthlib==3.2.2
@@ -135,10 +154,22 @@ pamela==1.2.0
     # via jupyterhub
 prometheus-client==0.21.0
     # via jupyterhub
+proto-plus==1.24.0
+    # via google-api-core
+protobuf==5.28.2
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
+    #   proto-plus
 psycopg2==2.9.9
     # via -r requirements.in
 pyasn1==0.6.1
-    # via ldap3
+    # via
+    #   ldap3
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
 pycparser==2.22
     # via cffi
 pycurl==7.45.3
@@ -149,12 +180,13 @@ pydantic-core==2.23.4
     # via pydantic
 pyjwt==2.9.0
     # via
-    #   -r requirements.in
     #   jupyterhub-ltiauthenticator
     #   mwoauth
     #   oauthenticator
 pymysql==1.1.1
     # via -r requirements.in
+pyparsing==3.1.4
+    # via httplib2
 python-dateutil==2.9.0.post0
     # via
     #   arrow
@@ -177,12 +209,15 @@ referencing==0.35.1
     #   jupyter-events
 requests==2.32.3
     # via
+    #   google-api-core
     #   jupyterhub
     #   mwoauth
     #   oauthenticator
     #   requests-oauthlib
 requests-oauthlib==2.0.0
-    # via mwoauth
+    # via
+    #   google-auth-oauthlib
+    #   mwoauth
 rfc3339-validator==0.1.4
     # via
     #   jsonschema
@@ -195,6 +230,8 @@ rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
+rsa==4.9
+    # via google-auth
 ruamel-yaml==0.18.6
     # via oauthenticator
 ruamel-yaml-clib==0.2.8
@@ -240,6 +277,8 @@ typing-extensions==4.12.2
     #   sqlalchemy
 uri-template==1.3.0
     # via jsonschema
+uritemplate==4.1.1
+    # via google-api-python-client
 urllib3==2.2.3
     # via
     #   jupyterhub-kubespawner
@@ -247,5 +286,5 @@ urllib3==2.2.3
     #   requests
 webcolors==24.8.0
     # via jsonschema
-yarl==1.11.1
+yarl==1.13.1
     # via aiohttp

--- a/images/singleuser-sample/requirements.txt
+++ b/images/singleuser-sample/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    Use the "Run workflow" button at https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions/workflows/watch-dependencies.yaml
 #
-alembic==1.13.2
+alembic==1.13.3
     # via jupyterhub
 annotated-types==0.7.0
     # via pydantic
@@ -49,7 +49,7 @@ comm==0.2.2
     # via ipykernel
 cryptography==43.0.1
     # via certipy
-debugpy==1.8.5
+debugpy==1.8.6
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -203,7 +203,7 @@ prometheus-client==0.21.0
     # via
     #   jupyter-server
     #   jupyterhub
-prompt-toolkit==3.0.47
+prompt-toolkit==3.0.48
     # via ipython
 psutil==6.0.0
     # via ipykernel


### PR DESCRIPTION
- We had nullauthenticator package explicitly installed, but its now an authenticator class part of jupyterhub.
- We had pyjwt and mwoauth installed for oauthenticator, but its better we use the oauthenticator extras to install things when possible as that allows oauthenticator to put constraints on versions. So mwoauth is now installed that way, and pyjwt is installed by oauthenticator no matter what nowdays.
- The oauthenticator[googlegroups] extras has been installed as it was a requirement for full function of google groups things.