### PR TITLE
Set working directory for JupyterHub deployment

### DIFF
--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -166,6 +166,7 @@ spec:
               {{- with .Values.hub.db.pvc.subPath }}
               subPath: {{ . | quote }}
               {{- end }}
+          workingDir: /srv/jupyterhub
             {{- end }}
           {{- with .Values.hub.resources }}
           resources:


### PR DESCRIPTION
In case the image's default working dir is not set to /srv/