### PR TITLE
remove maintenance label from autobump PRs

### DIFF
--- a/.github/workflows/watch-dependencies.yaml
+++ b/.github/workflows/watch-dependencies.yaml
@@ -120,7 +120,7 @@ jobs:
           author: JupterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
           committer: JupterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
           branch: update-image-${{ matrix.name }}
-          labels: maintenance,dependencies
+          labels: dependencies
           commit-message: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
           title: Update ${{ matrix.repository }} version from ${{ steps.local.outputs.tag }} to ${{ steps.latest.outputs.tag }}
           body: >-
@@ -189,7 +189,7 @@ jobs:
           author: JupterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
           committer: JupterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
           branch: update-jupyterhub
-          labels: maintenance,dependencies
+          labels: dependencies
           commit-message: Update jupyterhub from ${{ steps.local.outputs.version }} to ${{ steps.latest.outputs.version }}
           title: Update jupyterhub from ${{ steps.local.outputs.version }} to ${{ steps.latest.outputs.version }}
           body: >-


### PR DESCRIPTION
results in miscategorization in github-activity changelogs