### PR TITLE
fix: make hub.existingSecret fully replace the chart managed Secret

### DIFF
--- a/ci/test-hub-existing-secret.yaml
+++ b/ci/test-hub-existing-secret.yaml
@@ -7,6 +7,8 @@ metadata:
 type: Opaque
 stringData:
   hub.services.test-hub-existing-secret.apiToken: ffff9999
+  hub.services.test.apiToken: give-pytest-control
+  hub.services.test-with-scoped-access.apiToken: give-pytest-scoped-control
   hub.config.ConfigurableHTTPProxy.auth_token: ffff9999
   hub.config.JupyterHub.cookie_secret: ffff9999
   hub.config.CryptKeeper.keys: ffff9999

--- a/ci/test-hub-existing-secret.yaml
+++ b/ci/test-hub-existing-secret.yaml
@@ -7,7 +7,7 @@ metadata:
 type: Opaque
 stringData:
   hub.services.test-hub-existing-secret.apiToken: ffff9999
-  hub.config.ConfigurableHTTPProxy.auth_token: ffff9999 # should be ignored by set in self managed k8s Secret
+  hub.config.ConfigurableHTTPProxy.auth_token: ffff9999
   hub.config.JupyterHub.cookie_secret: ffff9999
   hub.config.CryptKeeper.keys: ffff9999
   values.yaml: |

--- a/ci/test-hub-existing-secret.yaml
+++ b/ci/test-hub-existing-secret.yaml
@@ -9,6 +9,8 @@ stringData:
   hub.services.test-hub-existing-secret.apiToken: ffff9999
   hub.services.test.apiToken: give-pytest-control
   hub.services.test-with-scoped-access.apiToken: give-pytest-scoped-control
+  hub.services.test-explicit-name.apiToken: eeee5555
+  hub.services.test-generation-of-apiToken.apiToken: cccc3333
   hub.config.ConfigurableHTTPProxy.auth_token: ffff9999
   hub.config.JupyterHub.cookie_secret: ffff9999
   hub.config.CryptKeeper.keys: ffff9999

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -28,7 +28,9 @@ spec:
       annotations:
         {{- /* This lets us autorestart when the secret changes! */}}
         checksum/config-map: {{ include (print .Template.BasePath "/hub/configmap.yaml") . | sha256sum }}
+        {{- if not (include "jupyterhub.hub-existing-secret.fullname" .) }}
         checksum/secret: {{ include (print .Template.BasePath "/hub/secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.hub.annotations }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}
@@ -194,13 +196,7 @@ spec:
             - name: CONFIGPROXY_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  {{- /* NOTE:
-                    References the chart managed k8s Secret even if
-                    hub.existingSecret is specified to avoid using the lookup
-                    function on the user managed k8s Secret which is assumed to
-                    not be possible.
-                  */}}
-                  name: {{ include "jupyterhub.hub.fullname" . }}
+                  name: {{ include "jupyterhub.hub-existing-secret-or-default.fullname" . }}
                   key: hub.config.ConfigurableHTTPProxy.auth_token
             {{- with .Values.hub.extraEnv }}
             {{- include "jupyterhub.extraEnv" . | nindent 12 }}

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -28,9 +28,7 @@ spec:
       annotations:
         {{- /* This lets us autorestart when the secret changes! */}}
         checksum/config-map: {{ include (print .Template.BasePath "/hub/configmap.yaml") . | sha256sum }}
-        {{- if not (include "jupyterhub.hub-existing-secret.fullname" .) }}
         checksum/secret: {{ include (print .Template.BasePath "/hub/secret.yaml") . | sha256sum }}
-        {{- end }}
         {{- with .Values.hub.annotations }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}
@@ -53,7 +51,7 @@ spec:
             name: {{ include "jupyterhub.hub.fullname" . }}
         - name: secret
           secret:
-            secretName: {{ include "jupyterhub.hub-existing-secret-or-default.fullname" . }}
+            secretName: {{ include "jupyterhub.hub.fullname" . }}
         {{- with (include "jupyterhub.hub-existing-secret.fullname" .) }}
         - name: existing-secret
           secret:

--- a/jupyterhub/templates/hub/deployment.yaml
+++ b/jupyterhub/templates/hub/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             name: {{ include "jupyterhub.hub.fullname" . }}
         - name: secret
           secret:
-            secretName: {{ include "jupyterhub.hub.fullname" . }}
+            secretName: {{ include "jupyterhub.hub-existing-secret-or-default.fullname" . }}
         {{- with (include "jupyterhub.hub-existing-secret.fullname" .) }}
         - name: existing-secret
           secret:

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not (include "jupyterhub.hub-existing-secret.fullname" .) }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -13,8 +14,7 @@ data:
   values.yaml: {{ $values | toYaml | b64enc | quote }}
 
   {{- with .Values.hub.db.password }}
-  # Used to mount MYSQL_PWD or PGPASSWORD on hub pod, unless hub.existingSecret
-  # is set as then that k8s Secret's value must be specified instead.
+  # Used to mount MYSQL_PWD or PGPASSWORD on hub pod.
   hub.db.password: {{ . | b64enc | quote }}
   {{- end }}
 
@@ -47,4 +47,5 @@ data:
 {{- with include "jupyterhub.extraFiles.stringData" .Values.hub.extraFiles }}
 stringData:
   {{- . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/jupyterhub/templates/hub/secret.yaml
+++ b/jupyterhub/templates/hub/secret.yaml
@@ -1,4 +1,3 @@
-{{- if not (include "jupyterhub.hub-existing-secret.fullname" .) }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -18,6 +17,7 @@ data:
   hub.db.password: {{ . | b64enc | quote }}
   {{- end }}
 
+  {{- if not (include "jupyterhub.hub-existing-secret.fullname" .) }}
   # Any JupyterHub Services api_tokens are exposed in this k8s Secret as a
   # convinience for external services running in the k8s cluster that could
   # mount them directly from this k8s Secret.
@@ -39,6 +39,7 @@ data:
   hub.config.ConfigurableHTTPProxy.auth_token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | required "This should not happen: blank output from 'jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token' template" | b64enc | quote }}
   hub.config.JupyterHub.cookie_secret: {{ include "jupyterhub.hub.config.JupyterHub.cookie_secret" . | required "This should not happen: blank output from 'jupyterhub.hub.config.JupyterHub.cookie_secret' template" | b64enc | quote }}
   hub.config.CryptKeeper.keys: {{ include "jupyterhub.hub.config.CryptKeeper.keys" . | required "This should not happen: blank output from 'jupyterhub.hub.config.CryptKeeper.keys' template" | b64enc | quote }}
+  {{- end }}
 
   {{- with include "jupyterhub.extraFiles.data" .Values.hub.extraFiles }}
   {{- . | nindent 2 }}
@@ -47,5 +48,4 @@ data:
 {{- with include "jupyterhub.extraFiles.stringData" .Values.hub.extraFiles }}
 stringData:
   {{- . | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -37,7 +37,9 @@ spec:
         # the k8s Secret template. This will cause this annotation to change to
         # match the k8s Secret during the first upgrade following an auth_token
         # was generated.
+        {{- if not (include "jupyterhub.hub-existing-secret.fullname" .) }}
         checksum/auth-token: {{ include "jupyterhub.hub.config.ConfigurableHTTPProxy.auth_token" . | sha256sum | trunc 4 | quote }}
+        {{- end }}
         checksum/proxy-secret: {{ include (print $.Template.BasePath "/proxy/secret.yaml") . | sha256sum | quote }}
         {{- with .Values.proxy.annotations }}
         {{- . | toYaml | nindent 8 }}

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -120,10 +120,7 @@ spec:
             - name: CONFIGPROXY_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  # NOTE: References the chart managed k8s Secret even if
-                  #       hub.existingSecret is specified to avoid using the
-                  #       lookup function on the user managed k8s Secret.
-                  name: {{ include "jupyterhub.hub.fullname" . }}
+                  name: {{ include "jupyterhub.hub-existing-secret-or-default.fullname" . }}
                   key: hub.config.ConfigurableHTTPProxy.auth_token
             {{- with .Values.proxy.chp.extraEnv }}
             {{- include "jupyterhub.extraEnv" . | nindent 12 }}

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -147,6 +147,19 @@ hub:
     periodSeconds: 2
     failureThreshold: 1000
     timeoutSeconds: 1
+  # existingSecret can be set to the name of a k8s Secret that fully replaces
+  # the chart managed k8s Secret. When set, the chart managed Secret is not
+  # rendered and the hub and proxy pods read all tokens directly from the user
+  # managed Secret. The Secret must contain the following keys:
+  #
+  #   hub.config.ConfigurableHTTPProxy.auth_token  (hex string, min 64 chars)
+  #   hub.config.JupyterHub.cookie_secret          (hex string, min 64 chars)
+  #   hub.config.CryptKeeper.keys                  (hex string, min 64 chars)
+  #   hub.services.<name>.apiToken                 (one entry per service)
+  #
+  # This approach is well suited for GitOps workflows where Helm rendering
+  # without cluster access (e.g. ArgoCD) would otherwise produce non-deterministic
+  # output due to the random token fallback in the chart's lookup logic.
   existingSecret:
   serviceAccount:
     create: true

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -242,8 +242,10 @@ def test_load_existing_secret():
                 pytest.skip(f"k8s Secret '{k8s_secret}' not found")
 
     # NOTE:  ffff9999 are values from ci/test-hub-existing-secret.yaml that
-    #        hub.existingSecret will reference, while aaaa1111-dddd4444 come from
-    #        the chart managed k8s Secret.
+    #        hub.existingSecret will reference. When hub.existingSecret is set
+    #        the chart managed k8s Secret is not rendered and all token reads,
+    #        including CONFIGPROXY_AUTH_TOKEN, are satisfied from the user
+    #        managed k8s Secret.
     #
     # FIXME: It would be good to test use against custom databases, then we
     #        would also test hub.db.password here and that the environment
@@ -251,7 +253,7 @@ def test_load_existing_secret():
     #        configuring that would make the hub fail to startup without an
     #        actual database.
     assert "hub.services.test-hub-existing-secret.apiToken=ffff9999" in hub_logs
-    assert "CONFIGPROXY_AUTH_TOKEN=aaaa1111" in hub_logs
+    assert "CONFIGPROXY_AUTH_TOKEN=ffff9999" in hub_logs
     assert "JupyterHub.cookie_secret=ffff9999" in hub_logs
     assert "CryptKeeper.keys=ffff9999" in hub_logs
     assert "singleuser.extraLabels.test-chart-managed-secret=ok" in hub_logs


### PR DESCRIPTION
When `hub.existingSecret` is set, the chart still renders its own hub Secret
with randomly generated tokens. In ArgoCD/GitOps setups where `lookup()` has
no cluster access, these tokens change on every render, which rolls the hub pod
on every reconcile.

This PR makes `hub.existingSecret` actually replace the token keys:

- Omit the random token keys from the hub Secret when `existingSecret` is set (values.yaml, db.password and extraFiles are still rendered — those are deterministic and needed for volume mounts)
- Point `CONFIGPROXY_AUTH_TOKEN` in hub and proxy Deployments to the user-managed Secret
- The `checksum/secret` annotation now stabilises because the hub Secret no longer contains random values

The `hub-existing-secret-or-default` helper already existed — it just wasn't
wired up in the right places.

No change when `hub.existingSecret` is not set.