### PR TITLE
Unpin cryptography

### DIFF
--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -39,7 +39,6 @@ charset-normalizer==3.4.7
     # via requests
 cryptography==48.0.0
     # via
-    #   -r unfrozen/requirements.txt
     #   certipy
     #   google-auth
     #   pyjwt
@@ -159,9 +158,9 @@ pycparser==3.0
     # via cffi
 pycurl==7.46.0
     # via -r unfrozen/requirements.txt
-pydantic==2.13.3
+pydantic==2.13.4
     # via jupyterhub
-pydantic-core==2.46.3
+pydantic-core==2.46.4
     # via pydantic
 pyjwt==2.12.1
     # via
@@ -238,7 +237,7 @@ tornado==6.5.5
     #   jupyterhub
     #   jupyterhub-idle-culler
     #   oauthenticator
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   jupyter-events
     #   jupyterhub

--- a/images/hub/unfrozen/requirements.txt
+++ b/images/hub/unfrozen/requirements.txt
@@ -25,9 +25,6 @@ oauthenticator[googlegroups,mediawiki]==17.*
 # JupyterHub service shutting servers after a period of inactivity
 jupyterhub-idle-culler==1.*
 
-# temporary: pin down cryptography until certipy 0.2.3
-cryptography==48.*
-
 # Other optional dependencies for additional features
 pymysql  # mysql
 psycopg2  # postgres

--- a/images/singleuser-sample/requirements.txt
+++ b/images/singleuser-sample/requirements.txt
@@ -128,7 +128,7 @@ jupyter-events==0.12.1
     #   jupyterhub
 jupyter-lsp==2.3.1
     # via jupyterlab
-jupyter-server==2.18.1
+jupyter-server==2.18.2
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -220,9 +220,9 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==3.0
     # via cffi
-pydantic==2.13.3
+pydantic==2.13.4
     # via jupyterhub
-pydantic-core==2.46.3
+pydantic-core==2.46.4
     # via pydantic
 pygments==2.20.0
     # via
@@ -295,7 +295,7 @@ tornado==6.5.5
     #   jupyterlab
     #   nbgitpuller
     #   terminado
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   ipykernel
     #   ipython


### PR DESCRIPTION
certipy 0.2.3 means we don't need the pin anymore, it was temporary