### PR TITLE
Set service name in HTTPRoute to match the proxy-public service name

### DIFF
--- a/jupyterhub/templates/httproute.yaml
+++ b/jupyterhub/templates/httproute.yaml
@@ -22,6 +22,6 @@ spec:
   {{- end }}
   rules:
     - backendRefs:
-        - name: proxy-public
+        - name: {{ include "jupyterhub.proxy-public.fullname" . }}
           port: 80
 {{- end }}


### PR DESCRIPTION
- fixes #3805

When using fullnameOverrides, the proxy-public service name changes.
This PR reflects the service name into the HTTPRoute object.

Tested with these values:
```
nameOverride: jupyterhub
fullnameOverride: jupyterhub
httpRoute:
  enabled: true
  hostnames:
  - some.host.name
  gateway:
    name: istio-gateway
    namespace: istio-gateway
hub:
  baseUrl: /
  networkPolicy:
    enabled: false

proxy:
  service:
    type: ClusterIP
    nodePorts: {}
  chp:
    networkPolicy:
      enabled: false
  traefik:
    networkPolicy:
      enabled: false
  https:
    enabled: false

singleuser:
  networkPolicy:
    enabled: false
  cloudMetadata:
    blockWithIptables: false

```