### PR TITLE
Support dict values for volumes, volume_mounts and other list based configs that support dict values

### DIFF
--- a/docs/source/jupyterhub/customizing/user-resources.md
+++ b/docs/source/jupyterhub/customizing/user-resources.md
@@ -118,11 +118,13 @@ The following configuration will increase the SHM allocation by mounting a
 singleuser:
   storage:
     extraVolumes:
-      - name: shm-volume
+      shm-volume:
+        name: shm-volume
         emptyDir:
           medium: Memory
     extraVolumeMounts:
-      - name: shm-volume
+      shm-volume:
+        name: shm-volume
         mountPath: /dev/shm
 ```
 

--- a/docs/source/jupyterhub/customizing/user-storage.md
+++ b/docs/source/jupyterhub/customizing/user-storage.md
@@ -235,11 +235,13 @@ pods:
 singleuser:
   storage:
     extraVolumes:
-      - name: jupyterhub-shared
+      jupyterhub-shared:
+        name: jupyterhub-shared
         persistentVolumeClaim:
           claimName: jupyterhub-shared-volume
     extraVolumeMounts:
-      - name: jupyterhub-shared
+      jupyterhub-shared:
+        name: jupyterhub-shared
         mountPath: /home/shared
 ```
 

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -252,6 +252,9 @@ tolerations = scheduling_user_pods_tolerations + singleuser_extra_tolerations
 if tolerations:
     c.KubeSpawner.tolerations = tolerations
 
+volumes = {}
+volume_mounts = {}
+
 # Configure dynamically provisioning pvc
 storage_type = get_config("singleuser.storage.type")
 if storage_type == "dynamic":
@@ -273,32 +276,35 @@ if storage_type == "dynamic":
     )
 
     # Add volumes to singleuser pods
-    c.KubeSpawner.volumes = [
-        {
+    volumes = {
+        volume_name_template: {
             "name": volume_name_template,
             "persistentVolumeClaim": {"claimName": "{pvc_name}"},
         }
-    ]
-    c.KubeSpawner.volume_mounts = [
-        {
+    }
+    volume_mounts = {
+        volume_name_template: {
             "mountPath": get_config("singleuser.storage.homeMountPath"),
             "name": volume_name_template,
             "subPath": get_config("singleuser.storage.dynamic.subPath"),
         }
-    ]
+    }
 elif storage_type == "static":
     pvc_claim_name = get_config("singleuser.storage.static.pvcName")
-    c.KubeSpawner.volumes = [
-        {"name": "home", "persistentVolumeClaim": {"claimName": pvc_claim_name}}
-    ]
+    volumes = {
+        "home": {
+            "name": "home",
+            "persistentVolumeClaim": {"claimName": pvc_claim_name},
+        }
+    }
 
-    c.KubeSpawner.volume_mounts = [
-        {
+    volume_mounts = {
+        "home": {
             "mountPath": get_config("singleuser.storage.homeMountPath"),
             "name": "home",
             "subPath": get_config("singleuser.storage.static.subPath"),
         }
-    ]
+    }
 
 # Inject singleuser.extraFiles as volumes and volumeMounts with data loaded from
 # the dedicated k8s Secret prepared to hold the extraFiles actual content.
@@ -323,24 +329,39 @@ if extra_files:
         "secretName": get_name("singleuser"),
         "items": items,
     }
-    c.KubeSpawner.volumes.append(volume)
+    volumes.update({volume["name"]: volume})
 
-    volume_mounts = []
-    for file_key, file_details in extra_files.items():
-        volume_mounts.append(
-            {
-                "mountPath": file_details["mountPath"],
-                "subPath": file_key,
-                "name": "files",
-            }
-        )
-    c.KubeSpawner.volume_mounts.extend(volume_mounts)
+    for idx, (file_key, file_details) in enumerate(extra_files.items()):
+        volume_mount = {
+            "mountPath": file_details["mountPath"],
+            "subPath": file_key,
+            "name": "files",
+        }
+        volume_mounts.update({f"{idx}-files": volume_mount})
 
 # Inject extraVolumes / extraVolumeMounts
-c.KubeSpawner.volumes.extend(get_config("singleuser.storage.extraVolumes", []))
-c.KubeSpawner.volume_mounts.extend(
-    get_config("singleuser.storage.extraVolumeMounts", [])
-)
+extra_volumes = get_config("singleuser.storage.extraVolumes", default={})
+if isinstance(extra_volumes, dict):
+    for key, volume in extra_volumes.items():
+        volumes.update({key: volume})
+elif isinstance(extra_volumes, list):
+    for volume in extra_volumes:
+        volumes.update({volume["name"]: volume})
+
+extra_volume_mounts = get_config("singleuser.storage.extraVolumeMounts", default={})
+if isinstance(extra_volume_mounts, dict):
+    for key, volume_mount in extra_volume_mounts.items():
+        volume_mounts.update({key: volume_mount})
+elif isinstance(extra_volume_mounts, list):
+    # If extraVolumeMounts is a list, we need to add them to the volume_mounts
+    # dictionary with a unique key.
+    # Since volume mount's name is not guaranteed to be unique, we use the index
+    # as part of the key.
+    for idx, volume_mount in enumerate(extra_volume_mounts):
+        volume_mounts.update({f"{idx}-{volume_mount['name']}": volume_mount})
+
+c.KubeSpawner.volumes = volumes
+c.KubeSpawner.volume_mounts = volume_mounts
 
 c.JupyterHub.services = []
 c.JupyterHub.load_roles = []

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2418,8 +2418,28 @@ properties:
               Configures `KubeSpawner.storage_extra_labels`. Note that these
               labels are set on the PVC during creation only and won't be
               updated after creation.
-          extraVolumeMounts: *extraVolumeMounts-spec
-          extraVolumes: *extraVolumes-spec
+          extraVolumeMounts:
+            type: [object, array]
+            description: |
+              Configures `KubeSpawner.volume_mounts` dictionary. Can be a dictionary
+              or an array.
+              If it's an array, a combination of the volume name and its index is
+              used as the key while setting up the volume mount entry in
+              KubeSpawner.volume_mounts and the value is the volume mount
+              configuration.
+              If it's a dictionary, the keys of the dictionary can be any descriptive
+              name for the volume mount and the value is the volume mount
+              configuration.
+          extraVolumes:
+            type: [object, array]
+            description: |
+              Configures `KubeSpawner.volumes` dictionary. Can be a dictionary or an
+              array.
+              If it's an array, the name of the volume is used as the key while
+              setting up the volume entry in KubeSpawner.volumes and the value is the
+              volume configuration.
+              If it's a dictionary, the keys of the dictionary can be any descriptive
+              name for the volume and the value is the volume configuration.
           homeMountPath:
             type: string
             description: |

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -404,8 +404,8 @@ singleuser:
   storage:
     type: dynamic
     extraLabels: {}
-    extraVolumes: []
-    extraVolumeMounts: []
+    extraVolumes: {}
+    extraVolumeMounts: {}
     static:
       pvcName:
       subPath: "{username}"

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -455,8 +455,8 @@ singleuser:
   storage:
     type: dynamic
     extraLabels: *labels
-    extraVolumes: []
-    extraVolumeMounts: []
+    extraVolumes: {}
+    extraVolumeMounts: {}
     static:
       pvcName:
       subPath: "{username}"


### PR DESCRIPTION
KubeSpawner now supports dict values for volumes, volume_mounts etc. This allows for easy overriding when required. ref: https://github.com/jupyterhub/kubespawner/pull/843 and https://github.com/jupyterhub/kubespawner/pull/845

This PR makes sure `jupyterhub_config.py` also support defining these values as dictionaries and changes the default of these list based configurations to be dict.