### PR TITLE
Add proxy.traefik.command and args config and workaround intermittent CI failure

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -309,6 +309,9 @@ jobs:
 
           helm install jupyterhub --repo https://hub.jupyter.org/helm-chart/ jupyterhub --values ../dev-config.yaml --version=$UPGRADE_FROM_VERSION ${{ matrix.upgrade-from-extra-args }}
 
+      # FIXME: cleanup this workaround when we only upgrade test from versions
+      #        >4.3.4, and move the sleep command modification in
+      #        dev-config-local-chart-extra-config.yaml to dev-config.yaml.
       - name: "(Upgrade) Patch autohttps/traefik to sleep a bit for ACME challenge reliability"
         if: matrix.test == 'upgrade'
         run: |

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -309,6 +309,11 @@ jobs:
 
           helm install jupyterhub --repo https://hub.jupyter.org/helm-chart/ jupyterhub --values ../dev-config.yaml --version=$UPGRADE_FROM_VERSION ${{ matrix.upgrade-from-extra-args }}
 
+      - name: "(Upgrade) Patch autohttps/traefik to sleep a bit for ACME challenge reliability"
+        if: matrix.test == 'upgrade'
+        run: |
+          kubectl patch deployment autohttps --type=strategic -p='{"spec":{"template":{"spec":{"containers":[{"name":"traefik","command":["sh","-c","sleep 10 && /entrypoint.sh traefik"]}]}}}}'
+
       - name: "(Upgrade) Install helm diff"
         if: matrix.test == 'upgrade'
         run: |

--- a/dev-config-local-chart-extra-config.yaml
+++ b/dev-config-local-chart-extra-config.yaml
@@ -19,3 +19,14 @@ singleuser:
       test-volume-mount:
         name: test-volume
         mountPath: /test-volume
+
+proxy:
+  traefik:
+    # This startup delay can help the k8s container network interface setup
+    # network routing of traffic to the pod, which is essential for the ACME
+    # challenge submitted by Traefik on startup to acquire a TLS certificate.
+    #
+    # This change is also applied by a kubectl patch in test-chart.yaml for
+    # already released charts when command wasn't configurable (<=4.3.4).
+    #
+    command: ["sh", "-c", "sleep 10 && /entrypoint.sh traefik"]

--- a/dev-config-local-chart-extra-config.yaml
+++ b/dev-config-local-chart-extra-config.yaml
@@ -26,7 +26,8 @@ proxy:
     # network routing of traffic to the pod, which is essential for the ACME
     # challenge submitted by Traefik on startup to acquire a TLS certificate.
     #
-    # This change is also applied by a kubectl patch in test-chart.yaml for
-    # already released charts when command wasn't configurable (<=4.3.4).
+    # FIXME: move this configuration to dev-config.yaml when we only upgrade
+    #        test from versions >4.3.4, and then also cleanup the `kubectl patch
+    #        deployment autohttps ...` step in test-chart.yaml.
     #
     command: ["sh", "-c", "sleep 10 && /entrypoint.sh traefik"]

--- a/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -91,6 +91,14 @@ spec:
           {{- with .Values.proxy.traefik.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
+          {{- with .Values.proxy.traefik.command }}
+          command:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.proxy.traefik.args }}
+          args:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           {{- with .Values.proxy.traefik.resources }}
           resources:
             {{- . | toYaml | nindent 12 }}

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1899,6 +1899,38 @@ properties:
         description: |
           Configure the traefik proxy used to terminate TLS when 'autohttps' is enabled
         properties:
+          command:
+            type: array
+            description: |
+              Overrides the traefik image's ENTRYPOINT, and makes its CMD
+              ignored. traefik 3.7's ENTRYPOINT is `["/entrypoint.sh"]`, and
+              traefik's CMD is `["trafik"]`.
+
+              Configuring this can be relevant to workaround a slow network
+              initialization which can make ACME challenges fail. You could then
+              configure
+
+              ```yaml
+              proxy:
+                traefik:
+                  # This startup delay can help the k8s container network
+                  # interface setup network routing of traffic to the pod, which
+                  # is essential for the ACME challenge submitted by Traefik on
+                  # startup to acquire a TLS certificate.
+                  #
+                  command: ["sh", "-c", "sleep 10 && /entrypoint.sh traefik"]
+              ```
+
+              For more information, see the [Kubernetes Container
+              specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#container-v1-core).
+          args:
+            type: array
+            description: |
+              Overrides the traefik image's CMD, which for traefik as of 3.7 is
+              `["traefik"]`.
+
+              For more information, see the [Kubernetes Container
+              specification](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#container-v1-core).
           revisionHistoryLimit: *revisionHistoryLimit
           labels:
             type: object

--- a/tools/templates/lint-and-validate-values.yaml
+++ b/tools/templates/lint-and-validate-values.yaml
@@ -275,6 +275,8 @@ proxy:
       minAvailable: 1
     extraPodSpec: *extraPodSpec
   traefik:
+    command: ["hello"]
+    args: ["there"]
     revisionHistoryLimit: 1
     labels: *labels
     resources: *resources


### PR DESCRIPTION
We have suffered from this intermittent issue in our CI environment for many years now. I think the issue is that the autohttps pod is initiating an ACME challenge directly on startup, but sometimes the pebble ACME server that receives the request fails to reach traefik in the autohttps pod's container because it was so freshly started and inbound networking isn't functional yet.

I've concluded that an init container with sleep doesn't cut it, it has to be the traefik container that delays things by a sleep. So, whatever networking needs time to initialize needs time after the traefik container starts.

Since its intermittent, its not 100% this is a fix, but the CI system has now run the test-chart.yaml workflow four times in a row without failure with the workaround applied when I expect it to fail more than 50% of the time for any given run.

## The failure fixed

Here are logs from the "Await local chart cert acquisition" step in a [test job that failed](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/actions/runs/25176445928/job/73809732581#step:19:496):

```
...
2026-04-30T16:19:15Z ERR github.com/traefik/traefik/v3/pkg/provider/acme/provider.go:574 > Unable to obtain ACME certificate for domains error="unable to generate a certificate for the domains [local.jovyan.org]: error: one or more domains had a problem:\n[local.jovyan.org] invalid authorization: acme: error: 400 :: urn:ietf:params:acme:error:connection :: Get \"[http://local.jovyan.org:80/.well-known/acme-challenge/3EmYJjvsX2qt25HF8SxFfc5acT_p7FhXjeepo9pYU3E\](http://local.jovyan.org/.well-known/acme-challenge/3EmYJjvsX2qt25HF8SxFfc5acT_p7FhXjeepo9pYU3E/)": dial tcp 10.43.238.114:80: connect: connection refused\n" ACME CA=https://pebble/dir acmeCA=https://pebble/dir domains=["local.jovyan.org"] providerName=default.acme routerName=default@file rule=PathPrefix(`/`)
2026-04-30 16:19:16,726 INFO /usr/local/bin/acme-secret-sync.py watch-save --label=app.kubernetes.io/name=jupyterhub --label=app.kubernetes.io/instance=jupyterhub --label=helm.sh/chart=jupyterhub-5.0.0-0.dev.git.7372.ha7f1f069 --label=app.kubernetes.io/managed-by=secret-sync proxy-public-tls-acme acme.json /etc/acme/acme.json
2026-04-30 16:19:16,726 INFO No certificate detected in /etc/acme/acme.json
2026-04-30 16:19:46,727 INFO No certificate detected in /etc/acme/acme.json
Error: Process completed with exit code 1.
```

## Related history

- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1716
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2150
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2431
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2601
- https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2818
- https://github.com/traefik/traefik/issues/8803

## AI disclosure

- I used codex with GPT 5.5 to generate an initial attempt to fix based on my own proposed workaround with an init container in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/2150#issuecomment-1127605987.
- I used codex with GPT 5.5 to clarify what ENTRYPOINT / CMD (command / argsin k8s ) the traefik image uses so I can add a sleep before it when overriding it
- I asked how to do a specific kubectl patch command, and got this:
  ```
  kubectl patch deployment autohttps --type='strategic' -p='{"spec":{"template":{"spec":{"containers": [{"name":"traefik","command":["sh","-c","sleep 10 && /entrypoint.sh traefik"]}]}}}}'
  ```