### PR TITLE
v4 upgrade doc, changelog for 4.0

### DIFF
--- a/docs/source/administrator/upgrading/upgrade-3-to-4.md
+++ b/docs/source/administrator/upgrading/upgrade-3-to-4.md
@@ -2,4 +2,84 @@
 
 # Major upgrade: 3.\* to 4.\*
 
-This is currently just a placeholder file for until we have written upgrade docs.
+zero-to-jupyterhub 4.0 is a major upgrade that may require some changes to your configuration,
+depending on what features you may use.
+This mostly comes in the form of some upgraded packages, described below.
+
+See the [changelog](changelog) for details of upgraded packages.
+
+## JupyterHub 5
+
+zero-to-jupyterhub 4.0 upgrades the JupyterHub version from 4.1.6 to 5.2.1.
+
+:::{seealso}
+For more detailed changes in JupyterHub, see JupyterHub's own documentation on upgrading to version 5:
+
+Especially if you use features like per-user subdomains or custom page templates.
+
+- [jupyterhub changelog](https://jupyterhub.readthedocs.io/en/5.2.1/reference/changelog.html)
+- [Upgrading to JupyterHub 5](https://jupyterhub.readthedocs.io/en/5.2.1/howto/upgrading-v5.html)
+
+:::
+
+### Allowing users
+
+JupyterHub 5 promotes the `allow_all` and `allow_existing_users` configuration used on OAuthenticator to all other Authenticators.
+If you have no explicitly allowed users, the default is now to allow no users (this was already the default if you were using OAuth).
+If you are using an Authenticator where all users who can successfully authenticate should have access, set:
+
+```yaml
+hub:
+  config:
+    Authenticator:
+      allow_all: true
+```
+
+to explicitly opt in to this behavior that was previously the default for some authenticators.
+
+## KubeSpawner 7
+
+zero-to-jupyterhub 4.0 upgrades the KubeSpawner version from 6 to 7.
+The main relevant change here is the "slug scheme" used to compute names of resources such as pods and PVC (user storage) is changed.
+
+The new scheme is called "safe" and is the default, whereas the old scheme is called "escape".
+If you do not have any custom templated fields, it is _unlikely_ that anything should change for you and everything should work.
+If, however, you specify custom templated fields such as volume mounts or environment variables,
+especially those that have the `{username}` or `{servername}` fields,
+those values are likely to change under the new scheme for some usernames.
+In particular, there are new fields that should make things easier:
+
+- `{user_server}` combines the username and server name, and is equivalent to `{username}{servername}` in the old escape scheme
+- `{pod_name}`, `{pvc_name}`
+
+You can opt in to the kubespawner 6 behavior with:
+
+```yaml
+hub:
+  config:
+    KubeSpawner:
+      slug_scheme: escape
+```
+
+which _should_ result in no changes for you from previous behavior.
+
+:::{seealso}
+
+- [KubeSpawner changelog](https://jupyterhub-kubespawner.readthedocs.io/en/latest/changelog.html)
+- [KubeSpawner docs on templated fields](https://jupyterhub-kubespawner.readthedocs.io/en/latest/templates.html#fields)
+
+:::
+
+## OAuthenticator 17
+
+OAuthenticator is upgraded from 16.3.1 to 17.1.
+The main changes are related to using group information from OAuth providers.
+If you used or would like to use groups for authentication,
+check out the [OAuthenticator changelog](https://oauthenticator.readthedocs.io/en/stable/reference/changelog.html#:~:text=17.1)
+
+## Other package upgrades
+
+- Python is upgraded from 3.11 to 3.12 in the Hub image
+- LDAPAuthenticator is upgraded from 1 to 2 ([changelog](https://github.com/jupyterhub/ldapauthenticator/blob/2.0.0/CHANGELOG.md#200---2024-10-18))
+- FirstUseAuthenticator is upgraded from 1.0 to 1.1 ([changelog](https://github.com/jupyterhub/firstuseauthenticator/blob/1.1.0/CHANGELOG.md))
+- idle culler is upgraded from 1.3.1 to 1.4.0 ([changelog](https://github.com/jupyterhub/jupyterhub-idle-culler/blob/1.4.0/CHANGELOG.md))

--- a/docs/source/administrator/upgrading/upgrade-3-to-4.md
+++ b/docs/source/administrator/upgrading/upgrade-3-to-4.md
@@ -6,13 +6,19 @@ zero-to-jupyterhub 4.0 is a major upgrade that may require some changes to your 
 depending on what features you may use.
 This mostly comes in the form of some upgraded packages, described below.
 
-See the [changelog](changelog) for details of upgraded packages.
+:::{seealso}
+
+- the [general upgrade documentation](upgrading-major-upgrades) for upgrade steps to take every time you do a major chart update
+- the [changelog](changelog-4.0) for details of upgraded packages
+
+:::
 
 ## JupyterHub 5
 
 zero-to-jupyterhub 4.0 upgrades the JupyterHub version from 4.1.6 to 5.2.1.
 
 :::{seealso}
+
 For more detailed changes in JupyterHub, see JupyterHub's own documentation on upgrading to version 5:
 
 Especially if you use features like per-user subdomains or custom page templates.
@@ -49,10 +55,12 @@ especially those that have the `{username}` or `{servername}` fields,
 those values are likely to change under the new scheme for some usernames.
 In particular, there are new fields that should make things easier:
 
-- `{user_server}` combines the username and server name, and is equivalent to `{username}{servername}` in the old escape scheme
-- `{pod_name}`, `{pvc_name}`
+- `{user_server}` combines the username and server name, and is equivalent to `{username}{servername}` in the old escape scheme.
+  It is the recommended value when a string should be unique per named server, as opposed to per user.
+- `{pod_name}`, `{pvc_name}` are now available to reference the fully resolved names of these objects
+  and can be used to avoid duplicating templates.
 
-You can opt in to the kubespawner 6 behavior with:
+You can opt in globally to keep the kubespawner 6 behavior with:
 
 ```yaml
 hub:
@@ -63,23 +71,32 @@ hub:
 
 which _should_ result in no changes for you from previous behavior.
 
+One user-facing place where a default template may require administrator action is if you are using:
+
+```yaml
+singleuser:
+  storage:
+    type: static
+```
+
+The default value for `subPath` is `{username}` which may resolve to a different value for some usernames, which could appear like a 'lost' home directory because the mount path changes.
+The data is not lost, but the mount location has changed.
+To ensure this value doesn't change, you can use:
+
+```yaml
+singleuser:
+  storage:
+    type: static
+    static:
+      subPath: "{escaped_username}"
+```
+
+which applies the previous 'escape' scheme to the subPath.
+Alternatively, you can keep the new scheme, and perform a one-time migration to move files for the affected usernames.
+
 :::{seealso}
 
 - [KubeSpawner changelog](https://jupyterhub-kubespawner.readthedocs.io/en/latest/changelog.html)
 - [KubeSpawner docs on templated fields](https://jupyterhub-kubespawner.readthedocs.io/en/latest/templates.html#fields)
 
 :::
-
-## OAuthenticator 17
-
-OAuthenticator is upgraded from 16.3.1 to 17.1.
-The main changes are related to using group information from OAuth providers.
-If you used or would like to use groups for authentication,
-check out the [OAuthenticator changelog](https://oauthenticator.readthedocs.io/en/stable/reference/changelog.html)
-
-## Other package upgrades
-
-- Python is upgraded from 3.11 to 3.12 in the Hub image
-- LDAPAuthenticator is upgraded from 1 to 2 ([changelog](https://github.com/jupyterhub/ldapauthenticator/blob/2.0.0/CHANGELOG.md#200---2024-10-18))
-- FirstUseAuthenticator is upgraded from 1.0 to 1.1 ([changelog](https://github.com/jupyterhub/firstuseauthenticator/blob/1.1.0/CHANGELOG.md))
-- idle culler is upgraded from 1.3.1 to 1.4.0 ([changelog](https://github.com/jupyterhub/jupyterhub-idle-culler/blob/1.4.0/CHANGELOG.md))

--- a/docs/source/administrator/upgrading/upgrade-3-to-4.md
+++ b/docs/source/administrator/upgrading/upgrade-3-to-4.md
@@ -75,7 +75,7 @@ which _should_ result in no changes for you from previous behavior.
 OAuthenticator is upgraded from 16.3.1 to 17.1.
 The main changes are related to using group information from OAuth providers.
 If you used or would like to use groups for authentication,
-check out the [OAuthenticator changelog](https://oauthenticator.readthedocs.io/en/stable/reference/changelog.html#:~:text=17.1)
+check out the [OAuthenticator changelog](https://oauthenticator.readthedocs.io/en/stable/reference/changelog.html)
 
 ## Other package upgrades
 

--- a/docs/source/administrator/upgrading/upgrade-3-to-4.md
+++ b/docs/source/administrator/upgrading/upgrade-3-to-4.md
@@ -25,7 +25,7 @@ Especially if you use features like per-user subdomains or custom page templates
 ### Allowing users
 
 JupyterHub 5 promotes the `allow_all` and `allow_existing_users` configuration used on OAuthenticator to all other Authenticators.
-If you have no explicitly allowed users, the default is now to allow no users (this was already the default if you were using OAuth).
+If you have not explicitly allowed users, the default is to allow no users (this was already the default if you were using OAuth).
 If you are using an Authenticator where all users who can successfully authenticate should have access, set:
 
 ```yaml

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -17,7 +17,7 @@ changes in pull requests], this list should be updated.
 
 ## 4.0
 
-### 4.0.0 - 2024-11
+### 4.0.0 - 2024-11-07
 
 This release updates JupyterHub itself from version 4 to 5, and the dependencies
 `jupyterhub-kubespawner`, `oauthenticator`, and `ldapauthenticator` to a new
@@ -42,12 +42,12 @@ major version.
 - JupyterHub 4.1.6 has been upgraded to 5.2.1
   - Refer to the [JupyterHub changelog] for details and pay attention to the
     entries for JupyterHub version 5.0.0.
-- OAuthenticator 16.3.1 has been upgraded to 17.0.0
+- OAuthenticator 16.3.1 has been upgraded to 17.1.0
   - If you are using an OAuthenticator based authenticator class
     (GitHubOAuthenticator, GoogleOAuthenticator, ...), refer to the
     [OAuthenticator changelog] for details and pay attention to the entries for
     JupyterHub version 17.0.0.
-- LDAPAuthenticator 1.3.2 has been upgraded to 2.0.0b2
+- LDAPAuthenticator 1.3.2 has been upgraded to 2.0.2
   - If you are using this authenticator class, refer to the [LDAPAuthenticator
     changelog] for details and pay attention to the entries for
     LDAPAuthenticator version 2.0.0.
@@ -61,12 +61,12 @@ major version.
 | [jupyterhub](https://github.com/jupyterhub/jupyterhub)                           | 4.1.6            | 5.2.1            | [Changelog](https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html)         | Run in the `hub` pod               |
 | [kubespawner](https://github.com/jupyterhub/kubespawner)                         | 6.2.0            | 7.0.0            | [Changelog](https://jupyterhub-kubespawner.readthedocs.io/en/stable/changelog.html)       | Run in the `hub` pod               |
 | [oauthenticator](https://github.com/jupyterhub/oauthenticator)                   | 16.3.1           | 17.1.0           | [Changelog](https://oauthenticator.readthedocs.io/en/stable/reference/changelog.html)     | Run in the `hub` pod               |
-| [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)             | 1.3.2            | 2.0.0            | [Changelog](https://github.com/jupyterhub/ldapauthenticator/blob/HEAD/CHANGELOG.md)       | Run in the `hub` pod               |
+| [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)             | 1.3.2            | 2.0.2            | [Changelog](https://github.com/jupyterhub/ldapauthenticator/blob/HEAD/CHANGELOG.md)       | Run in the `hub` pod               |
 | [nativeauthenticator](https://github.com/jupyterhub/nativeauthenticator)         | 1.2.0            | 1.3.0            | [Changelog](https://github.com/jupyterhub/nativeauthenticator/blob/HEAD/CHANGELOG.md)     | Run in the `hub` pod               |
 | [jupyterhub-idle-culler](https://github.com/jupyterhub/jupyterhub-idle-culler)   | 1.3.1            | 1.4.0            | [Changelog](https://github.com/jupyterhub/jupyterhub-idle-culler/blob/main/CHANGELOG.md)  | Run in the `hub` pod               |
 | [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy) | 4.6.1            | 4.6.2            | [Changelog](https://github.com/jupyterhub/configurable-http-proxy/blob/HEAD/CHANGELOG.md) | Run in the `proxy` pod             |
-| [traefik](https://github.com/traefik/traefik)                                    | v2.11.0          | v3.1.4           | [Changelog](https://github.com/traefik/traefik/blob/HEAD/CHANGELOG.md)                    | Run in the `autohttps` pod         |
-| [kube-scheduler](https://github.com/kubernetes/kube-scheduler)                   | v1.26.15         | v1.30.5          | [Changelog](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG)               | Run in the `user-scheduler` pod(s) |
+| [traefik](https://github.com/traefik/traefik)                                    | v2.11.0          | v3.2.0           | [Changelog](https://github.com/traefik/traefik/blob/HEAD/CHANGELOG.md)                    | Run in the `autohttps` pod         |
+| [kube-scheduler](https://github.com/kubernetes/kube-scheduler)                   | v1.26.15         | v1.30.6          | [Changelog](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG)               | Run in the `user-scheduler` pod(s) |
 
 For a detailed list of Python dependencies in the `hub` Pod's Docker image,
 inspect the [images/hub/requirements.txt] file and use its git history to see
@@ -88,10 +88,10 @@ what changes between tagged versions.
 #### Bugs fixed
 
 - fix default pvc mounting with kubespawner 7 [#3537](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3537) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
-- network-tools image: pin alpine 3.18 for legacy iptables [#3369](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3369) ([@consideRatio](https://github.com/consideRatio))
 
 #### Maintenance and upkeep improvements
 
+- Use python 3.12 instead of 3.11 in built images [#3526](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3526) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
 - user-scheduler: update kube-scheduler binary from 1.28.14 to 1.30.5 [#3514](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3514) ([@consideRatio](https://github.com/consideRatio))
 - Drop support for k8s 1.26-1.27 [#3508](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3508) ([@consideRatio](https://github.com/consideRatio))
 - Bump debian distribution for images [#3457](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3457) ([@SchutteJan](https://github.com/SchutteJan), [@manics](https://github.com/manics))
@@ -100,8 +100,6 @@ what changes between tagged versions.
 
 #### Documentation improvements
 
-- Add changelog for 4.0.0-beta.4 [#3543](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3543) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
-- Add changelog for 4.0.0-beta.1 [#3522](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3522) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
 - Add backdated upgrade guide for 2 to 3 [#3521](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3521) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - debugging: remove old (now misleading) example [#3487](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3487) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - RTD custom domain changes [#3461](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3461) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
@@ -109,23 +107,25 @@ what changes between tagged versions.
 
 #### Continuous integration improvements
 
+- Pin and automate doing isolated bumps of hub image dependencies' major versions [#3565](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3565) ([@consideRatio](https://github.com/consideRatio), [@minrk](https://github.com/minrk), [@manics](https://github.com/manics))
+- remove maintenance label from autobump PRs [#3558](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3558) ([@minrk](https://github.com/minrk), [@manics](https://github.com/manics))
+- ci: Bump postgresql chart [#3554](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3554) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - ci: configure automatic bump of kube-scheduler to version 1.30.x [#3517](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3517) ([@consideRatio](https://github.com/consideRatio))
 
 #### Other merged PRs
 
 This changelog entry omits automated PRs, for example those updating
 dependencies in: images, github actions, pre-commit hooks. For a full list of
-changes, see the [full
-comparison](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/3.3.8...4.0.0-beta.1).
+changes, see the [full comparison](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/3.3.8...4.0.0).
 
 #### Contributors to this release
 
 The following people contributed discussions, new ideas, code and documentation contributions, and review.
 See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
 
-([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2024-03-20&to=2024-10-24&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2024-07-31&to=2024-11-07&type=c))
 
-@alxyok ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aalxyok+updated%3A2024-03-20..2024-10-24&type=Issues)) | @benz0li ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Abenz0li+updated%3A2024-03-20..2024-10-24&type=Issues)) | @buti1021 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Abuti1021+updated%3A2024-03-20..2024-10-24&type=Issues)) | @colinlodter ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Acolinlodter+updated%3A2024-03-20..2024-10-24&type=Issues)) | @consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2024-03-20..2024-10-24&type=Issues)) | @jash2105 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajash2105+updated%3A2024-03-20..2024-10-24&type=Issues)) | @jrdnbradford ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajrdnbradford+updated%3A2024-03-20..2024-10-24&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2024-03-20..2024-10-24&type=Issues)) | @Khoi16 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AKhoi16+updated%3A2024-03-20..2024-10-24&type=Issues)) | @lahwaacz ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Alahwaacz+updated%3A2024-03-20..2024-10-24&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Amanics+updated%3A2024-03-20..2024-10-24&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2024-03-20..2024-10-24&type=Issues)) | @samyuh ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asamyuh+updated%3A2024-03-20..2024-10-24&type=Issues)) | @SchutteJan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3ASchutteJan+updated%3A2024-03-20..2024-10-24&type=Issues)) | @snickell ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asnickell+updated%3A2024-03-20..2024-10-24&type=Issues)) | @StefanTheWiz ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AStefanTheWiz+updated%3A2024-03-20..2024-10-24&type=Issues))
+@alxyok ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aalxyok+updated%3A2024-07-31..2024-11-07&type=Issues)) | @colinlodter ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Acolinlodter+updated%3A2024-07-31..2024-11-07&type=Issues)) | @consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2024-07-31..2024-11-07&type=Issues)) | @jrdnbradford ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajrdnbradford+updated%3A2024-07-31..2024-11-07&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2024-07-31..2024-11-07&type=Issues)) | @lahwaacz ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Alahwaacz+updated%3A2024-07-31..2024-11-07&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Amanics+updated%3A2024-07-31..2024-11-07&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2024-07-31..2024-11-07&type=Issues)) | @samyuh ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asamyuh+updated%3A2024-07-31..2024-11-07&type=Issues)) | @snickell ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asnickell+updated%3A2024-07-31..2024-11-07&type=Issues)) | @StefanTheWiz ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AStefanTheWiz+updated%3A2024-07-31..2024-11-07&type=Issues))
 
 ## 3.3
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -10,19 +10,27 @@ This Helm chart provides [development releases], and as we merge [breaking
 changes in pull requests], this list should be updated.
 
 [development releases]: https://hub.jupyter.org/helm-chart/#development-releases-jupyterhub
+
 [breaking changes in pull requests]: https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pulls?q=is%3Apr+is%3Aclosed+label%3Abreaking
+
+(changelog-4.0)=
 
 ## 4.0
 
-### 4.0.0 - 2024-10
+### 4.0.0 - 2024-11
 
 This release updates JupyterHub itself from version 4 to 5, and the dependencies
 `jupyterhub-kubespawner`, `oauthenticator`, and `ldapauthenticator` to a new
 major version.
 
-See the [upgrade guide](upgrade-3-to-4) for specific instructions for upgrading chart version from 3 to 4,
-and check the summary of breaking changes and the linked changelogs below
-if you use any of the upgraded packages.
+:::{seealso}
+
+- the [general upgrade documentation](upgrading-major-upgrades) for upgrade steps to take every time you do a major chart update
+- the [upgrade guide](upgrade-3-to-4) for specific instructions for upgrading chart version from 3 to 4
+- check the summary of breaking changes and the linked changelogs below
+  if you use any of the upgraded packages.
+
+:::
 
 #### Breaking changes
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -14,93 +14,24 @@ changes in pull requests], this list should be updated.
 
 ## 4.0
 
-### 4.0.0-beta.4 - 2024-10-11
-
-ldapauthenticator was said to be bumped from version 1.3.2 to 2.0.0b2
-in the 4.0.0-beta.1 release, but wasn't. With this release, it actually is.
-
-#### Maintenance and upkeep improvements
-
-- Update ldapauthenticator from 1.3.2 to 2.0.0.b2 [#3544](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3544) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
-- Update oauthenticator from 17.0.0 to 17.1.0 [#3542](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3542) ([@consideRatio](https://github.com/consideRatio), [@jrdnbradford](https://github.com/jrdnbradford))
-- Bump to kubespawner from 7.0.0b2 to 7.0.0b3 [#3541](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3541) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
-- Update library/traefik version from v3.1.5 to v3.1.6 [#3540](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3540) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@manics](https://github.com/manics))
-
-#### Contributors to this release
-
-The following people contributed discussions, new ideas, code and documentation contributions, and review.
-See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
-
-([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2024-10-03&to=2024-10-11&type=c))
-
-@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2024-10-03..2024-10-11&type=Issues)) | @jrdnbradford ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajrdnbradford+updated%3A2024-10-03..2024-10-11&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2024-10-03..2024-10-11&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Amanics+updated%3A2024-10-03..2024-10-11&type=Issues))
-
-### 4.0.0-beta.3 - 2024-10-03
-
-#### New features added
-
-- add appProtocol to hub service definition [#3534](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3534) ([@colinlodter](https://github.com/colinlodter), [@consideRatio](https://github.com/consideRatio))
-
-#### Bugs fixed
-
-- fix default pvc mounting with kubespawner 7 [#3537](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3537) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
-
-#### Maintenance and upkeep improvements
-
-- Update library/traefik version from v3.1.4 to v3.1.5 [#3535](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3535) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
-
-#### Contributors to this release
-
-The following people contributed discussions, new ideas, code and documentation contributions, and review.
-See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
-
-([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2024-10-02&to=2024-10-03&type=c))
-
-@colinlodter ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Acolinlodter+updated%3A2024-10-02..2024-10-03&type=Issues)) | @consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2024-10-02..2024-10-03&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2024-10-02..2024-10-03&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2024-10-02..2024-10-03&type=Issues))
-
-### 4.0.0-beta.2 - 2024-10-02
-
-#### Breaking changes
-
-- Python 3.12 is now used in the chart's images
-
-#### Maintenance and upkeep improvements
-
-- kubespawner 7.0.0b2 [#3529](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3529) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
-- Update jupyterhub from 5.1.0 to 5.2.0 [#3527](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3527) ([@jupyterhub-bot](https://github.com/jupyterhub-bot), [@consideRatio](https://github.com/consideRatio))
-- Use python 3.12 instead of 3.11 in built images [#3526](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3526) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
-
-#### Other merged PRs
-
-This changelog entry omits automated PRs, for example those updating
-dependencies in: images, github actions, pre-commit hooks. For a full list of
-changes, see the [full
-comparison](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/4.0.0-beta.1...4.0.0-beta.2).
-
-#### Contributors to this release
-
-The following people contributed discussions, new ideas, code and documentation contributions, and review.
-See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
-
-([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2024-10-01&to=2024-10-02&type=c))
-
-@consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2024-10-01..2024-10-02&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2024-10-01..2024-10-02&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Amanics+updated%3A2024-10-01..2024-10-02&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2024-10-01..2024-10-02&type=Issues))
-
-### 4.0.0-beta.1 - 2024-10-01
+### 4.0.0 - 2024-10
 
 This release updates JupyterHub itself from version 4 to 5, and the dependencies
 `jupyterhub-kubespawner`, `oauthenticator`, and `ldapauthenticator` to a new
 major version.
 
-We will provide an [upgrade guide for 3 to 4](upgrade-3-to-4) before the final release, but for now please read the summary of breaking changes below, and the linked changelogs.
+See the [upgrade guide](upgrade-3-to-4) for specific instructions for upgrading chart version from 3 to 4,
+and check the summary of breaking changes and the linked changelogs below
+if you use any of the upgraded packages.
 
 #### Breaking changes
 
 - The chart now require Kubernetes 1.28+, up from 1.23+
-- KubeSpawner is upgraded one major version from 6.2.0 to 7.0.0b1
+- Python is upgraded in chart images from 3.11 to 3.12
+- KubeSpawner is upgraded from 6.2.0 to 7.0.0
   - Refer to the [KubeSpawner changelog] for details and pay attention to the
-    entries for KubeSpawner version 7.0.0b1.
-- JupyterHub 4.1.6 has been upgraded to 5.1.0
+    entries for KubeSpawner version 7.0.0.
+- JupyterHub 4.1.6 has been upgraded to 5.2.1
   - Refer to the [JupyterHub changelog] for details and pay attention to the
     entries for JupyterHub version 5.0.0.
 - OAuthenticator 16.3.1 has been upgraded to 17.0.0
@@ -117,19 +48,17 @@ We will provide an [upgrade guide for 3 to 4](upgrade-3-to-4) before the final r
 
 #### Notable dependencies updated
 
-| Dependency                                                                       | Version in 3.3.8 | Version in 4.0.0-beta.1 | Changelog link                                                                            | Note                               |
-| -------------------------------------------------------------------------------- | ---------------- | ----------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------- |
-| [jupyterhub](https://github.com/jupyterhub/jupyterhub)                           | 4.1.6            | 5.1.0                   | [Changelog](https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html)         | Run in the `hub` pod               |
-| [kubespawner](https://github.com/jupyterhub/kubespawner)                         | 6.2.0            | 7.0.0b1                 | [Changelog](https://jupyterhub-kubespawner.readthedocs.io/en/stable/changelog.html)       | Run in the `hub` pod               |
-| [oauthenticator](https://github.com/jupyterhub/oauthenticator)                   | 16.3.1           | 17.0.0                  | [Changelog](https://oauthenticator.readthedocs.io/en/stable/reference/changelog.html)     | Run in the `hub` pod               |
-| [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)             | 1.3.2            | 2.0.0b2                 | [Changelog](https://github.com/jupyterhub/ldapauthenticator/blob/HEAD/CHANGELOG.md)       | Run in the `hub` pod               |
-| [ltiauthenticator](https://github.com/jupyterhub/ltiauthenticator)               | 1.6.2            | 1.6.2                   | [Changelog](https://github.com/jupyterhub/ltiauthenticator/blob/HEAD/CHANGELOG.md)        | Run in the `hub` pod               |
-| [nativeauthenticator](https://github.com/jupyterhub/nativeauthenticator)         | 1.2.0            | 1.3.0                   | [Changelog](https://github.com/jupyterhub/nativeauthenticator/blob/HEAD/CHANGELOG.md)     | Run in the `hub` pod               |
-| [tmpauthenticator](https://github.com/jupyterhub/tmpauthenticator)               | 1.0.0            | 1.0.0                   | [Changelog](https://github.com/jupyterhub/tmpauthenticator/blob/HEAD/CHANGELOG.md)        | Run in the `hub` pod               |
-| [jupyterhub-idle-culler](https://github.com/jupyterhub/jupyterhub-idle-culler)   | 1.3.1            | 1.4.0                   | [Changelog](https://github.com/jupyterhub/jupyterhub-idle-culler/blob/main/CHANGELOG.md)  | Run in the `hub` pod               |
-| [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy) | 4.6.1            | 4.6.2                   | [Changelog](https://github.com/jupyterhub/configurable-http-proxy/blob/HEAD/CHANGELOG.md) | Run in the `proxy` pod             |
-| [traefik](https://github.com/traefik/traefik)                                    | v2.11.0          | v3.1.4                  | [Changelog](https://github.com/traefik/traefik/blob/HEAD/CHANGELOG.md)                    | Run in the `autohttps` pod         |
-| [kube-scheduler](https://github.com/kubernetes/kube-scheduler)                   | v1.26.15         | v1.30.5                 | [Changelog](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG)               | Run in the `user-scheduler` pod(s) |
+| Dependency                                                                       | Version in 3.3.8 | Version in 4.0.0 | Changelog link                                                                            | Note                               |
+| -------------------------------------------------------------------------------- | ---------------- | ---------------- | ----------------------------------------------------------------------------------------- | ---------------------------------- |
+| [jupyterhub](https://github.com/jupyterhub/jupyterhub)                           | 4.1.6            | 5.2.1            | [Changelog](https://jupyterhub.readthedocs.io/en/stable/reference/changelog.html)         | Run in the `hub` pod               |
+| [kubespawner](https://github.com/jupyterhub/kubespawner)                         | 6.2.0            | 7.0.0            | [Changelog](https://jupyterhub-kubespawner.readthedocs.io/en/stable/changelog.html)       | Run in the `hub` pod               |
+| [oauthenticator](https://github.com/jupyterhub/oauthenticator)                   | 16.3.1           | 17.1.0           | [Changelog](https://oauthenticator.readthedocs.io/en/stable/reference/changelog.html)     | Run in the `hub` pod               |
+| [ldapauthenticator](https://github.com/jupyterhub/ldapauthenticator)             | 1.3.2            | 2.0.0            | [Changelog](https://github.com/jupyterhub/ldapauthenticator/blob/HEAD/CHANGELOG.md)       | Run in the `hub` pod               |
+| [nativeauthenticator](https://github.com/jupyterhub/nativeauthenticator)         | 1.2.0            | 1.3.0            | [Changelog](https://github.com/jupyterhub/nativeauthenticator/blob/HEAD/CHANGELOG.md)     | Run in the `hub` pod               |
+| [jupyterhub-idle-culler](https://github.com/jupyterhub/jupyterhub-idle-culler)   | 1.3.1            | 1.4.0            | [Changelog](https://github.com/jupyterhub/jupyterhub-idle-culler/blob/main/CHANGELOG.md)  | Run in the `hub` pod               |
+| [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy) | 4.6.1            | 4.6.2            | [Changelog](https://github.com/jupyterhub/configurable-http-proxy/blob/HEAD/CHANGELOG.md) | Run in the `proxy` pod             |
+| [traefik](https://github.com/traefik/traefik)                                    | v2.11.0          | v3.1.4           | [Changelog](https://github.com/traefik/traefik/blob/HEAD/CHANGELOG.md)                    | Run in the `autohttps` pod         |
+| [kube-scheduler](https://github.com/kubernetes/kube-scheduler)                   | v1.26.15         | v1.30.5          | [Changelog](https://github.com/kubernetes/kubernetes/tree/master/CHANGELOG)               | Run in the `user-scheduler` pod(s) |
 
 For a detailed list of Python dependencies in the `hub` Pod's Docker image,
 inspect the [images/hub/requirements.txt] file and use its git history to see
@@ -137,6 +66,8 @@ what changes between tagged versions.
 
 #### New features added
 
+- Support subdomain_host (CHP needs --host-routing) [#3548](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3548) ([@manics](https://github.com/manics), [@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
+- add appProtocol to hub service definition [#3534](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3534) ([@colinlodter](https://github.com/colinlodter), [@consideRatio](https://github.com/consideRatio))
 - Add oauthenticator googlegroups extras and cleanup dependencies [#3523](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3523) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
 - Add `ingress.extraPaths` config [#3492](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3492) ([@alxyok](https://github.com/alxyok), [@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
 - Add `singleuser.storage.dynamic.subPath` config [#3468](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3468) ([@benz0li](https://github.com/benz0li), [@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
@@ -146,15 +77,23 @@ what changes between tagged versions.
 
 - Security context hardening [#3464](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3464) ([@lahwaacz](https://github.com/lahwaacz), [@manics](https://github.com/manics))
 
+#### Bugs fixed
+
+- fix default pvc mounting with kubespawner 7 [#3537](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3537) ([@minrk](https://github.com/minrk), [@consideRatio](https://github.com/consideRatio))
+- network-tools image: pin alpine 3.18 for legacy iptables [#3369](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3369) ([@consideRatio](https://github.com/consideRatio))
+
 #### Maintenance and upkeep improvements
 
 - user-scheduler: update kube-scheduler binary from 1.28.14 to 1.30.5 [#3514](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3514) ([@consideRatio](https://github.com/consideRatio))
 - Drop support for k8s 1.26-1.27 [#3508](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3508) ([@consideRatio](https://github.com/consideRatio))
 - Bump debian distribution for images [#3457](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3457) ([@SchutteJan](https://github.com/SchutteJan), [@manics](https://github.com/manics))
 - Bump pip-tools to v7 used by ci/refreeze script updating requirements.txt files [#3455](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3455) ([@consideRatio](https://github.com/consideRatio))
+- Ensure hub container is first by appending instead of prepending hub.extraContainers [#3546](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3546) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
 
 #### Documentation improvements
 
+- Add changelog for 4.0.0-beta.4 [#3543](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3543) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
+- Add changelog for 4.0.0-beta.1 [#3522](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3522) ([@consideRatio](https://github.com/consideRatio), [@manics](https://github.com/manics))
 - Add backdated upgrade guide for 2 to 3 [#3521](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3521) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - debugging: remove old (now misleading) example [#3487](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3487) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
 - RTD custom domain changes [#3461](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3461) ([@manics](https://github.com/manics), [@consideRatio](https://github.com/consideRatio))
@@ -176,9 +115,9 @@ comparison](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/3.3.8..
 The following people contributed discussions, new ideas, code and documentation contributions, and review.
 See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/#how-does-this-tool-define-contributions-in-the-reports).
 
-([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2024-03-20&to=2024-10-01&type=c))
+([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2024-03-20&to=2024-10-24&type=c))
 
-@alxyok ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aalxyok+updated%3A2024-03-20..2024-10-01&type=Issues)) | @benz0li ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Abenz0li+updated%3A2024-03-20..2024-10-01&type=Issues)) | @buti1021 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Abuti1021+updated%3A2024-03-20..2024-10-01&type=Issues)) | @consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2024-03-20..2024-10-01&type=Issues)) | @jash2105 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajash2105+updated%3A2024-03-20..2024-10-01&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2024-03-20..2024-10-01&type=Issues)) | @Khoi16 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AKhoi16+updated%3A2024-03-20..2024-10-01&type=Issues)) | @lahwaacz ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Alahwaacz+updated%3A2024-03-20..2024-10-01&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Amanics+updated%3A2024-03-20..2024-10-01&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2024-03-20..2024-10-01&type=Issues)) | @samyuh ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asamyuh+updated%3A2024-03-20..2024-10-01&type=Issues)) | @SchutteJan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3ASchutteJan+updated%3A2024-03-20..2024-10-01&type=Issues)) | @snickell ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asnickell+updated%3A2024-03-20..2024-10-01&type=Issues))
+@alxyok ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aalxyok+updated%3A2024-03-20..2024-10-24&type=Issues)) | @benz0li ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Abenz0li+updated%3A2024-03-20..2024-10-24&type=Issues)) | @buti1021 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Abuti1021+updated%3A2024-03-20..2024-10-24&type=Issues)) | @colinlodter ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Acolinlodter+updated%3A2024-03-20..2024-10-24&type=Issues)) | @consideRatio ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AconsideRatio+updated%3A2024-03-20..2024-10-24&type=Issues)) | @jash2105 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajash2105+updated%3A2024-03-20..2024-10-24&type=Issues)) | @jrdnbradford ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajrdnbradford+updated%3A2024-03-20..2024-10-24&type=Issues)) | @jupyterhub-bot ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Ajupyterhub-bot+updated%3A2024-03-20..2024-10-24&type=Issues)) | @Khoi16 ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AKhoi16+updated%3A2024-03-20..2024-10-24&type=Issues)) | @lahwaacz ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Alahwaacz+updated%3A2024-03-20..2024-10-24&type=Issues)) | @manics ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Amanics+updated%3A2024-03-20..2024-10-24&type=Issues)) | @minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2024-03-20..2024-10-24&type=Issues)) | @samyuh ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asamyuh+updated%3A2024-03-20..2024-10-24&type=Issues)) | @SchutteJan ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3ASchutteJan+updated%3A2024-03-20..2024-10-24&type=Issues)) | @snickell ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Asnickell+updated%3A2024-03-20..2024-10-24&type=Issues)) | @StefanTheWiz ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3AStefanTheWiz+updated%3A2024-03-20..2024-10-24&type=Issues))
 
 ## 3.3
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # ref: https://myst-parser.readthedocs.io/en/latest/configuration.html
 #
 myst_enable_extensions = [
+    "colon_fence",
     "substitution",
 ]
 


### PR DESCRIPTION
adds 3-to-4 upgrade doc, which summarizes the relevant changes in dependencies and upgrade strategies in the chart config. I could find no changes in the chart itself that really needed upgrade docs, does anyone disagree, are there any new features we want to highlight in the upgrade doc in addition to possible breakages?

To prepare for final release, this collapses beta changelog entries into a single entry for 4.0, since I don't think we should keep changelog entries for prereleases.

I think theres some redundancy in the "version upgrade table" between the changelog and the upgrade doc. I think some redundancy is fine, but I don't have a great guide in my head for what level of info belongs where.