### PR TITLE
Features: Add per-singleuser Service/Route exposure"

### DIFF
--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -16,9 +16,13 @@ for configuration_directory in (
     os.path.dirname(os.path.realpath(__file__)),
     "/usr/local/etc/jupyterhub/config",
 ):
-    if os.path.isdir(configuration_directory) and configuration_directory not in sys.path:
+    if (
+        os.path.isdir(configuration_directory)
+        and configuration_directory not in sys.path
+    ):
         sys.path.insert(0, configuration_directory)
 
+from singleuser_exposure import configure_singleuser_exposure
 from z2jh import (
     get_config,
     get_name,
@@ -26,7 +30,6 @@ from z2jh import (
     get_secret_value,
     set_config_if_not_none,
 )
-from singleuser_exposure import configure_singleuser_exposure
 
 
 def camelCaseify(s):

--- a/jupyterhub/files/hub/jupyterhub_config.py
+++ b/jupyterhub/files/hub/jupyterhub_config.py
@@ -10,9 +10,14 @@ from jupyterhub.utils import url_path_join
 from kubernetes_asyncio import client
 from tornado.httpclient import AsyncHTTPClient
 
-# Make sure that modules placed in the same directory as the jupyterhub config are added to the pythonpath
-configuration_directory = os.path.dirname(os.path.realpath(__file__))
-sys.path.insert(0, configuration_directory)
+# Make sure that modules placed alongside the config file, or injected via the
+# chart's config ConfigMap mount, are importable.
+for configuration_directory in (
+    os.path.dirname(os.path.realpath(__file__)),
+    "/usr/local/etc/jupyterhub/config",
+):
+    if os.path.isdir(configuration_directory) and configuration_directory not in sys.path:
+        sys.path.insert(0, configuration_directory)
 
 from z2jh import (
     get_config,
@@ -21,6 +26,7 @@ from z2jh import (
     get_secret_value,
     set_config_if_not_none,
 )
+from singleuser_exposure import configure_singleuser_exposure
 
 
 def camelCaseify(s):
@@ -540,3 +546,7 @@ if os.path.isdir(config_dir):
 for key, config_py in sorted(get_config("hub.extraConfig", {}).items()):
     print(f"Loading extra config: {key}")
     exec(config_py)
+
+# apply chart-managed hook composition after hub.extraConfig has had a chance to
+# register any custom hook functions of its own.
+configure_singleuser_exposure(c, get_config)

--- a/jupyterhub/files/hub/singleuser_exposure.py
+++ b/jupyterhub/files/hub/singleuser_exposure.py
@@ -157,7 +157,9 @@ def build_service_metadata_patch(spawner, service, exposure_config):
     labels.update(expand_templates(exposure_config.get("labels", {}), context))
 
     annotations = dict(service["metadata"].get("annotations") or {})
-    annotations.update(expand_templates(exposure_config.get("annotations", {}), context))
+    annotations.update(
+        expand_templates(exposure_config.get("annotations", {}), context)
+    )
 
     metadata = {"labels": labels}
     if annotations:
@@ -396,7 +398,9 @@ async def apply_exposure(spawner, exposure_config, pod):
         )
 
         if exposure_config["type"] == "loadBalancer":
-            await apply_loadbalancer_service(core_api, spawner, service, exposure_config)
+            await apply_loadbalancer_service(
+                core_api, spawner, service, exposure_config
+            )
         elif exposure_config["type"] == "route":
             service = await apply_clusterip_service(
                 core_api, spawner, service, exposure_config

--- a/jupyterhub/files/hub/singleuser_exposure.py
+++ b/jupyterhub/files/hub/singleuser_exposure.py
@@ -1,0 +1,455 @@
+import copy
+from collections.abc import Mapping
+
+from jupyterhub.utils import exponential_backoff, maybe_future
+
+try:
+    from kubernetes_asyncio import client
+    from kubernetes_asyncio.client import ApiException
+except ImportError:  # pragma: no cover - local tooling may not have hub deps
+    client = None
+
+    class ApiException(Exception):
+        def __init__(self, status=None, *args, **kwargs):
+            super().__init__(*args)
+            self.status = status
+
+
+RESOURCE_TYPES = {
+    "route": {
+        "apiVersion": "route.openshift.io/v1",
+        "group": "route.openshift.io",
+        "version": "v1",
+        "plural": "routes",
+        "kind": "Route",
+    }
+}
+
+EXPOSURE_TYPES = {"loadBalancer", "route"}
+DEFAULT_SSH_PORT = 22
+DEFAULT_SSH_PORT_NAME = "ssh"
+
+
+class ExposureConfigError(ValueError):
+    """Raised when singleuser.exposure is invalid."""
+
+
+def get_service_name(spawner):
+    return spawner.pod_name
+
+
+def build_template_context(spawner, service_name=None):
+    server_name = spawner.name or ""
+    user_server = spawner.user.name
+    if server_name:
+        user_server = f"{user_server}--{server_name}"
+
+    return {
+        "username": spawner.user.name,
+        "escaped_username": getattr(spawner.user, "escaped_name", spawner.user.name),
+        "servername": server_name,
+        "service_name": service_name or get_service_name(spawner),
+        "pod_name": spawner.pod_name,
+        "namespace": spawner.namespace,
+        "base_url": spawner.server.base_url,
+        "user_server": user_server,
+    }
+
+
+def render_template_string(template, context):
+    try:
+        return template.format_map(context)
+    except KeyError as exc:
+        raise ExposureConfigError(
+            f"Unknown template field '{exc.args[0]}' in singleuser.exposure"
+        ) from exc
+
+
+def expand_templates(value, context):
+    if isinstance(value, str):
+        return render_template_string(value, context)
+    if isinstance(value, list):
+        return [expand_templates(item, context) for item in value]
+    if isinstance(value, Mapping):
+        return {key: expand_templates(item, context) for key, item in value.items()}
+    return value
+
+
+def validate_exposure_config(exposure_config):
+    exposure_type = exposure_config.get("type")
+    if exposure_type not in EXPOSURE_TYPES:
+        raise ExposureConfigError(
+            "singleuser.exposure.type must be one of: "
+            + ", ".join(sorted(EXPOSURE_TYPES))
+        )
+
+
+def build_owner_reference(pod):
+    return {
+        "apiVersion": pod.get("apiVersion", "v1"),
+        "kind": pod.get("kind", "Pod"),
+        "name": pod["metadata"]["name"],
+        "uid": pod["metadata"]["uid"],
+        "blockOwnerDeletion": True,
+        "controller": False,
+    }
+
+
+def build_resource_metadata(spawner, pod, exposure_config, service_name):
+    context = build_template_context(spawner, service_name=service_name)
+    labels = dict(getattr(spawner, "common_labels", {}) or {})
+    labels.update(
+        {
+            "app.kubernetes.io/component": getattr(
+                spawner, "component_label", "singleuser-server"
+            ),
+            "component": getattr(spawner, "component_label", "singleuser-server"),
+            "hub.jupyter.org/external-access": "true",
+        }
+    )
+    labels.update(expand_templates(exposure_config.get("labels", {}), context))
+
+    metadata = {
+        "name": service_name,
+        "labels": labels,
+        "ownerReferences": [build_owner_reference(pod)],
+    }
+
+    annotations = expand_templates(exposure_config.get("annotations", {}), context)
+    if annotations:
+        metadata["annotations"] = annotations
+
+    return metadata
+
+
+def get_service_ports(service, exposure_config):
+    ssh_config = exposure_config.get("ssh", {})
+    if not ssh_config.get("enabled", True):
+        return copy.deepcopy(service.get("spec", {}).get("ports", []))
+
+    service_port = ssh_config.get("externalPort")
+    if service_port is None:
+        service_port = DEFAULT_SSH_PORT
+
+    target_port = ssh_config.get("containerPort")
+    if target_port is None:
+        target_port = service_port
+
+    ssh_port = {
+        "name": DEFAULT_SSH_PORT_NAME,
+        "port": service_port,
+        "targetPort": target_port,
+        "protocol": "TCP",
+    }
+    existing_ports = copy.deepcopy(service.get("spec", {}).get("ports", []))
+    existing_ports = [
+        port for port in existing_ports if port.get("name") != DEFAULT_SSH_PORT_NAME
+    ]
+    return [ssh_port] + existing_ports
+
+
+def build_service_metadata_patch(spawner, service, exposure_config):
+    service_name = service["metadata"]["name"]
+    context = build_template_context(spawner, service_name=service_name)
+
+    labels = dict(service["metadata"].get("labels") or {})
+    labels["hub.jupyter.org/external-access"] = "true"
+    labels.update(expand_templates(exposure_config.get("labels", {}), context))
+
+    annotations = dict(service["metadata"].get("annotations") or {})
+    annotations.update(expand_templates(exposure_config.get("annotations", {}), context))
+
+    metadata = {"labels": labels}
+    if annotations:
+        metadata["annotations"] = annotations
+    return metadata
+
+
+def build_loadbalancer_service_patch(spawner, service, exposure_config):
+    service_config = exposure_config.get("service", {})
+    spec = {"type": "LoadBalancer"}
+    for field in (
+        "allocateLoadBalancerNodePorts",
+        "externalTrafficPolicy",
+        "ipFamilies",
+        "ipFamilyPolicy",
+        "loadBalancerClass",
+        "loadBalancerIP",
+        "loadBalancerSourceRanges",
+    ):
+        if service_config.get(field) is not None:
+            spec[field] = service_config[field]
+
+    ports = get_service_ports(service, exposure_config)
+    if ports:
+        spec["ports"] = ports
+
+    return {
+        "metadata": build_service_metadata_patch(spawner, service, exposure_config),
+        "spec": spec,
+    }
+
+
+def build_clusterip_service_patch(spawner, service, exposure_config):
+    spec = {"type": "ClusterIP"}
+    ports = get_service_ports(service, exposure_config)
+    if ports:
+        spec["ports"] = ports
+
+    return {
+        "metadata": build_service_metadata_patch(spawner, service, exposure_config),
+        "spec": spec,
+    }
+
+
+def get_route_target_port(service):
+    service_port = (service.get("spec", {}).get("ports") or [{}])[0]
+    return (
+        service_port.get("name")
+        or service_port.get("targetPort")
+        or service_port.get("port")
+    )
+
+
+def build_route_manifest(spawner, pod, service, exposure_config):
+    service_name = service["metadata"]["name"]
+    context = build_template_context(spawner, service_name=service_name)
+    route_config = exposure_config.get("route", {})
+    spec = {
+        "to": {
+            "kind": "Service",
+            "name": service_name,
+        },
+        "port": {
+            "targetPort": get_route_target_port(service),
+        },
+    }
+
+    if exposure_config.get("hostTemplate"):
+        spec["host"] = render_template_string(exposure_config["hostTemplate"], context)
+
+    tls_config = {
+        key: value
+        for key, value in expand_templates(route_config.get("tls", {}), context).items()
+        if value is not None
+    }
+    if tls_config:
+        spec["tls"] = tls_config
+
+    if route_config.get("wildcardPolicy") is not None:
+        spec["wildcardPolicy"] = route_config["wildcardPolicy"]
+
+    return {
+        "apiVersion": RESOURCE_TYPES["route"]["apiVersion"],
+        "kind": RESOURCE_TYPES["route"]["kind"],
+        "metadata": build_resource_metadata(
+            spawner, pod, exposure_config, service_name=service_name
+        ),
+        "spec": spec,
+    }
+
+
+async def wait_for_service(api, namespace, name):
+    async def get_service():
+        try:
+            return await api.read_namespaced_service(name=name, namespace=namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                return False
+            raise
+
+    service = await exponential_backoff(
+        get_service,
+        f"Service {namespace}/{name} did not appear",
+        timeout=30,
+    )
+    return service.to_dict()
+
+
+async def apply_loadbalancer_service(api, spawner, service, exposure_config):
+    patch = build_loadbalancer_service_patch(spawner, service, exposure_config)
+    response = await api.patch_namespaced_service(
+        name=service["metadata"]["name"],
+        namespace=spawner.namespace,
+        body=patch,
+        _content_type="application/merge-patch+json",
+    )
+    response = response.to_dict()
+    spawner.log.info(
+        "Ensured LoadBalancer Service %s for %s",
+        response["metadata"]["name"],
+        spawner.server.base_url,
+    )
+    return response
+
+
+async def apply_clusterip_service(api, spawner, service, exposure_config):
+    patch = build_clusterip_service_patch(spawner, service, exposure_config)
+    response = await api.patch_namespaced_service(
+        name=service["metadata"]["name"],
+        namespace=spawner.namespace,
+        body=patch,
+        _content_type="application/merge-patch+json",
+    )
+    response = response.to_dict()
+    spawner.log.info(
+        "Ensured ClusterIP Service %s for %s",
+        response["metadata"]["name"],
+        spawner.server.base_url,
+    )
+    return response
+
+
+async def delete_service(api, spawner):
+    try:
+        await api.delete_namespaced_service(
+            name=get_service_name(spawner),
+            namespace=spawner.namespace,
+            body=client.V1DeleteOptions(),
+        )
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
+    else:
+        spawner.log.info("Deleted Service %s", get_service_name(spawner))
+
+
+async def apply_route(api, spawner, service, exposure_config, pod):
+    manifest = build_route_manifest(spawner, pod, service, exposure_config)
+    resource = RESOURCE_TYPES["route"]
+    name = manifest["metadata"]["name"]
+
+    try:
+        existing = await api.get_namespaced_custom_object(
+            group=resource["group"],
+            version=resource["version"],
+            namespace=spawner.namespace,
+            plural=resource["plural"],
+            name=name,
+        )
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
+        response = await api.create_namespaced_custom_object(
+            group=resource["group"],
+            version=resource["version"],
+            namespace=spawner.namespace,
+            plural=resource["plural"],
+            body=manifest,
+        )
+    else:
+        manifest = copy.deepcopy(manifest)
+        manifest["metadata"]["resourceVersion"] = existing["metadata"][
+            "resourceVersion"
+        ]
+        response = await api.replace_namespaced_custom_object(
+            group=resource["group"],
+            version=resource["version"],
+            namespace=spawner.namespace,
+            plural=resource["plural"],
+            name=name,
+            body=manifest,
+        )
+
+    host = response.get("spec", {}).get("host") or response.get("status", {}).get(
+        "ingress", [{}]
+    )[0].get("host", "")
+    spawner.log.info(
+        "Ensured Route %s for %s%s",
+        name,
+        host or "<dynamic-host>",
+        spawner.server.base_url,
+    )
+
+
+async def delete_route(api, spawner):
+    resource = RESOURCE_TYPES["route"]
+
+    try:
+        await api.delete_namespaced_custom_object(
+            group=resource["group"],
+            version=resource["version"],
+            namespace=spawner.namespace,
+            plural=resource["plural"],
+            name=get_service_name(spawner),
+            body=client.V1DeleteOptions(),
+        )
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
+    else:
+        spawner.log.info("Deleted Route %s", get_service_name(spawner))
+
+
+async def apply_exposure(spawner, exposure_config, pod):
+    if client is None:  # pragma: no cover - only relevant in hub runtime
+        raise ExposureConfigError(
+            "kubernetes_asyncio is required to manage singleuser exposure resources"
+        )
+
+    validate_exposure_config(exposure_config)
+
+    async with client.ApiClient() as api_client:
+        core_api = client.CoreV1Api(api_client)
+        service = await wait_for_service(
+            core_api, spawner.namespace, get_service_name(spawner)
+        )
+
+        if exposure_config["type"] == "loadBalancer":
+            await apply_loadbalancer_service(core_api, spawner, service, exposure_config)
+        elif exposure_config["type"] == "route":
+            service = await apply_clusterip_service(
+                core_api, spawner, service, exposure_config
+            )
+            custom_api = client.CustomObjectsApi(api_client)
+            await apply_route(custom_api, spawner, service, exposure_config, pod)
+
+
+async def cleanup_exposure(spawner, exposure_config):
+    if client is None:  # pragma: no cover - only relevant in hub runtime
+        raise ExposureConfigError(
+            "kubernetes_asyncio is required to manage singleuser exposure resources"
+        )
+
+    async with client.ApiClient() as api_client:
+        if exposure_config["type"] == "route":
+            custom_api = client.CustomObjectsApi(api_client)
+            await delete_route(custom_api, spawner)
+
+        core_api = client.CoreV1Api(api_client)
+        await delete_service(core_api, spawner)
+
+
+def chain_hooks(existing_hook, new_hook):
+    if existing_hook is None:
+        return new_hook
+
+    async def chained_hook(*args, **kwargs):
+        await maybe_future(existing_hook(*args, **kwargs))
+        return await maybe_future(new_hook(*args, **kwargs))
+
+    return chained_hook
+
+
+def configure_singleuser_exposure(c, get_config):
+    exposure_config = copy.deepcopy(get_config("singleuser.exposure", {}))
+    if not exposure_config.get("enabled"):
+        return
+
+    validate_exposure_config(exposure_config)
+
+    c.KubeSpawner.services_enabled = True
+
+    async def after_pod_created(spawner, pod):
+        await apply_exposure(spawner, exposure_config, pod)
+
+    async def post_stop(spawner):
+        await cleanup_exposure(spawner, exposure_config)
+
+    existing_after_hook = c.KubeSpawner.get("after_pod_created_hook")
+    existing_post_stop_hook = c.KubeSpawner.get("post_stop_hook")
+
+    c.KubeSpawner.after_pod_created_hook = chain_hooks(
+        existing_after_hook, after_pod_created
+    )
+    c.KubeSpawner.post_stop_hook = chain_hooks(existing_post_stop_hook, post_stop)

--- a/jupyterhub/templates/hub/rbac.yaml
+++ b/jupyterhub/templates/hub/rbac.yaml
@@ -12,6 +12,16 @@ rules:
   - apiGroups: [""]       # "" indicates the core API group
     resources: ["events"]
     verbs: ["get", "watch", "list"]
+  {{- if and .Values.singleuser.exposure.enabled (or (eq .Values.singleuser.exposure.type "loadBalancer") (eq .Values.singleuser.exposure.type "route")) }}
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "update", "patch"]
+  {{- end }}
+  {{- if and .Values.singleuser.exposure.enabled (eq .Values.singleuser.exposure.type "route") }}
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  {{- end }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -2320,6 +2320,188 @@ properties:
         description: |
           Passthrough configuration for
           [KubeSpawner.extra_pod_config](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.extra_pod_config).
+      exposure:
+        type: object
+        additionalProperties: false
+        required: [enabled, type]
+        description: |
+          Create a dedicated external resource for each spawned single-user
+          server.
+
+          Enabling this also sets
+          [KubeSpawner.services_enabled](https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner.services_enabled)
+          so each user pod gets a dedicated k8s Service with a stable name.
+          When `type=loadBalancer`, that Service is patched to
+          `spec.type=LoadBalancer`. When `type=route`, that Service is kept as
+          `spec.type=ClusterIP` and an OpenShift `Route` is created on top of
+          it.
+
+          Service ports are configured via `singleuser.exposure.ssh`. By
+          default, the per-user Service is exposed on port `22`, and you can
+          override both the externally exposed service port and the in-pod
+          target port.
+
+          The generated Service or Route keeps the same name as the single-user
+          pod for the lifetime of that server and is deleted again when the
+          server stops.
+
+          Template placeholders available in `hostTemplate`, `annotations`, and
+          `labels` are:
+          `{username}`, `{escaped_username}`, `{servername}`,
+          `{service_name}`, `{pod_name}`, `{namespace}`, `{base_url}`, and
+          `{user_server}`.
+
+          If [`singleuser.networkPolicy.enabled`](schema_singleuser.networkPolicy.enabled)
+          is true, you may also need to allow ingress from your router or
+          load balancer implementation via
+          [`singleuser.networkPolicy.ingress`](schema_singleuser.networkPolicy.ingress).
+        properties:
+          enabled:
+            type: boolean
+            description: |
+              Whether to create a per-user external resource alongside each
+              spawned single-user server.
+          type:
+            enum: [loadBalancer, route]
+            description: |
+              The exposure type to create per single-user server.
+
+              Use `loadBalancer` to expose the per-user Service directly, or
+              `route` on OpenShift clusters with the Route API.
+          hostTemplate:
+            type: [string, "null"]
+            description: |
+              Optional template for the generated hostname when `type=route`.
+
+              When unset, the OpenShift router assigns a host automatically.
+
+              Example:
+
+              ```yaml
+              singleuser:
+                exposure:
+                  hostTemplate: "{service_name}.apps.example.com"
+              ```
+          annotations:
+            type: object
+            additionalProperties: false
+            patternProperties: *labels-and-annotations-patternProperties
+            description: |
+              Annotations to apply to the generated Service when
+              `type=loadBalancer`, or to the generated Route when `type=route`.
+          labels:
+            type: object
+            additionalProperties: false
+            patternProperties: *labels-and-annotations-patternProperties
+            description: |
+              Labels to apply to the generated Service when
+              `type=loadBalancer`, or to the generated Route when `type=route`.
+          service:
+            type: object
+            additionalProperties: false
+            description: |
+              LoadBalancer Service specific options, used when
+              `type=loadBalancer`.
+            properties:
+              allocateLoadBalancerNodePorts:
+                type: [boolean, "null"]
+                description: |
+                  Maps to the Service's
+                  `spec.allocateLoadBalancerNodePorts`.
+              externalTrafficPolicy:
+                enum: [null, Cluster, Local]
+                description: |
+                  Maps to the Service's `spec.externalTrafficPolicy`.
+              ipFamilies:
+                type: [array, "null"]
+                items:
+                  type: string
+                description: |
+                  Maps to the Service's `spec.ipFamilies`.
+              ipFamilyPolicy:
+                enum: [null, SingleStack, PreferDualStack, RequireDualStack]
+                description: |
+                  Maps to the Service's `spec.ipFamilyPolicy`.
+              loadBalancerClass:
+                type: [string, "null"]
+                description: |
+                  Maps to the Service's `spec.loadBalancerClass`.
+              loadBalancerIP:
+                type: [string, "null"]
+                description: |
+                  Maps to the Service's `spec.loadBalancerIP`.
+              loadBalancerSourceRanges:
+                type: [array, "null"]
+                items:
+                  type: string
+                description: |
+                  Maps to the Service's `spec.loadBalancerSourceRanges`.
+          ssh:
+            type: object
+            additionalProperties: false
+            description: |
+              SSH port configuration for per-user Service exposure.
+
+              This applies to both `type=loadBalancer` and `type=route`.
+              Requires a custom singleuser image with an SSH server listening
+              on `containerPort`.
+            properties:
+              enabled:
+                type: boolean
+                description: |
+                  Whether to use SSH port mapping for per-user Service exposure.
+
+                  If set to false, the Service keeps its existing port mapping.
+
+                  Example Dockerfile:
+                  ```dockerfile
+                  FROM quay.io/jupyterhub/k8s-singleuser-sample:latest
+                  RUN apt-get update && apt-get install -y openssh-server
+                  ```
+              externalPort:
+                type: [integer, "null"]
+                minimum: 1
+                maximum: 65535
+                description: |
+                  Service port exposed per single-user server.
+                  Default: 22
+              containerPort:
+                type: [integer, "null"]
+                minimum: 1
+                maximum: 65535
+                description: |
+                  In-pod target port for the per-user Service.
+                  Default: same as `externalPort` (or 22 if unset).
+          route:
+            type: object
+            additionalProperties: false
+            description: |
+              OpenShift Route specific options, used when `type=route`.
+            properties:
+              wildcardPolicy:
+                enum: [null, None, Subdomain]
+                description: |
+                  Route wildcard policy, if needed.
+              tls:
+                type: object
+                additionalProperties: false
+                description: |
+                  Optional TLS configuration for the generated OpenShift Route.
+
+                  Leave unset to avoid adding a `spec.tls` block to the Route.
+                properties:
+                  termination:
+                    enum: [null, edge, passthrough, reencrypt]
+                  insecureEdgeTerminationPolicy:
+                    enum: [null, None, Allow, Redirect]
+                  certificate:
+                    type: [string, "null"]
+                  key:
+                    type: [string, "null"]
+                  caCertificate:
+                    type: [string, "null"]
+                  destinationCACertificate:
+                    type: [string, "null"]
       extraResource:
         type: object
         additionalProperties: false

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -440,6 +440,39 @@ singleuser:
   cmd: jupyterhub-singleuser
   defaultUrl:
   extraPodConfig: {}
+  exposure:
+    enabled: false
+    type: loadBalancer
+    annotations: {}
+    labels: {}
+    # Applies only when type=route. If left empty, the OpenShift router will
+    # assign a host automatically.
+    hostTemplate:
+    service:
+      allocateLoadBalancerNodePorts:
+      externalTrafficPolicy:
+      ipFamilies:
+      ipFamilyPolicy:
+      loadBalancerClass:
+      loadBalancerIP:
+      loadBalancerSourceRanges:
+    # SSH service port configuration used for both loadBalancer and route
+    # exposure types. By default, single-user services are exposed on port 22.
+    ssh:
+      enabled: true
+      externalPort: 22
+      containerPort: 22
+    route:
+      wildcardPolicy:
+      # Optional TLS settings for the generated OpenShift Route. Leave unset to
+      # avoid adding a tls block to the Route spec.
+      tls:
+        termination:
+        insecureEdgeTerminationPolicy:
+        certificate:
+        key:
+        caCertificate:
+        destinationCACertificate:
   profileList: []
 
 # scheduling relates to the user-scheduler pods and user-placeholder pods.

--- a/sub/Chart.yaml
+++ b/sub/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: jupyterhub-exposure-overlay
+description: Wrapper chart that enables per-singleuser Service/Route exposure on top of the packaged jupyterhub chart.
+type: application
+version: 0.1.0
+appVersion: 5.4.4
+dependencies:
+  - name: jupyterhub
+    version: 0.0.1-set.by.chartpress
+    repository: file://charts

--- a/sub/files/singleuser-exposure/singleuser_exposure.py
+++ b/sub/files/singleuser-exposure/singleuser_exposure.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+configuration_directory = os.path.dirname(os.path.realpath(__file__))
+if configuration_directory not in sys.path:
+    sys.path.insert(0, configuration_directory)
+
+from singleuser_exposure_common import *  # noqa: F401,F403
+from singleuser_exposure_hooks import chain_hooks, configure_singleuser_exposure
+from singleuser_exposure_k8s import *  # noqa: F401,F403

--- a/sub/files/singleuser-exposure/singleuser_exposure_common.py
+++ b/sub/files/singleuser-exposure/singleuser_exposure_common.py
@@ -67,4 +67,3 @@ def validate_exposure_config(exposure_config):
             "singleuser.exposure.type must be one of: "
             + ", ".join(sorted(EXPOSURE_TYPES))
         )
-

--- a/sub/files/singleuser-exposure/singleuser_exposure_common.py
+++ b/sub/files/singleuser-exposure/singleuser_exposure_common.py
@@ -1,0 +1,70 @@
+from collections.abc import Mapping
+
+RESOURCE_TYPES = {
+    "route": {
+        "apiVersion": "route.openshift.io/v1",
+        "group": "route.openshift.io",
+        "version": "v1",
+        "plural": "routes",
+        "kind": "Route",
+    }
+}
+
+EXPOSURE_TYPES = {"loadBalancer", "route"}
+DEFAULT_SSH_PORT = 22
+DEFAULT_SSH_PORT_NAME = "ssh"
+
+
+class ExposureConfigError(ValueError):
+    """Raised when singleuser.exposure is invalid."""
+
+
+def get_service_name(spawner):
+    return spawner.pod_name
+
+
+def build_template_context(spawner, service_name=None):
+    server_name = spawner.name or ""
+    user_server = spawner.user.name
+    if server_name:
+        user_server = f"{user_server}--{server_name}"
+
+    return {
+        "username": spawner.user.name,
+        "escaped_username": getattr(spawner.user, "escaped_name", spawner.user.name),
+        "servername": server_name,
+        "service_name": service_name or get_service_name(spawner),
+        "pod_name": spawner.pod_name,
+        "namespace": spawner.namespace,
+        "base_url": spawner.server.base_url,
+        "user_server": user_server,
+    }
+
+
+def render_template_string(template, context):
+    try:
+        return template.format_map(context)
+    except KeyError as exc:
+        raise ExposureConfigError(
+            f"Unknown template field '{exc.args[0]}' in singleuser.exposure"
+        ) from exc
+
+
+def expand_templates(value, context):
+    if isinstance(value, str):
+        return render_template_string(value, context)
+    if isinstance(value, list):
+        return [expand_templates(item, context) for item in value]
+    if isinstance(value, Mapping):
+        return {key: expand_templates(item, context) for key, item in value.items()}
+    return value
+
+
+def validate_exposure_config(exposure_config):
+    exposure_type = exposure_config.get("type")
+    if exposure_type not in EXPOSURE_TYPES:
+        raise ExposureConfigError(
+            "singleuser.exposure.type must be one of: "
+            + ", ".join(sorted(EXPOSURE_TYPES))
+        )
+

--- a/sub/files/singleuser-exposure/singleuser_exposure_hooks.py
+++ b/sub/files/singleuser-exposure/singleuser_exposure_hooks.py
@@ -1,0 +1,42 @@
+import copy
+
+from jupyterhub.utils import maybe_future
+
+from singleuser_exposure_common import validate_exposure_config
+from singleuser_exposure_k8s import apply_exposure, cleanup_exposure
+
+
+def chain_hooks(existing_hook, new_hook):
+    if existing_hook is None:
+        return new_hook
+
+    async def chained_hook(*args, **kwargs):
+        await maybe_future(existing_hook(*args, **kwargs))
+        return await maybe_future(new_hook(*args, **kwargs))
+
+    return chained_hook
+
+
+def configure_singleuser_exposure(c, get_config):
+    exposure_config = copy.deepcopy(get_config("singleuser.exposure", {}))
+    if not exposure_config.get("enabled"):
+        return
+
+    validate_exposure_config(exposure_config)
+
+    c.KubeSpawner.services_enabled = True
+
+    async def after_pod_created(spawner, pod):
+        await apply_exposure(spawner, exposure_config, pod)
+
+    async def post_stop(spawner):
+        await cleanup_exposure(spawner, exposure_config)
+
+    existing_after_hook = c.KubeSpawner.get("after_pod_created_hook")
+    existing_post_stop_hook = c.KubeSpawner.get("post_stop_hook")
+
+    c.KubeSpawner.after_pod_created_hook = chain_hooks(
+        existing_after_hook, after_pod_created
+    )
+    c.KubeSpawner.post_stop_hook = chain_hooks(existing_post_stop_hook, post_stop)
+

--- a/sub/files/singleuser-exposure/singleuser_exposure_hooks.py
+++ b/sub/files/singleuser-exposure/singleuser_exposure_hooks.py
@@ -1,7 +1,6 @@
 import copy
 
 from jupyterhub.utils import maybe_future
-
 from singleuser_exposure_common import validate_exposure_config
 from singleuser_exposure_k8s import apply_exposure, cleanup_exposure
 
@@ -39,4 +38,3 @@ def configure_singleuser_exposure(c, get_config):
         existing_after_hook, after_pod_created
     )
     c.KubeSpawner.post_stop_hook = chain_hooks(existing_post_stop_hook, post_stop)
-

--- a/sub/files/singleuser-exposure/singleuser_exposure_k8s.py
+++ b/sub/files/singleuser-exposure/singleuser_exposure_k8s.py
@@ -1,7 +1,6 @@
 import copy
 
 from jupyterhub.utils import exponential_backoff
-
 from singleuser_exposure_common import (
     DEFAULT_SSH_PORT,
     DEFAULT_SSH_PORT_NAME,
@@ -99,7 +98,9 @@ def build_service_metadata_patch(spawner, service, exposure_config):
     labels.update(expand_templates(exposure_config.get("labels", {}), context))
 
     annotations = dict(service["metadata"].get("annotations") or {})
-    annotations.update(expand_templates(exposure_config.get("annotations", {}), context))
+    annotations.update(
+        expand_templates(exposure_config.get("annotations", {}), context)
+    )
 
     metadata = {"labels": labels}
     if annotations:
@@ -338,7 +339,9 @@ async def apply_exposure(spawner, exposure_config, pod):
         )
 
         if exposure_config["type"] == "loadBalancer":
-            await apply_loadbalancer_service(core_api, spawner, service, exposure_config)
+            await apply_loadbalancer_service(
+                core_api, spawner, service, exposure_config
+            )
         elif exposure_config["type"] == "route":
             service = await apply_clusterip_service(
                 core_api, spawner, service, exposure_config
@@ -360,4 +363,3 @@ async def cleanup_exposure(spawner, exposure_config):
 
         core_api = client.CoreV1Api(api_client)
         await delete_service(core_api, spawner)
-

--- a/sub/files/singleuser-exposure/singleuser_exposure_k8s.py
+++ b/sub/files/singleuser-exposure/singleuser_exposure_k8s.py
@@ -1,0 +1,363 @@
+import copy
+
+from jupyterhub.utils import exponential_backoff
+
+from singleuser_exposure_common import (
+    DEFAULT_SSH_PORT,
+    DEFAULT_SSH_PORT_NAME,
+    RESOURCE_TYPES,
+    ExposureConfigError,
+    build_template_context,
+    expand_templates,
+    get_service_name,
+    render_template_string,
+    validate_exposure_config,
+)
+
+try:
+    from kubernetes_asyncio import client
+    from kubernetes_asyncio.client import ApiException
+except ImportError:  # pragma: no cover - local tooling may not have hub deps
+    client = None
+
+    class ApiException(Exception):
+        def __init__(self, status=None, *args, **kwargs):
+            super().__init__(*args)
+            self.status = status
+
+
+def build_owner_reference(pod):
+    return {
+        "apiVersion": pod.get("apiVersion", "v1"),
+        "kind": pod.get("kind", "Pod"),
+        "name": pod["metadata"]["name"],
+        "uid": pod["metadata"]["uid"],
+        "blockOwnerDeletion": True,
+        "controller": False,
+    }
+
+
+def build_resource_metadata(spawner, pod, exposure_config, service_name):
+    context = build_template_context(spawner, service_name=service_name)
+    labels = dict(getattr(spawner, "common_labels", {}) or {})
+    labels.update(
+        {
+            "app.kubernetes.io/component": getattr(
+                spawner, "component_label", "singleuser-server"
+            ),
+            "component": getattr(spawner, "component_label", "singleuser-server"),
+            "hub.jupyter.org/external-access": "true",
+        }
+    )
+    labels.update(expand_templates(exposure_config.get("labels", {}), context))
+
+    metadata = {
+        "name": service_name,
+        "labels": labels,
+        "ownerReferences": [build_owner_reference(pod)],
+    }
+
+    annotations = expand_templates(exposure_config.get("annotations", {}), context)
+    if annotations:
+        metadata["annotations"] = annotations
+
+    return metadata
+
+
+def get_service_ports(service, exposure_config):
+    ssh_config = exposure_config.get("ssh", {})
+    if not ssh_config.get("enabled", True):
+        return copy.deepcopy(service.get("spec", {}).get("ports", []))
+
+    service_port = ssh_config.get("externalPort")
+    if service_port is None:
+        service_port = DEFAULT_SSH_PORT
+
+    target_port = ssh_config.get("containerPort")
+    if target_port is None:
+        target_port = service_port
+
+    ssh_port = {
+        "name": DEFAULT_SSH_PORT_NAME,
+        "port": service_port,
+        "targetPort": target_port,
+        "protocol": "TCP",
+    }
+    existing_ports = copy.deepcopy(service.get("spec", {}).get("ports", []))
+    existing_ports = [
+        port for port in existing_ports if port.get("name") != DEFAULT_SSH_PORT_NAME
+    ]
+    return [ssh_port] + existing_ports
+
+
+def build_service_metadata_patch(spawner, service, exposure_config):
+    service_name = service["metadata"]["name"]
+    context = build_template_context(spawner, service_name=service_name)
+
+    labels = dict(service["metadata"].get("labels") or {})
+    labels["hub.jupyter.org/external-access"] = "true"
+    labels.update(expand_templates(exposure_config.get("labels", {}), context))
+
+    annotations = dict(service["metadata"].get("annotations") or {})
+    annotations.update(expand_templates(exposure_config.get("annotations", {}), context))
+
+    metadata = {"labels": labels}
+    if annotations:
+        metadata["annotations"] = annotations
+    return metadata
+
+
+def build_loadbalancer_service_patch(spawner, service, exposure_config):
+    service_config = exposure_config.get("service", {})
+    spec = {"type": "LoadBalancer"}
+    for field in (
+        "allocateLoadBalancerNodePorts",
+        "externalTrafficPolicy",
+        "ipFamilies",
+        "ipFamilyPolicy",
+        "loadBalancerClass",
+        "loadBalancerIP",
+        "loadBalancerSourceRanges",
+    ):
+        if service_config.get(field) is not None:
+            spec[field] = service_config[field]
+
+    ports = get_service_ports(service, exposure_config)
+    if ports:
+        spec["ports"] = ports
+
+    return {
+        "metadata": build_service_metadata_patch(spawner, service, exposure_config),
+        "spec": spec,
+    }
+
+
+def build_clusterip_service_patch(spawner, service, exposure_config):
+    spec = {"type": "ClusterIP"}
+    ports = get_service_ports(service, exposure_config)
+    if ports:
+        spec["ports"] = ports
+
+    return {
+        "metadata": build_service_metadata_patch(spawner, service, exposure_config),
+        "spec": spec,
+    }
+
+
+def get_route_target_port(service):
+    service_port = (service.get("spec", {}).get("ports") or [{}])[0]
+    return (
+        service_port.get("name")
+        or service_port.get("targetPort")
+        or service_port.get("port")
+    )
+
+
+def build_route_manifest(spawner, pod, service, exposure_config):
+    service_name = service["metadata"]["name"]
+    context = build_template_context(spawner, service_name=service_name)
+    route_config = exposure_config.get("route", {})
+    spec = {
+        "to": {
+            "kind": "Service",
+            "name": service_name,
+        },
+        "port": {
+            "targetPort": get_route_target_port(service),
+        },
+    }
+
+    if exposure_config.get("hostTemplate"):
+        spec["host"] = render_template_string(exposure_config["hostTemplate"], context)
+
+    tls_config = {
+        key: value
+        for key, value in expand_templates(route_config.get("tls", {}), context).items()
+        if value is not None
+    }
+    if tls_config:
+        spec["tls"] = tls_config
+
+    if route_config.get("wildcardPolicy") is not None:
+        spec["wildcardPolicy"] = route_config["wildcardPolicy"]
+
+    return {
+        "apiVersion": RESOURCE_TYPES["route"]["apiVersion"],
+        "kind": RESOURCE_TYPES["route"]["kind"],
+        "metadata": build_resource_metadata(
+            spawner, pod, exposure_config, service_name=service_name
+        ),
+        "spec": spec,
+    }
+
+
+async def wait_for_service(api, namespace, name):
+    async def get_service():
+        try:
+            return await api.read_namespaced_service(name=name, namespace=namespace)
+        except ApiException as exc:
+            if exc.status == 404:
+                return False
+            raise
+
+    service = await exponential_backoff(
+        get_service,
+        f"Service {namespace}/{name} did not appear",
+        timeout=30,
+    )
+    return service.to_dict()
+
+
+async def apply_loadbalancer_service(api, spawner, service, exposure_config):
+    patch = build_loadbalancer_service_patch(spawner, service, exposure_config)
+    response = await api.patch_namespaced_service(
+        name=service["metadata"]["name"],
+        namespace=spawner.namespace,
+        body=patch,
+        _content_type="application/merge-patch+json",
+    )
+    response = response.to_dict()
+    spawner.log.info(
+        "Ensured LoadBalancer Service %s for %s",
+        response["metadata"]["name"],
+        spawner.server.base_url,
+    )
+    return response
+
+
+async def apply_clusterip_service(api, spawner, service, exposure_config):
+    patch = build_clusterip_service_patch(spawner, service, exposure_config)
+    response = await api.patch_namespaced_service(
+        name=service["metadata"]["name"],
+        namespace=spawner.namespace,
+        body=patch,
+        _content_type="application/merge-patch+json",
+    )
+    response = response.to_dict()
+    spawner.log.info(
+        "Ensured ClusterIP Service %s for %s",
+        response["metadata"]["name"],
+        spawner.server.base_url,
+    )
+    return response
+
+
+async def delete_service(api, spawner):
+    try:
+        await api.delete_namespaced_service(
+            name=get_service_name(spawner),
+            namespace=spawner.namespace,
+            body=client.V1DeleteOptions(),
+        )
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
+    else:
+        spawner.log.info("Deleted Service %s", get_service_name(spawner))
+
+
+async def apply_route(api, spawner, service, exposure_config, pod):
+    manifest = build_route_manifest(spawner, pod, service, exposure_config)
+    resource = RESOURCE_TYPES["route"]
+    name = manifest["metadata"]["name"]
+
+    try:
+        existing = await api.get_namespaced_custom_object(
+            group=resource["group"],
+            version=resource["version"],
+            namespace=spawner.namespace,
+            plural=resource["plural"],
+            name=name,
+        )
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
+        response = await api.create_namespaced_custom_object(
+            group=resource["group"],
+            version=resource["version"],
+            namespace=spawner.namespace,
+            plural=resource["plural"],
+            body=manifest,
+        )
+    else:
+        manifest = copy.deepcopy(manifest)
+        manifest["metadata"]["resourceVersion"] = existing["metadata"][
+            "resourceVersion"
+        ]
+        response = await api.replace_namespaced_custom_object(
+            group=resource["group"],
+            version=resource["version"],
+            namespace=spawner.namespace,
+            plural=resource["plural"],
+            name=name,
+            body=manifest,
+        )
+
+    host = response.get("spec", {}).get("host") or response.get("status", {}).get(
+        "ingress", [{}]
+    )[0].get("host", "")
+    spawner.log.info(
+        "Ensured Route %s for %s%s",
+        name,
+        host or "<dynamic-host>",
+        spawner.server.base_url,
+    )
+
+
+async def delete_route(api, spawner):
+    resource = RESOURCE_TYPES["route"]
+
+    try:
+        await api.delete_namespaced_custom_object(
+            group=resource["group"],
+            version=resource["version"],
+            namespace=spawner.namespace,
+            plural=resource["plural"],
+            name=get_service_name(spawner),
+            body=client.V1DeleteOptions(),
+        )
+    except ApiException as exc:
+        if exc.status != 404:
+            raise
+    else:
+        spawner.log.info("Deleted Route %s", get_service_name(spawner))
+
+
+async def apply_exposure(spawner, exposure_config, pod):
+    if client is None:  # pragma: no cover - only relevant in hub runtime
+        raise ExposureConfigError(
+            "kubernetes_asyncio is required to manage singleuser exposure resources"
+        )
+
+    validate_exposure_config(exposure_config)
+
+    async with client.ApiClient() as api_client:
+        core_api = client.CoreV1Api(api_client)
+        service = await wait_for_service(
+            core_api, spawner.namespace, get_service_name(spawner)
+        )
+
+        if exposure_config["type"] == "loadBalancer":
+            await apply_loadbalancer_service(core_api, spawner, service, exposure_config)
+        elif exposure_config["type"] == "route":
+            service = await apply_clusterip_service(
+                core_api, spawner, service, exposure_config
+            )
+            custom_api = client.CustomObjectsApi(api_client)
+            await apply_route(custom_api, spawner, service, exposure_config, pod)
+
+
+async def cleanup_exposure(spawner, exposure_config):
+    if client is None:  # pragma: no cover - only relevant in hub runtime
+        raise ExposureConfigError(
+            "kubernetes_asyncio is required to manage singleuser exposure resources"
+        )
+
+    async with client.ApiClient() as api_client:
+        if exposure_config["type"] == "route":
+            custom_api = client.CustomObjectsApi(api_client)
+            await delete_route(custom_api, spawner)
+
+        core_api = client.CoreV1Api(api_client)
+        await delete_service(core_api, spawner)
+

--- a/sub/templates/singleuser-exposure-configmap.yaml
+++ b/sub/templates/singleuser-exposure-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.jupyterhub.singleuser.exposure.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: singleuser-exposure-files
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+data:
+  singleuser_exposure.py: |
+{{ .Files.Get "files/singleuser-exposure/singleuser_exposure.py" | nindent 4 }}
+  singleuser_exposure_common.py: |
+{{ .Files.Get "files/singleuser-exposure/singleuser_exposure_common.py" | nindent 4 }}
+  singleuser_exposure_hooks.py: |
+{{ .Files.Get "files/singleuser-exposure/singleuser_exposure_hooks.py" | nindent 4 }}
+  singleuser_exposure_k8s.py: |
+{{ .Files.Get "files/singleuser-exposure/singleuser_exposure_k8s.py" | nindent 4 }}
+{{- end }}

--- a/sub/values-singleuser-loadbalancer.yaml
+++ b/sub/values-singleuser-loadbalancer.yaml
@@ -1,0 +1,54 @@
+jupyterhub:
+  proxy:
+    service:
+      type: ClusterIP
+
+  hub:
+    image:
+      tag: "4.3.1"
+    extraVolumes:
+      - name: singleuser-exposure-files
+        configMap:
+          name: singleuser-exposure-files
+    extraVolumeMounts:
+      - name: singleuser-exposure-files
+        mountPath: /usr/local/etc/jupyterhub/singleuser-exposure
+        readOnly: true
+    extraConfig:
+      00-singleuser-exposure: |
+        import os
+        import sys
+
+        exposure_dir = "/usr/local/etc/jupyterhub/singleuser-exposure"
+        if exposure_dir not in sys.path:
+            sys.path.insert(0, exposure_dir)
+
+        from singleuser_exposure import configure_singleuser_exposure
+
+        configure_singleuser_exposure(c, get_config)
+
+  singleuser:
+    image:
+      tag: "4.3.1"
+    networkTools:
+      image:
+        tag: "4.3.1"
+    networkPolicy:
+      enabled: false
+
+    exposure:
+      enabled: true
+      type: loadBalancer
+      ssh:
+        enabled: true
+        externalPort: 22
+        containerPort: 22
+      service:
+        allocateLoadBalancerNodePorts: false
+        externalTrafficPolicy: Local
+
+  prePuller:
+    hook:
+      enabled: false
+    continuous:
+      enabled: false

--- a/sub/values-singleuser-route-openshift.yaml
+++ b/sub/values-singleuser-route-openshift.yaml
@@ -1,0 +1,54 @@
+jupyterhub:
+  proxy:
+    service:
+      type: ClusterIP
+
+  hub:
+    image:
+      tag: "4.3.1"
+    extraVolumes:
+      - name: singleuser-exposure-files
+        configMap:
+          name: singleuser-exposure-files
+    extraVolumeMounts:
+      - name: singleuser-exposure-files
+        mountPath: /usr/local/etc/jupyterhub/singleuser-exposure
+        readOnly: true
+    extraConfig:
+      00-singleuser-exposure: |
+        import os
+        import sys
+
+        exposure_dir = "/usr/local/etc/jupyterhub/singleuser-exposure"
+        if exposure_dir not in sys.path:
+            sys.path.insert(0, exposure_dir)
+
+        from singleuser_exposure import configure_singleuser_exposure
+
+        configure_singleuser_exposure(c, get_config)
+
+  singleuser:
+    image:
+      tag: "4.3.1"
+    networkTools:
+      image:
+        tag: "4.3.1"
+    networkPolicy:
+      enabled: false
+
+    exposure:
+      enabled: true
+      type: route
+      hostTemplate: "{service_name}.apps.example.com"
+      ssh:
+        enabled: true
+        externalPort: 22
+        containerPort: 22
+      route:
+        wildcardPolicy: None
+
+  prePuller:
+    hook:
+      enabled: false
+    continuous:
+      enabled: false

--- a/sub/values.yaml
+++ b/sub/values.yaml
@@ -1,0 +1,54 @@
+jupyterhub:
+  proxy:
+    service:
+      type: ClusterIP
+
+  hub:
+    image:
+      tag: "4.3.1"
+    extraVolumes:
+      - name: singleuser-exposure-files
+        configMap:
+          name: singleuser-exposure-files
+    extraVolumeMounts:
+      - name: singleuser-exposure-files
+        mountPath: /usr/local/etc/jupyterhub/singleuser-exposure
+        readOnly: true
+    extraConfig:
+      00-singleuser-exposure: |
+        import os
+        import sys
+
+        exposure_dir = "/usr/local/etc/jupyterhub/singleuser-exposure"
+        if exposure_dir not in sys.path:
+            sys.path.insert(0, exposure_dir)
+
+        from singleuser_exposure import configure_singleuser_exposure
+
+        configure_singleuser_exposure(c, get_config)
+
+  singleuser:
+    image:
+      tag: "4.3.1"
+    networkTools:
+      image:
+        tag: "4.3.1"
+    networkPolicy:
+      enabled: false
+
+    exposure:
+      enabled: true
+      type: route
+      hostTemplate: "{service_name}.apps.example.com"
+      ssh:
+        enabled: true
+        externalPort: 22
+        containerPort: 22
+      route:
+        wildcardPolicy: None
+
+  prePuller:
+    hook:
+      enabled: false
+    continuous:
+      enabled: false

--- a/tests/test_singleuser_exposure.py
+++ b/tests/test_singleuser_exposure.py
@@ -1,0 +1,291 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "jupyterhub"
+    / "files"
+    / "hub"
+    / "singleuser_exposure.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("singleuser_exposure", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_spawner():
+    return SimpleNamespace(
+        name="",
+        pod_name="jupyter-alice",
+        namespace="ns1",
+        port=8888,
+        user=SimpleNamespace(name="alice", escaped_name="alice"),
+        server=SimpleNamespace(base_url="/user/alice/"),
+        common_labels={"app.kubernetes.io/name": "jupyterhub"},
+        component_label="singleuser-server",
+    )
+
+
+def make_pod():
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": "jupyter-alice",
+            "uid": "pod-uid",
+        },
+    }
+
+
+class ConfigSection(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
+class ConfigRoot:
+    def __init__(self):
+        self.KubeSpawner = ConfigSection()
+
+
+def test_build_loadbalancer_service_patch():
+    module = load_module()
+    spawner = make_spawner()
+    service = {
+        "metadata": {
+            "name": "jupyter-alice",
+            "labels": {"existing": "label"},
+            "annotations": {"existing": "annotation"},
+        },
+        "spec": {
+            "type": "ClusterIP",
+            "ports": [{"name": "notebook-port", "port": 8888}],
+        },
+    }
+    exposure_config = {
+        "enabled": True,
+        "type": "loadBalancer",
+        "annotations": {"anno": "{service_name}"},
+        "labels": {"label": "{username}"},
+        "service": {
+            "externalTrafficPolicy": "Local",
+            "loadBalancerClass": "internal-vip",
+        },
+    }
+
+    patch = module.build_loadbalancer_service_patch(spawner, service, exposure_config)
+
+    assert patch["spec"]["type"] == "LoadBalancer"
+    assert patch["spec"]["externalTrafficPolicy"] == "Local"
+    assert patch["spec"]["loadBalancerClass"] == "internal-vip"
+    assert patch["metadata"]["labels"]["existing"] == "label"
+    assert patch["metadata"]["labels"]["label"] == "alice"
+    assert patch["metadata"]["labels"]["hub.jupyter.org/external-access"] == "true"
+    assert patch["metadata"]["annotations"]["existing"] == "annotation"
+    assert patch["metadata"]["annotations"]["anno"] == "jupyter-alice"
+    assert patch["spec"]["ports"][0] == {
+        "name": "ssh",
+        "port": 22,
+        "targetPort": 22,
+        "protocol": "TCP",
+    }
+    assert patch["spec"]["ports"][1]["name"] == "notebook-port"
+    assert patch["spec"]["ports"][1]["port"] == 8888
+
+
+def test_build_loadbalancer_service_patch_uses_custom_ssh_ports():
+    module = load_module()
+    spawner = make_spawner()
+    service = {
+        "metadata": {"name": "jupyter-alice"},
+        "spec": {"type": "ClusterIP", "ports": [{"name": "notebook-port", "port": 8888}]},
+    }
+    exposure_config = {
+        "enabled": True,
+        "type": "loadBalancer",
+        "ssh": {"enabled": True, "externalPort": 2222, "containerPort": 10022},
+        "service": {},
+    }
+
+    patch = module.build_loadbalancer_service_patch(spawner, service, exposure_config)
+
+    assert patch["spec"]["ports"][0] == {
+        "name": "ssh",
+        "port": 2222,
+        "targetPort": 10022,
+        "protocol": "TCP",
+    }
+    assert patch["spec"]["ports"][1]["name"] == "notebook-port"
+    assert patch["spec"]["ports"][1]["port"] == 8888
+
+
+def test_build_clusterip_service_patch_for_route_sets_ssh_port():
+    module = load_module()
+    spawner = make_spawner()
+    service = {
+        "metadata": {"name": "jupyter-alice", "labels": {"existing": "label"}},
+        "spec": {"type": "ClusterIP", "ports": [{"name": "notebook-port", "port": 8888}]},
+    }
+    exposure_config = {
+        "enabled": True,
+        "type": "route",
+        "ssh": {"enabled": True, "externalPort": 22, "containerPort": 22},
+        "labels": {"label": "{username}"},
+    }
+
+    patch = module.build_clusterip_service_patch(spawner, service, exposure_config)
+
+    assert patch["spec"]["type"] == "ClusterIP"
+    assert patch["spec"]["ports"][0] == {
+        "name": "ssh",
+        "port": 22,
+        "targetPort": 22,
+        "protocol": "TCP",
+    }
+    assert patch["spec"]["ports"][1]["name"] == "notebook-port"
+    assert patch["spec"]["ports"][1]["port"] == 8888
+    assert patch["metadata"]["labels"]["label"] == "alice"
+    assert patch["metadata"]["labels"]["existing"] == "label"
+
+
+def test_build_route_manifest_targets_service_and_keeps_stable_name():
+    module = load_module()
+    spawner = make_spawner()
+    pod = make_pod()
+    service = {
+        "metadata": {"name": "jupyter-alice"},
+        "spec": {
+            "ports": [
+                {
+                    "name": "notebook-port",
+                    "port": 8888,
+                    "targetPort": "notebook-port",
+                }
+            ]
+        },
+    }
+    exposure_config = {
+        "enabled": True,
+        "type": "route",
+        "hostTemplate": "{service_name}.apps.example.com",
+        "annotations": {"anno": "{user_server}"},
+        "labels": {"label": "{username}"},
+        "route": {
+            "wildcardPolicy": "None",
+        },
+    }
+
+    manifest = module.build_route_manifest(spawner, pod, service, exposure_config)
+
+    assert manifest["metadata"]["name"] == "jupyter-alice"
+    assert manifest["metadata"]["annotations"]["anno"] == "alice"
+    assert manifest["metadata"]["labels"]["label"] == "alice"
+    assert manifest["metadata"]["ownerReferences"][0]["uid"] == "pod-uid"
+    assert manifest["spec"]["to"]["name"] == "jupyter-alice"
+    assert manifest["spec"]["port"]["targetPort"] == "notebook-port"
+    assert manifest["spec"]["host"] == "jupyter-alice.apps.example.com"
+    assert "tls" not in manifest["spec"]
+    assert manifest["spec"]["wildcardPolicy"] == "None"
+
+
+def test_build_route_manifest_includes_tls_when_configured():
+    module = load_module()
+    spawner = make_spawner()
+    pod = make_pod()
+    service = {
+        "metadata": {"name": "jupyter-alice"},
+        "spec": {
+            "ports": [
+                {
+                    "name": "notebook-port",
+                    "port": 8888,
+                    "targetPort": "notebook-port",
+                }
+            ]
+        },
+    }
+    exposure_config = {
+        "enabled": True,
+        "type": "route",
+        "route": {
+            "tls": {"termination": "edge"},
+        },
+    }
+
+    manifest = module.build_route_manifest(spawner, pod, service, exposure_config)
+
+    assert manifest["spec"]["tls"]["termination"] == "edge"
+
+
+def test_chain_hooks_runs_existing_before_new():
+    module = load_module()
+    calls = []
+
+    async def existing(*args, **kwargs):
+        calls.append(("existing", args, kwargs))
+
+    async def new(*args, **kwargs):
+        calls.append(("new", args, kwargs))
+
+    asyncio.run(module.chain_hooks(existing, new)("spawner", pod="pod"))
+
+    assert [call[0] for call in calls] == ["existing", "new"]
+
+
+def test_configure_singleuser_exposure_enables_services_and_registers_hooks(
+    monkeypatch,
+):
+    module = load_module()
+    applied = []
+    cleaned = []
+
+    async def fake_apply(spawner, exposure_config, pod):
+        applied.append((spawner.pod_name, exposure_config["type"], pod["metadata"]["uid"]))
+
+    async def fake_cleanup(spawner, exposure_config):
+        cleaned.append((spawner.pod_name, exposure_config["type"]))
+
+    monkeypatch.setattr(module, "apply_exposure", fake_apply)
+    monkeypatch.setattr(module, "cleanup_exposure", fake_cleanup)
+
+    c = ConfigRoot()
+
+    def get_config(key, default=None):
+        if key == "singleuser.exposure":
+            return {"enabled": True, "type": "loadBalancer", "service": {}}
+        return default
+
+    module.configure_singleuser_exposure(c, get_config)
+
+    assert c.KubeSpawner.services_enabled is True
+    assert c.KubeSpawner.after_pod_created_hook is not None
+    assert c.KubeSpawner.post_stop_hook is not None
+
+    spawner = make_spawner()
+    pod = make_pod()
+    asyncio.run(c.KubeSpawner.after_pod_created_hook(spawner, pod))
+    asyncio.run(c.KubeSpawner.post_stop_hook(spawner))
+
+    assert applied == [("jupyter-alice", "loadBalancer", "pod-uid")]
+    assert cleaned == [("jupyter-alice", "loadBalancer")]
+
+
+def test_validate_exposure_config_rejects_unknown_type():
+    module = load_module()
+
+    with pytest.raises(module.ExposureConfigError):
+        module.validate_exposure_config({"enabled": True, "type": "httpRoute"})

--- a/tests/test_singleuser_exposure.py
+++ b/tests/test_singleuser_exposure.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 
-
 MODULE_PATH = (
     Path(__file__).resolve().parents[1]
     / "jupyterhub"
@@ -112,7 +111,10 @@ def test_build_loadbalancer_service_patch_uses_custom_ssh_ports():
     spawner = make_spawner()
     service = {
         "metadata": {"name": "jupyter-alice"},
-        "spec": {"type": "ClusterIP", "ports": [{"name": "notebook-port", "port": 8888}]},
+        "spec": {
+            "type": "ClusterIP",
+            "ports": [{"name": "notebook-port", "port": 8888}],
+        },
     }
     exposure_config = {
         "enabled": True,
@@ -138,7 +140,10 @@ def test_build_clusterip_service_patch_for_route_sets_ssh_port():
     spawner = make_spawner()
     service = {
         "metadata": {"name": "jupyter-alice", "labels": {"existing": "label"}},
-        "spec": {"type": "ClusterIP", "ports": [{"name": "notebook-port", "port": 8888}]},
+        "spec": {
+            "type": "ClusterIP",
+            "ports": [{"name": "notebook-port", "port": 8888}],
+        },
     }
     exposure_config = {
         "enabled": True,
@@ -254,7 +259,9 @@ def test_configure_singleuser_exposure_enables_services_and_registers_hooks(
     cleaned = []
 
     async def fake_apply(spawner, exposure_config, pod):
-        applied.append((spawner.pod_name, exposure_config["type"], pod["metadata"]["uid"]))
+        applied.append(
+            (spawner.pod_name, exposure_config["type"], pod["metadata"]["uid"])
+        )
 
     async def fake_cleanup(spawner, exposure_config):
         cleaned.append((spawner.pod_name, exposure_config["type"]))

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -491,6 +491,26 @@ singleuser:
       mock: 1
   cmd: jupyterhub-singleuser
   defaultUrl: /
+  exposure:
+    enabled: true
+    type: route
+    annotations: *annotations
+    labels: *labels
+    hostTemplate: "{service_name}.apps.example.com"
+    service:
+      allocateLoadBalancerNodePorts: false
+      externalTrafficPolicy: Cluster
+      ipFamilies: [IPv4]
+      ipFamilyPolicy: SingleStack
+      loadBalancerClass: mock-loadbalancer-class
+      loadBalancerIP: 203.0.113.10
+      loadBalancerSourceRanges: [203.0.113.0/24]
+    ssh:
+      enabled: true
+      externalPort: 2222
+      containerPort: 22
+    route:
+      wildcardPolicy: None
 
 scheduling:
   userScheduler:

--- a/values-example-singleuser-loadbalancer.yaml
+++ b/values-example-singleuser-loadbalancer.yaml
@@ -1,0 +1,20 @@
+proxy:
+  service:
+    type: ClusterIP
+
+singleuser:
+  # If you keep NetworkPolicy enabled, make sure your cloud load balancer can
+  # reach single-user pods.
+  networkPolicy:
+    enabled: false
+
+  exposure:
+    enabled: true
+    type: loadBalancer
+    ssh:
+      enabled: true
+      externalPort: 22
+      containerPort: 22
+    service:
+      allocateLoadBalancerNodePorts: false
+      externalTrafficPolicy: Local

--- a/values-example-singleuser-route-openshift.yaml
+++ b/values-example-singleuser-route-openshift.yaml
@@ -1,0 +1,18 @@
+proxy:
+  service:
+    type: ClusterIP
+
+singleuser:
+  # For a quick working setup, disable the chart-managed NetworkPolicy.
+  # If you keep it enabled, make sure the OpenShift router can reach user pods.
+  networkPolicy:
+    enabled: false
+
+  exposure:
+    enabled: true
+    type: route
+    ssh:
+      enabled: true
+      externalPort: 22
+      containerPort: 22
+    hostTemplate: "{service_name}.apps.example.com"


### PR DESCRIPTION
## Summary

Adds a new `singleuser.exposure` feature that creates a dedicated external resource per single-user server.

### What it does
- Enables per-user Service exposure for `LoadBalancer` or OpenShift `Route`
- Keeps a stable name per user server
- Supports optional SSH port mapping
- Supports templated labels, annotations, and Route hostnames
- Cleans up the created Service/Route when the server stops

### Implementation
- Added dedicated Python modules for the exposure logic
- Wired the feature into hub configuration via post-extra config loading
- Added RBAC rules for Service and Route management
- Added schema and example values for the new configuration

### Notes
- `LoadBalancer` mode works on Kubernetes clusters that support it
- `Route` mode is intended for OpenShift clusters with the Route API
