### PR TITLE
add option to expose the automount_service_account_token option

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -154,6 +154,7 @@ for trait, cfg_key in (
     ("uid", None),
     ("fs_gid", None),
     ("service_account", "serviceAccountName"),
+    ("automount_service_account_token", "automountServiceAccountToken"),
     ("storage_extra_labels", "storage.extraLabels"),
     # ("tolerations", "extraTolerations"), # Managed manually below
     ("node_selector", None),


### PR DESCRIPTION
This MR exposes the kubespawner option automount_service_account_token_option in the values.yaml for singleuser pods. This is useful if you want a sidecar to have access to the service account token but don't want the actual notebook container to have access to it.