### PR TITLE
Add pullPolicy to pre-pulled extraImages

### DIFF
--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -196,6 +196,9 @@ spec:
         {{- range $k, $v := .Values.prePuller.extraImages }}
         - name: image-pull-{{ $k }}
           image: {{ $v.name }}:{{ $v.tag }}
+          {{- with $v.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           command:
             - /bin/sh
             - -c

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -563,7 +563,7 @@ properties:
               v1.11.1
               zhy270a
               ```
-          pullPolicy:
+          pullPolicy: &imagePullPolicy
             enum: [null, "", IfNotPresent, Always, Never]
             description: |
               Configures the Pod's `spec.imagePullPolicy`.
@@ -2921,6 +2921,7 @@ properties:
                 type: string
               tag:
                 type: string
+              pullPolicy: *imagePullPolicy
       containerSecurityContext: *containerSecurityContext-spec
       pause:
         type: object

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -574,6 +574,7 @@ prePuller:
     mockImage2:
       name: mock-user/mock-image2
       tag: mock-tag
+      pullPolicy: Always
 
 ingress:
   enabled: true


### PR DESCRIPTION
We support `imagePullPolicy` for most images that can be pre-pulled (though not all, e.g. `kubespawner_override.image` which we may want to review in future).