### PR TITLE
refactor: no pins in hub image's requirements.in

### DIFF
--- a/images/hub/requirements.in
+++ b/images/hub/requirements.in
@@ -1,32 +1,30 @@
-# This file is the input to requirements.txt,
-# which is a frozen version of this. To update
-# requirements.txt, use the "Run workflow" button at
+# This file is the input to requirements.txt, which is a frozen version of this.
+# To update requirements.txt, use the "Run workflow" button at
 # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions/workflows/watch-dependencies.yaml
 # that will also update the jupyterhub version if needed.
-# README.md file.
 
 # JupyterHub itself, update this version pinning by running the workflow
 # mentioned above.
 jupyterhub==5.2.1
 
-## Authenticators
-jupyterhub-firstuseauthenticator>=1
+# JupyterHub Spawner, kubernetes specific
+jupyterhub-kubespawner
+
+# JupyterHub Authenticators
+jupyterhub-firstuseauthenticator
 jupyterhub-hmacauthenticator
-jupyterhub-ldapauthenticator>=2.0.1
-jupyterhub-ltiauthenticator!=1.3.0
+jupyterhub-ldapauthenticator
+jupyterhub-ltiauthenticator
 jupyterhub-nativeauthenticator
 jupyterhub-tmpauthenticator
 oauthenticator[googlegroups,mediawiki]
 
-## Kubernetes spawner
-jupyterhub-kubespawner>=7.0.0
+# A managed JupyterHub service culling idle servers
+jupyterhub-idle-culler
 
-## Other optional dependencies for additional features
+# Other optional dependencies for additional features
 pymysql  # mysql
 psycopg2  # postgres
 pycurl  # internal http requests handle more load with pycurl
 sqlalchemy-cockroachdb # cocroachdb
 statsd  # statsd metrics collection (TODO: remove soon, since folks use prometheus)
-
-# The idle culler service
-jupyterhub-idle-culler


### PR DESCRIPTION
I explored if we could have dependabot bump major versions if we let this include major version pins. I think that would been an improvement, as it would help us distinguish major version bumps from the typical version bumps which I think makes sense to do in isolation.

However, this isn't made easy with dependabot, so I opted to not think about it for now.
- Files must be named `*requirements.txt` (https://stackoverflow.com/a/75909900/2220152)
- To ignore files and only focus on one requirements file, they must be put in different directories (https://github.com/dependabot/dependabot-core/issues/2883)