### PR TITLE
test-chart.yaml: use docker.io/bitnamilegacy/postgresql

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -208,6 +208,7 @@ jobs:
               --set hub.db.upgrade=true
             create-k8s-test-resources: true
             # https://artifacthub.io/packages/helm/bitnami/postgresql
+            # TODO: Replace postgresql chart https://github.com/bitnami/containers/issues/83267
             setup-postgresql-args: >-
               --version=16.0.5
               --set auth.enablePostgresUser=true
@@ -217,6 +218,7 @@ jobs:
               --set audit.logConnections=true
               --set audit.logDisconnections=true
               --set audit.clientMinMessages=debug
+              --set image.repository=bitnamilegacy/postgresql
             os: ubuntu-24.04
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We use the Bitnami PostgreSQL chart for testing only. They've deprecated support:
https://github.com/bitnami/containers/issues/83267

This switches to their legacy repo and fixes our failing CI tests.