### PR TITLE
Ensure hub container is first by appending instead of prepending hub.extraContainers

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -93,9 +93,6 @@ spec:
         {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
-        {{- with .Values.hub.extraContainers }}
-        {{- . | toYaml | nindent 8 }}
-        {{- end }}
         - name: hub
           image: {{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}
           {{- with .Values.hub.command }}
@@ -238,6 +235,9 @@ spec:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
               port: http
           {{- end }}
+        {{- with .Values.hub.extraContainers }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       {{- with .Values.hub.extraPodSpec }}
       {{- . | toYaml | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
By doing this, you'd be able to do `kubectl logs deploy/hub` and get the
hub containers logs no matter what. Before, you'd get the first listed
`hub.extraContainer` instead and have to add `--container=hub` to ensure
getting the hub containers logs.

I'm maintaining a deployment where we use hub.extraContainers, and by
doing so, have been required to specify `-c hub` anytime I want logs,
because its not the first container in the pod specs list of containers.