### PR TITLE
Linkcheck: update ignored and permanently redirected external URLs

### DIFF
--- a/docs/source/administrator/authentication.md
+++ b/docs/source/administrator/authentication.md
@@ -404,9 +404,9 @@ OAuthenticator project and reference that instead of maintaining similar
 documentation in this project also.
 ```
 
-[OpenID Connect](https://openid.net/connect) is an identity layer on top of the
+[OpenID Connect](https://openid.net/developers/how-connect-works/) is an identity layer on top of the
 OAuth 2.0 protocol, implemented by [various servers and
-services](https://openid.net/certified-open-id-developer-tools/). While OpenID
+services](https://openid.net/developers/certified-openid-connect-implementations/). While OpenID
 Connect endpoint discovery is not supported by oauthentiator, you can still
 configure JupyterHub to authenticate with OpenID Connect providers by specifying
 all endpoints in the GenericOAuthenticator class.

--- a/docs/source/administrator/cost.md
+++ b/docs/source/administrator/cost.md
@@ -79,4 +79,4 @@ of CPU and memory usage. Ryan Lovett put together a short Jupyter notebook
 [estimating the cost for computational resources][estimating the cost for computational resources] depending on the student
 needs.
 
-[estimating the cost for computational resources]: https://github.com/data-8/jupyterhub-k8s/blob/HEAD/docs/cost-estimation/gce_budgeting.ipynb
+[estimating the cost for computational resources]: https://github.com/berkeley-dsep-infra/jupyterhub-k8s/blob/HEAD/docs/cost-estimation/gce_budgeting.ipynb

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -231,6 +231,8 @@ linkcheck_ignore = [
     "https://portal.azure.com",  # sign-in redirect noise
     "https://console.cloud.google.com",  # sign-in redirect noise
     "https://console.developers.google.com",  # sign-in redirect noise
+    "https://www.espncricinfo.com/cricketers/hamid-hassan-311427",  # CI: 403 Client Error: Forbidden for url
+    "https://kccncna17.sched.com/event/CU6z/hacking-and-hardening-kubernetes-clusters-by-example-i-brad-geesaman-symantec",  # CI: 500 Server Error: Internal Server Error for url
 ]
 linkcheck_anchors_ignore = [
     "/#!",

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -134,7 +134,7 @@ This guide and the associated helm chart would not be possible without
 the amazing institutional support from the following organizations (and
 the organizations that support them!)
 
-- [UC Berkeley Data Science Division](https://data.berkeley.edu/)
+- [UC Berkeley Data Science Division](https://cdss.berkeley.edu/)
 - [Berkeley Institute for Data Science](https://bids.berkeley.edu/)
 - [Cal Poly, San Luis Obispo](https://www.calpoly.edu/)
 - [Simula Research Institute](https://www.simula.no/)

--- a/docs/source/kubernetes/amazon/step-zero-aws.md
+++ b/docs/source/kubernetes/amazon/step-zero-aws.md
@@ -38,7 +38,7 @@ template you will use to setup and shape your cluster.
    ```
 
 3. SSH to your CI host. Instructions on how to do this are given
-   [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html).
+   [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-linux-inst-ssh.html).
 
 4. Install kops and kubectl on your CI host
 

--- a/docs/source/kubernetes/redhat/step-zero-openshift.md
+++ b/docs/source/kubernetes/redhat/step-zero-openshift.md
@@ -2,7 +2,7 @@
 
 # Kubernetes on Red Hat OpenShift
 
-[OpenShift](https://www.okd.io/) from RedHat is a cluster manager based on Kubernetes.
+[OpenShift](https://okd.io/) from RedHat is a cluster manager based on Kubernetes.
 
 For running Z2JH on openshift, check out the [z2jh-openshift](https://github.com/gembaadvantage/z2jh-openshift) project. It customizes the containers used by the helm chart with security configuration required by OpenShift, and makes minor alterations to network policies to enable networking with the Weave NPC and the default OpenShift DNS.
 

--- a/docs/source/repo2docker.md
+++ b/docs/source/repo2docker.md
@@ -38,7 +38,9 @@ to configure JupyterHub to build off of this image:
 
 1. **Download and start Docker.**
 
-   You can do this by [downloading and installing Docker](https://docs.docker.com/get-docker/). Once you’ve started
+   You can do this by
+   [downloading and installing Docker](https://docs.docker.com/get-started/get-docker/).
+   Once you’ve started
    Docker, it will show up as a tiny background application.
 
 2. **Install repo2docker** using `pip`:

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1980,7 +1980,7 @@ properties:
               TLS termination proxy.
 
               See [Mozilla's
-              documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
+              documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security)
               for more information.
             properties:
               includeSubdomains:


### PR DESCRIPTION
- Add URLs failing in CI to ignored list https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3653
- Updates most "permanently redirected" links to their new destination
  - Exceptions are redirected links in the changelog, and redirections with are region specific:

![image](https://github.com/user-attachments/assets/2ad95d3f-8403-4a5b-9421-04ad81b74889)
