### PR TITLE
Let `proxy.service.[ipFamilies|ipFamilyPolicy]` affect the `proxy-api` Service also

### DIFF
--- a/jupyterhub/templates/proxy/service.yaml
+++ b/jupyterhub/templates/proxy/service.yaml
@@ -18,6 +18,13 @@ spec:
   ports:
     - port: 8001
       targetPort: api
+  {{- with .Values.proxy.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.proxy.service.ipFamilies }}
+  ipFamilies:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
A followup to #3485, where we had one more k8s Service resource not being influenced.