### PR TITLE
Fix Traefik Gateway config for 1.33.6+

### DIFF
--- a/ci/traefik-config.yaml
+++ b/ci/traefik-config.yaml
@@ -12,7 +12,8 @@ spec:
       listeners:
         web:
           # -- Routes are restricted to namespace of the gateway [by default](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.FromNamespaces
-          namespacePolicy: All
+          namespacePolicy:
+            from: All
     logs:
       access:
         enabled: true


### PR DESCRIPTION
The gateway test started failing when the K3S stable channel was updated to 1.33.6. This is due to a bump in the bundle Traefik Helm chart, which requires a modified config.