### PR TITLE
Replace deprecated `pipes.quote` with `shlex.quote`

### DIFF
--- a/tools/templates/lint-and-validate.py
+++ b/tools/templates/lint-and-validate.py
@@ -16,7 +16,7 @@ yamllint: https://github.com/adrienverge/yamllint
 
 import argparse
 import os
-import pipes
+import shlex
 import subprocess
 import sys
 
@@ -30,7 +30,7 @@ def check_call(cmd, **kwargs):
     except subprocess.CalledProcessError as e:
         print(
             "`{}` exited with status {}".format(
-                " ".join(map(pipes.quote, cmd)),
+                " ".join(map(shlex.quote, cmd)),
                 e.returncode,
             ),
             file=sys.stderr,


### PR DESCRIPTION
# PR Summary
The `pipes` Python module has been deprecated for a while and been removed in Python 3.13. This PR fixes warnings in CI logs caused by this deprecated `pipes` module. More specifically, this PR replaces `pipes.quote` with `shlex.quote` in `tools/templates/lint-and-validate.py` to resolve:
```
/home/runner/work/zero-to-jupyterhub-k8s/zero-to-jupyterhub-k8s/tools/templates/lint-and-validate.py:19: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
  import pipes
```
See [CI log](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions/runs/14496221261/job/40664561393#step:5:12) for more details.