### PR TITLE
Add pod labels to image-puller daemonsets

### DIFF
--- a/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
+++ b/jupyterhub/templates/image-puller/_helpers-daemonset.tpl
@@ -49,6 +49,9 @@ spec:
     metadata:
       labels:
         {{- include "jupyterhub.matchLabelsLegacyAndModern" . | nindent 8 }}
+        {{- with .Values.prePuller.labels }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       {{- with .Values.prePuller.annotations }}
       annotations:
         {{- . | toYaml | nindent 8 }}


### PR DESCRIPTION
Allow the option to set pod labels to the image-puller daemonsets.

Closes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2506#issuecomment-3670574026