### PR TITLE
Add modern labels to pods controlled by deployments etc.

### DIFF
--- a/jupyterhub/templates/_helpers.tpl
+++ b/jupyterhub/templates/_helpers.tpl
@@ -124,52 +124,113 @@
       app.kubernetes.io/managed-by ("heritage")
 */}}
 {{- define "jupyterhub.commonLabels" -}}
+{{- if .legacyLabels -}}
 app: {{ .appLabel | default (include "jupyterhub.appLabel" .) | quote }}
 release: {{ .Release.Name | quote }}
 {{- if not .matchLabels }}
 chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 heritage: {{ .Release.Service }}
+{{- end }}
+{{- end }}
+{{- if and .legacyLabels .modernLabels -}}
+{{ printf "\n" }}
+{{- end }}
+{{- if .modernLabels -}}
 app.kubernetes.io/name: {{ .appLabel | default (include "jupyterhub.appLabel" .) | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- if not .matchLabels }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
 {{- end }}
 {{- end }}
 
 
 {{- /*
   jupyterhub.labels:
-    Provides old labels:
+    Provides labels conditionally on .legacyLabels, .modernLabels, and .matchLabels,
+    that are supposed to in the scoped passed this helper function.
+
+    The legacy labels are:
       component
       app
       release
       chart (omitted for matchLabels)
       heritage (omitted for matchLabels)
-    Provides modern labels (omitted for matchLabels):
-      app.kubernetes.io/component ("component")
-      app.kubernetes.io/name ("app")
-      app.kubernetes.io/instance release ("release")
-      helm.sh/chart ("chart")
-      app.kubernetes.io/managed-by ("heritage")
+
+    The equivalent modern labels are:
+      app.kubernetes.io/component
+      app.kubernetes.io/name
+      app.kubernetes.io/instance release
+      helm.sh/chart (omitted for matchLabels)
+      app.kubernetes.io/managed-by (omitted for matchLabels)
 */}}
 {{- define "jupyterhub.labels" -}}
+{{- /*
+  .legacyLabels defaults to true
+  .modernLabels defaults to false
+*/ -}}
+{{- $_ := . -}}
+{{- if typeIs "<nil>" .legacyLabels -}}
+{{- $_ = merge (dict "legacyLabels" true) $_ -}}
+{{- end -}}
+{{- if typeIs "<nil>" .modernLabels -}}
+{{- $_ = merge (dict "modernLabels" true) $_ -}}
+{{- end -}}
+
+{{- if $_.legacyLabels -}}
 component: {{ include "jupyterhub.componentLabel" . }}
-{{- if not .matchLabels }}
+{{- end }}
+
+{{- if and $_.legacyLabels $_.modernLabels -}}
+{{ printf "\n" }}
+{{- end }}
+
+{{- if $_.modernLabels -}}
 app.kubernetes.io/component: {{ include "jupyterhub.componentLabel" . }}
 {{- end }}
-{{ include "jupyterhub.commonLabels" . }}
+{{ include "jupyterhub.commonLabels" $_ }}
 {{- end }}
 
 
 {{- /*
   jupyterhub.matchLabels:
-    Provides old labels:
+    Provides legacy labels:
       component
       app
       release
 */}}
 {{- define "jupyterhub.matchLabels" -}}
-{{- $_ := merge (dict "matchLabels" true) . -}}
+{{- $_ := merge (dict "matchLabels" true "legacyLabels" true "modernLabels" false) . -}}
+{{ include "jupyterhub.labels" $_ }}
+{{- end }}
+
+
+{{- /*
+  jupyterhub.matchLabelsModern:
+    Provides modern labels:
+      app.kubernetes.io/component
+      app.kubernetes.io/name
+      app.kubernetes.io/instance
+*/}}
+{{- define "jupyterhub.matchLabelsModern" -}}
+{{- $_ := merge (dict "matchLabels" true "legacyLabels" false "modernLabels" true) . -}}
+{{ include "jupyterhub.labels" $_ }}
+{{- end }}
+
+
+{{- /*
+  jupyterhub.matchLabelsLegacyAndModern:
+    Provides legacy and modern labels:
+      component
+      app
+      release
+      app.kubernetes.io/component
+      app.kubernetes.io/name
+      app.kubernetes.io/instance
+*/}}
+{{- define "jupyterhub.matchLabelsLegacyAndModern" -}}
+{{- $_ := merge (dict "matchLabels" true "legacyLabels" true "modernLabels" true) . -}}
 {{ include "jupyterhub.labels" $_ }}
 {{- end }}
 

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- include "jupyterhub.matchLabelsLegacyAndModern" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-api: "true"
         hub.jupyter.org/network-access-proxy-http: "true"
         hub.jupyter.org/network-access-singleuser: "true"

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
-        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        {{- include "jupyterhub.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-api: "true"
         hub.jupyter.org/network-access-proxy-http: "true"
         hub.jupyter.org/network-access-singleuser: "true"

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -40,7 +40,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        {{- include "jupyterhub.labels" . | nindent 8 }}
       {{- with .Values.prePuller.annotations }}
       annotations:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -40,7 +40,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- include "jupyterhub.matchLabelsLegacyAndModern" . | nindent 8 }}
       {{- with .Values.prePuller.annotations }}
       annotations:
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -27,7 +27,7 @@ spec:
     metadata:
       labels:
         {{- /* Changes here will cause the Job to restart the pods. */}}
-        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        {{- include "jupyterhub.labels" . | nindent 8 }}
         {{- with .Values.prePuller.labels }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}

--- a/jupyterhub/templates/image-puller/job.yaml
+++ b/jupyterhub/templates/image-puller/job.yaml
@@ -27,7 +27,7 @@ spec:
     metadata:
       labels:
         {{- /* Changes here will cause the Job to restart the pods. */}}
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- include "jupyterhub.matchLabelsLegacyAndModern" . | nindent 8 }}
         {{- with .Values.prePuller.labels }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        {{- include "jupyterhub.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-http: "true"
         {{- with .Values.proxy.traefik.labels }}
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- include "jupyterhub.matchLabelsLegacyAndModern" . | nindent 8 }}
         hub.jupyter.org/network-access-proxy-http: "true"
         {{- with .Values.proxy.traefik.labels }}
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- include "jupyterhub.matchLabelsLegacyAndModern" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
         hub.jupyter.org/network-access-singleuser: "true"
         {{- with .Values.proxy.labels }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
-        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        {{- include "jupyterhub.labels" . | nindent 8 }}
         hub.jupyter.org/network-access-hub: "true"
         hub.jupyter.org/network-access-singleuser: "true"
         {{- with .Values.proxy.labels }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- include "jupyterhub.matchLabelsLegacyAndModern" . | nindent 8 }}
         {{- with .Values.scheduling.userPlaceholder.labels }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}

--- a/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
+++ b/jupyterhub/templates/scheduling/user-placeholder/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       labels:
         {{- /* Changes here will cause the Deployment to restart the pods. */}}
-        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        {{- include "jupyterhub.labels" . | nindent 8 }}
         {{- with .Values.scheduling.userPlaceholder.labels }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.labels" . | nindent 8 }}
+        {{- include "jupyterhub.matchLabelsLegacyAndModern" . | nindent 8 }}
         {{- with .Values.scheduling.userScheduler.labels }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}

--- a/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
+++ b/jupyterhub/templates/scheduling/user-scheduler/deployment.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "jupyterhub.matchLabels" . | nindent 8 }}
+        {{- include "jupyterhub.labels" . | nindent 8 }}
         {{- with .Values.scheduling.userScheduler.labels }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Some labels are missing in the pods, such as:
```
    app.kubernetes.io/name: "jupyterhub"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/managed-by: Helm
```

The issue occurred because 'jupyterhub.matchLabels' was imported instead of 'jupyterhub.labels'.

Closes #3595