### PR TITLE
Add plausible stats tracking, consolidated with jupyter.org stats

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -318,9 +318,12 @@ rediraffe_redirects = {
     "advanced": "administrator/advanced",
 }
 
+
 def setup(app):
     # Enable Plausible.io stats for jupyter.org
-    app.add_js_file("https://plausible.io/js/pa-B75UO5--FNXYQSG7GBWkf.js", loading_method="async")
+    app.add_js_file(
+        "https://plausible.io/js/pa-B75UO5--FNXYQSG7GBWkf.js", loading_method="async"
+    )
     app.add_js_file(
         filename=None,
         body="window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init({hashBasedRouting:true})",


### PR DESCRIPTION
I noticed that these docs are served from jupyter.org. This PR is similar to jupyter/jupyter#797. Stats would show up at https://plausible.io/jupyter.org
