### PR TITLE
4.x: jupyterhub 5.4.6

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -20,7 +20,7 @@ charts:
     #
     # baseVersion should be managed via tbump, see RELEASE.md for details
     #
-    baseVersion: "4.3.4"
+    baseVersion: "4.3.5-0.dev"
     repo:
       git: jupyterhub/helm-chart
       published: https://jupyterhub.github.io/helm-chart

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -14,6 +14,26 @@ changes in pull requests], this list should be updated.
 
 ## 4.3
 
+### 4.3.5 - 2026-05-06
+
+4.3.5 upgrades JupyterHub to 5.4.6, which fixes a regression in
+5.4.5 (chart version 4.3.4).
+
+([full changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/4.3.4...4.3.5))
+
+#### Maintenance and upkeep improvements
+
+- 4.x: jupyterhub 5.4.6 [#3891](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3891) ([@minrk])
+
+#### Contributors to this release
+
+The following people contributed discussions, new ideas, code and documentation contributions, and review.
+See [our definition of contributors](https://github-activity.readthedocs.io/en/latest/use/#how-does-this-tool-define-contributions-in-the-reports).
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/graphs/contributors?from=2026-04-28&to=2026-05-08&type=c))
+
+@minrk ([activity](https://github.com/search?q=repo%3Ajupyterhub%2Fzero-to-jupyterhub-k8s+involves%3Aminrk+updated%3A2026-04-28..2026-05-06&type=Issues))
+
 ### 4.3.4 - 2026-04-28
 
 ```{important}
@@ -26,6 +46,8 @@ This release fixes:
 - [CVE-2026-40864], a CSRF vulnerability in JupyterHub (jupyterhub 5.4.5)
 
 [CVE-2026-40864]: https://github.com/jupyterhub/jupyterhub/security/advisories/GHSA-m68r-v472-jgq9
+
+([full changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/compare/4.3.3...4.3.4))
 
 ### 4.3.3 - 2026-03-26
 

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -81,7 +81,7 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 jupyter-events==0.12.1
     # via jupyterhub
-jupyterhub==5.4.5
+jupyterhub==5.4.6
     # via
     #   -r unfrozen/requirements.txt
     #   jupyterhub-firstuseauthenticator

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -25,21 +25,20 @@ bcrypt==5.0.0
     # via
     #   jupyterhub-firstuseauthenticator
     #   jupyterhub-nativeauthenticator
-cachetools==7.0.6
+cachetools==7.1.1
     # via jupyterhub-ltiauthenticator
 certifi==2026.4.22
     # via
     #   kubernetes-asyncio
     #   requests
-certipy==0.2.2
+certipy==0.2.3
     # via jupyterhub
 cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-cryptography==46.0.7
+cryptography==48.0.0
     # via
-    #   -r unfrozen/requirements.txt
     #   certipy
     #   google-auth
     #   pyjwt
@@ -53,7 +52,7 @@ frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-google-auth==2.49.2
+google-auth==2.50.0
     # via google-auth-oauthlib
 google-auth-oauthlib==1.3.1
     # via oauthenticator
@@ -157,18 +156,18 @@ pyasn1-modules==0.4.2
     # via google-auth
 pycparser==3.0
     # via cffi
-pycurl==7.45.7
+pycurl==7.46.0
     # via -r unfrozen/requirements.txt
-pydantic==2.13.3
+pydantic==2.13.4
     # via jupyterhub
-pydantic-core==2.46.3
+pydantic-core==2.46.4
     # via pydantic
 pyjwt==2.12.1
     # via
     #   jupyterhub-ltiauthenticator
     #   mwoauth
     #   oauthenticator
-pymysql==1.1.2
+pymysql==1.1.3
     # via -r unfrozen/requirements.txt
 python-dateutil==2.9.0.post0
     # via
@@ -238,7 +237,7 @@ tornado==6.5.5
     #   jupyterhub
     #   jupyterhub-idle-culler
     #   oauthenticator
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   jupyter-events
     #   jupyterhub

--- a/images/hub/unfrozen/requirements.txt
+++ b/images/hub/unfrozen/requirements.txt
@@ -25,9 +25,6 @@ oauthenticator[googlegroups,mediawiki]==17.*
 # JupyterHub service shutting servers after a period of inactivity
 jupyterhub-idle-culler==1.*
 
-# temporary: pin down cryptography until certipy 0.2.3
-cryptography==46.*
-
 # Other optional dependencies for additional features
 pymysql  # mysql
 psycopg2  # postgres

--- a/images/hub/unfrozen/requirements.txt
+++ b/images/hub/unfrozen/requirements.txt
@@ -8,7 +8,7 @@
 #
 
 # JupyterHub itself
-jupyterhub==5.4.5
+jupyterhub==5.4.6
 
 # JupyterHub Spawner, kubernetes specific
 jupyterhub-kubespawner==7.*

--- a/images/singleuser-sample/requirements.txt
+++ b/images/singleuser-sample/requirements.txt
@@ -37,7 +37,7 @@ certifi==2026.4.22
     #   httpcore
     #   httpx
     #   requests
-certipy==0.2.2
+certipy==0.2.3
     # via jupyterhub
 cffi==2.0.0
     # via
@@ -47,7 +47,7 @@ charset-normalizer==3.4.7
     # via requests
 comm==0.2.3
     # via ipykernel
-cryptography==47.0.0
+cryptography==48.0.0
     # via certipy
 debugpy==1.8.20
     # via ipykernel
@@ -88,7 +88,7 @@ ipython-pygments-lexers==1.1.1
     # via ipython
 isoduration==20.11.0
     # via jsonschema
-jedi==0.19.2
+jedi==0.20.0
     # via ipython
 jinja2==3.1.6
     # via
@@ -128,7 +128,7 @@ jupyter-events==0.12.1
     #   jupyterhub
 jupyter-lsp==2.3.1
     # via jupyterlab
-jupyter-server==2.18.1
+jupyter-server==2.18.2
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -139,7 +139,7 @@ jupyter-server-terminals==0.5.4
     # via jupyter-server
 jupyterhub==5.4.6
     # via -r unfrozen/requirements.txt
-jupyterlab==4.5.6
+jupyterlab==4.5.7
     # via -r unfrozen/requirements.txt
 jupyterlab-pygments==0.3.0
     # via nbconvert
@@ -158,7 +158,7 @@ matplotlib-inline==0.2.1
     # via
     #   ipykernel
     #   ipython
-mistune==3.2.0
+mistune==3.2.1
     # via nbconvert
 nbclassic==1.3.3
     # via -r unfrozen/requirements.txt
@@ -196,7 +196,7 @@ pamela==1.2.0
     # via jupyterhub
 pandocfilters==1.5.1
     # via nbconvert
-parso==0.8.6
+parso==0.8.7
     # via jedi
 pexpect==4.9.0
     # via ipython
@@ -220,9 +220,9 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==3.0
     # via cffi
-pydantic==2.13.3
+pydantic==2.13.4
     # via jupyterhub
-pydantic-core==2.46.3
+pydantic-core==2.46.4
     # via pydantic
 pygments==2.20.0
     # via
@@ -295,7 +295,7 @@ tornado==6.5.5
     #   jupyterlab
     #   nbgitpuller
     #   terminado
-traitlets==5.14.3
+traitlets==5.15.0
     # via
     #   ipykernel
     #   ipython
@@ -327,7 +327,7 @@ uri-template==1.3.0
     # via jsonschema
 urllib3==2.6.3
     # via requests
-wcwidth==0.6.0
+wcwidth==0.7.0
     # via prompt-toolkit
 webcolors==25.10.0
     # via jsonschema

--- a/images/singleuser-sample/requirements.txt
+++ b/images/singleuser-sample/requirements.txt
@@ -128,7 +128,7 @@ jupyter-events==0.12.1
     #   jupyterhub
 jupyter-lsp==2.3.1
     # via jupyterlab
-jupyter-server==2.17.0
+jupyter-server==2.18.1
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -137,7 +137,7 @@ jupyter-server==2.17.0
     #   notebook-shim
 jupyter-server-terminals==0.5.4
     # via jupyter-server
-jupyterhub==5.4.5
+jupyterhub==5.4.6
     # via -r unfrozen/requirements.txt
 jupyterlab==4.5.6
     # via -r unfrozen/requirements.txt

--- a/images/singleuser-sample/unfrozen/requirements.txt
+++ b/images/singleuser-sample/unfrozen/requirements.txt
@@ -7,7 +7,7 @@
 
 # JupyterHub itself, update this version pinning by running the workflow
 # mentioned above.
-jupyterhub==5.4.5
+jupyterhub==5.4.6
 
 # UI
 jupyterlab

--- a/jupyterhub/Chart.yaml
+++ b/jupyterhub/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: jupyterhub
 version: 0.0.1-set.by.chartpress
-appVersion: "5.4.5"
+appVersion: "5.4.6"
 description: Multi-user Jupyter installation
 keywords: [jupyter, jupyterhub, z2jh]
 home: https://z2jh.jupyter.org

--- a/tbump.toml
+++ b/tbump.toml
@@ -5,7 +5,7 @@
 # Config reference: https://github.com/your-tools/tbump#readme
 #
 [version]
-current = "4.3.4"
+current = "4.3.5-0.dev"
 
 # match our prerelease prefixes
 # -alpha.1


### PR DESCRIPTION
- backport #3889 
- refreezes, removing cryptography pin for certipy (#3890)