### PR TITLE
Declare k8s Services ipFamilyPolicy to PreferDualStack, previously implicit SingleStack

### DIFF
--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -44,7 +44,7 @@ hub:
       appProtocol:
     extraPorts: []
     loadBalancerIP:
-    ipFamilyPolicy: ""
+    ipFamilyPolicy: PreferDualStack
     ipFamilies: []
   baseUrl: /
   cookieSecret:
@@ -201,7 +201,7 @@ proxy:
     externalIPs: []
     loadBalancerIP:
     loadBalancerSourceRanges: []
-    ipFamilyPolicy: ""
+    ipFamilyPolicy: PreferDualStack
     ipFamilies: []
   # chp relates to the proxy pod, which is responsible for routing traffic based
   # on dynamic configuration sent from JupyterHub to CHP's REST API.


### PR DESCRIPTION
Based on @manics discussion in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3485#issuecomment-2614662304, this PR declares the charts Service resources `hub`/`proxy-public`/`proxy-http`/`proxy-api` field `ipFamiliyPolicy` to `PreferDualStack` through the config introduced in #3485. This change is believed to be non-breaking.

## Related docs

- [About dual stack IP config](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
- [Switching Services between single-stack and dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#switching-services-between-single-stack-and-dual-stack)
- [Reference docs about k8s Service, including ipFamiliyPolicy](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)

  > **ipFamilyPolicy (string)**
  > 
  > IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.