### PR TITLE
Add dummy service accounts to hook-image-puller and continuous-image-puller pods

### DIFF
--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -198,11 +198,7 @@
 
 {{- /* hook-image-puller ServiceAccount */}}
 {{- define "jupyterhub.hook-image-puller-serviceaccount.fullname" -}}
-    {{- if .Values.prePuller.hook.serviceAccountImagePuller.create }}
-        {{- .Values.prePuller.hook.serviceAccountImagePuller.name | default (include "jupyterhub.hook-image-puller.fullname" .) }}
-    {{- else }}
-        {{- .Values.prePuller.hook.serviceAccountImagePuller.name | default "default" }}
-    {{- end }}
+    {{- .Values.prePuller.hook.serviceAccountImagePuller.name | default (include "jupyterhub.hook-image-puller.fullname" .) }}
 {{- end }}
 
 {{- /* continuous-image-puller DaemonSet */}}
@@ -212,11 +208,7 @@
 
 {{- /* continuous-image-puller ServiceAccount */}}
 {{- define "jupyterhub.continuous-image-puller-serviceaccount.fullname" -}}
-    {{- if .Values.prePuller.continuous.serviceAccount.create }}
-        {{- .Values.prePuller.continuous.serviceAccount.name | default (include "jupyterhub.continuous-image-puller.fullname" .) }}
-    {{- else }}
-        {{- .Values.prePuller.continuous.serviceAccount.name | default "default" }}
-    {{- end }}
+    {{- .Values.prePuller.continuous.serviceAccount.name | default (include "jupyterhub.continuous-image-puller.fullname" .) }}
 {{- end }}
 
 {{- /* singleuser NetworkPolicy */}}

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -308,7 +308,9 @@ image-puller-priority: {{ include "jupyterhub.image-puller-priority.fullname" . 
 hook-image-awaiter: {{ include "jupyterhub.hook-image-awaiter.fullname" . | quote }}
 hook-image-awaiter-serviceaccount: {{ include "jupyterhub.hook-image-awaiter-serviceaccount.fullname" . | quote }}
 hook-image-puller: {{ include "jupyterhub.hook-image-puller.fullname" . | quote }}
+hook-image-puller-serviceaccount: {{ include "jupyterhub.hook-image-puller-serviceaccount.fullname" . | quote }}
 continuous-image-puller: {{ include "jupyterhub.continuous-image-puller.fullname" . | quote }}
+continuous-image-puller-serviceaccount: {{ include "jupyterhub.continuous-image-puller-serviceaccount.fullname" . | quote }}
 singleuser: {{ include "jupyterhub.singleuser.fullname" . | quote }}
 image-pull-secret: {{ include "jupyterhub.image-pull-secret.fullname" . | quote }}
 ingress: {{ include "jupyterhub.ingress.fullname" . | quote }}

--- a/jupyterhub/templates/_helpers-names.tpl
+++ b/jupyterhub/templates/_helpers-names.tpl
@@ -196,9 +196,27 @@
     {{- include "jupyterhub.fullname.dash" . }}hook-image-puller
 {{- end }}
 
+{{- /* hook-image-puller ServiceAccount */}}
+{{- define "jupyterhub.hook-image-puller-serviceaccount.fullname" -}}
+    {{- if .Values.prePuller.hook.serviceAccountImagePuller.create }}
+        {{- .Values.prePuller.hook.serviceAccountImagePuller.name | default (include "jupyterhub.hook-image-puller.fullname" .) }}
+    {{- else }}
+        {{- .Values.prePuller.hook.serviceAccountImagePuller.name | default "default" }}
+    {{- end }}
+{{- end }}
+
 {{- /* continuous-image-puller DaemonSet */}}
 {{- define "jupyterhub.continuous-image-puller.fullname" -}}
     {{- include "jupyterhub.fullname.dash" . }}continuous-image-puller
+{{- end }}
+
+{{- /* continuous-image-puller ServiceAccount */}}
+{{- define "jupyterhub.continuous-image-puller-serviceaccount.fullname" -}}
+    {{- if .Values.prePuller.continuous.serviceAccount.create }}
+        {{- .Values.prePuller.continuous.serviceAccount.name | default (include "jupyterhub.continuous-image-puller.fullname" .) }}
+    {{- else }}
+        {{- .Values.prePuller.continuous.serviceAccount.name | default "default" }}
+    {{- end }}
 {{- end }}
 
 {{- /* singleuser NetworkPolicy */}}

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -70,6 +70,15 @@ spec:
               {{- include "jupyterhub.userNodeAffinityRequired" . | nindent 14 }}
       {{- end }}
       terminationGracePeriodSeconds: 0
+      {{- if .hook }}
+      {{- with include "jupyterhub.hook-image-puller-serviceaccount.fullname" . }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      {{- else }}
+      {{- with include "jupyterhub.continuous-image-puller-serviceaccount.fullname" . }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      {{- end }}
       automountServiceAccountToken: false
       {{- with include "jupyterhub.imagePullSecrets" (dict "root" . "image" .Values.singleuser.image) }}
       imagePullSecrets: {{ . }}

--- a/jupyterhub/templates/image-puller/serviceaccount-continuous.yaml
+++ b/jupyterhub/templates/image-puller/serviceaccount-continuous.yaml
@@ -1,0 +1,17 @@
+{{- /*
+ServiceAccount for the continuous image-puller daemonset
+*/}}
+{{- if .Values.prePuller.continuous.serviceAccount.create -}}
+{{- if .Values.prePuller.continuous.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.continuous-image-puller.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.prePuller.continuous.serviceAccount.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/templates/image-puller/serviceaccount-hook.yaml
+++ b/jupyterhub/templates/image-puller/serviceaccount-hook.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-weight": "-10"
     {{- with .Values.prePuller.hook.serviceAccountImagePuller.annotations }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}

--- a/jupyterhub/templates/image-puller/serviceaccount-hook.yaml
+++ b/jupyterhub/templates/image-puller/serviceaccount-hook.yaml
@@ -1,0 +1,21 @@
+{{- /*
+ServiceAccount for the hook image-puller daemonset
+*/}}
+{{- if .Values.prePuller.hook.serviceAccountImagePuller.create -}}
+{{- if (include "jupyterhub.imagePuller.daemonset.hook.install" .) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.hook-image-puller-serviceaccount.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    hub.jupyter.org/deletable: "true"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+    {{- with .Values.prePuller.hook.serviceAccountImagePuller.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2864,6 +2864,7 @@ properties:
           image: *image-spec
           resources: *resources-spec
           serviceAccount: *serviceAccount
+          serviceAccountImagePuller: *serviceAccount
       continuous:
         type: object
         additionalProperties: false
@@ -2880,6 +2881,7 @@ properties:
         properties:
           enabled:
             type: boolean
+          serviceAccount: *serviceAccount
       pullProfileListImages:
         type: boolean
         description: |

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -665,12 +665,22 @@ prePuller:
     nodeSelector: {}
     tolerations: []
     resources: {}
+    # Service Account for the hook-image-awaiter Job
     serviceAccount:
+      create: true
+      name:
+      annotations: {}
+    # Service Account for the hook-image-puller DaemonSet
+    serviceAccountImagePuller:
       create: true
       name:
       annotations: {}
   continuous:
     enabled: true
+    serviceAccount:
+      create: true
+      name:
+      annotations: {}
   pullProfileListImages: true
   extraImages: {}
   pause:

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -563,8 +563,10 @@ prePuller:
         value: mock-taint-value-hook
         effect: NoSchedule
     serviceAccount: *serviceAccount
+    serviceAccountImagePuller: *serviceAccount
   continuous:
     enabled: true
+    serviceAccount: *serviceAccount
   extraImages:
     mockImage1:
       name: mock-user/mock-image1


### PR DESCRIPTION
This MR adds two separate dummy ServiceAccounts for hook-image-puller and continuous-hook-image-puller.
- The continuous image puller runs constantly to ensure images are always available.
- The hook image puller is temporary, used during tasks like upgrades, and is deleted afterward.

Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3545