### PR TITLE
Update base debian image to 13 (trixie) Python 3.14

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -10,7 +10,7 @@
 # NOTE: If the image version is updated, also update it in ci/refreeze and
 #       singleuser-sample's Dockerfile!
 #
-FROM python:3.12-trixie as build-stage
+FROM python:3.14-trixie as build-stage
 
 # Build wheels
 #
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
 # This stage is built and published as quay.io/jupyterhub/k8s-hub-slim. It is meant to
 # provide no non-essential packages.
 #
-FROM python:3.12-slim-trixie as slim-stage
+FROM python:3.14-slim-trixie as slim-stage
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG NB_USER=jovyan \

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -10,7 +10,7 @@
 # NOTE: If the image version is updated, also update it in ci/refreeze and
 #       hub's Dockerfile!
 #
-FROM python:3.12-trixie as build-stage
+FROM python:3.14-trixie as build-stage
 
 # Build wheels
 #
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
 # The final stage
 # ---------------
 #
-FROM python:3.12-slim-trixie
+FROM python:3.14-slim-trixie
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV NB_USER=jovyan \


### PR DESCRIPTION
The slim Python images are based on the latest Debian release.

Debian 13 Trixie was released 3 weeks ago.

This version will be actively supported going forward, while bookworm will end full support in 2026 and will only receive critical security updates
https://www.debian.org/releases/bookworm/index.ru.html