### PR TITLE
Add `proxy.chp.command` config

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -75,8 +75,8 @@ spec:
           image: {{ .Values.proxy.chp.image.name }}:{{ .Values.proxy.chp.image.tag }}
           {{- $hubNameAsEnv := include "jupyterhub.hub.fullname" . | upper | replace "-" "_" }}
           {{- $hubHost := printf "http://%s:$(%s_SERVICE_PORT)" (include "jupyterhub.hub.fullname" .) $hubNameAsEnv }}
-          command:
-            - configurable-http-proxy
+          command: {{ .Values.proxy.chp.image.command }}
+          args:
             - "--ip="
             - "--api-ip="
             - --api-port=8001

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -75,7 +75,8 @@ spec:
           image: {{ .Values.proxy.chp.image.name }}:{{ .Values.proxy.chp.image.tag }}
           {{- $hubNameAsEnv := include "jupyterhub.hub.fullname" . | upper | replace "-" "_" }}
           {{- $hubHost := printf "http://%s:$(%s_SERVICE_PORT)" (include "jupyterhub.hub.fullname" .) $hubNameAsEnv }}
-          command: {{ .Values.proxy.chp.image.command }}
+          command:
+            {{- .Values.proxy.chp.image.command | toYaml | nindent 12 }}
           args:
             - "--ip="
             - "--api-ip="

--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           {{- $hubNameAsEnv := include "jupyterhub.hub.fullname" . | upper | replace "-" "_" }}
           {{- $hubHost := printf "http://%s:$(%s_SERVICE_PORT)" (include "jupyterhub.hub.fullname" .) $hubNameAsEnv }}
           command:
-            {{- .Values.proxy.chp.image.command | toYaml | nindent 12 }}
+            {{- .Values.proxy.chp.command | toYaml | nindent 12 }}
           args:
             - "--ip="
             - "--api-ip="

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1591,6 +1591,31 @@ properties:
         properties:
           revisionHistoryLimit: *revisionHistoryLimit
           networkPolicy: *networkPolicy-spec
+          command:
+            type: array
+            description: |
+              A list of strings to be added as the command.
+              In general, it needs to start with
+              [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
+              that will be expanded with Helm's template function `tpl` which
+              can render Helm template logic inside curly braces (`{{ ... }}`).
+
+              ```yaml
+              proxy:
+                chp:
+                  command:
+                    - "configurable-http-proxy"
+              ```
+
+              Note that this is added so that docker hardened image can also be used,
+              where the expectation is:
+              ```yaml
+              proxy:
+                chp:
+                  command:
+                    - "node"
+                    - "/srv/configurable-http-proxy/bin/configurable-http-proxy"
+              ```
           extraCommandLineFlags:
             type: array
             description: |

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1596,26 +1596,14 @@ properties:
             description: |
               A list of strings to be added as the command.
               In general, it needs to start with
-              [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
-              that will be expanded with Helm's template function `tpl` which
-              can render Helm template logic inside curly braces (`{{ ... }}`).
-
+              [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy).
               ```yaml
               proxy:
                 chp:
                   command:
                     - "configurable-http-proxy"
               ```
-
-              Note that this is added so that docker hardened image can also be used,
-              where the expectation is:
-              ```yaml
-              proxy:
-                chp:
-                  command:
-                    - "node"
-                    - "/srv/configurable-http-proxy/bin/configurable-http-proxy"
-              ```
+              Note that this is added so that docker hardened image can also be used.
           extraCommandLineFlags:
             type: array
             description: |

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -224,6 +224,7 @@ proxy:
       tag: "5.3.0" # https://github.com/jupyterhub/configurable-http-proxy/tags
       pullPolicy:
       pullSecrets: []
+      command: ["configurable-http-proxy"]
     extraCommandLineFlags: []
     livenessProbe:
       enabled: true

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -224,7 +224,7 @@ proxy:
       tag: "5.3.0" # https://github.com/jupyterhub/configurable-http-proxy/tags
       pullPolicy:
       pullSecrets: []
-      command: ["configurable-http-proxy"]
+    command: ["configurable-http-proxy"]
     extraCommandLineFlags: []
     livenessProbe:
       enabled: true


### PR DESCRIPTION
For feature #3937 - separate out `command` and `args` in proxy's deployment, so that a different `command` can be used.