### PR TITLE
add appProtocol to hub service definition

### DIFF
--- a/jupyterhub/templates/hub/service.yaml
+++ b/jupyterhub/templates/hub/service.yaml
@@ -31,6 +31,9 @@ spec:
       {{- with .Values.hub.service.ports.nodePort }}
       nodePort: {{ . }}
       {{- end }}
+      {{- with .Values.hub.service.ports.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
 
     {{- with .Values.hub.service.extraPorts }}
     {{- . | toYaml | nindent 4 }}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1104,6 +1104,10 @@ properties:
             description: |
               Object to configure the ports the hub service will be deployed on.
             properties:
+              appProtocol:
+                type: [string, "null"]
+                description: |
+                  The application protocol to utilize with the Service port. This may be required when an external application attempts to make calls to the hub service with a protocol the hub does not support.
               nodePort:
                 type: [integer, "null"]
                 minimum: 0
@@ -2760,7 +2764,7 @@ properties:
       extraPaths:
         type: array
         description: |
-          A list of custom paths to be added to the ingress configuration. 
+          A list of custom paths to be added to the ingress configuration.
 
           See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types)
           for more details about paths.

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -41,6 +41,7 @@ hub:
     annotations: {}
     ports:
       nodePort:
+      appProtocol:
     extraPorts: []
     loadBalancerIP:
   baseUrl: /


### PR DESCRIPTION
This addresses #3533 and allows `appProtocol` to be set on the `hub` Service defintion.