### PR TITLE
Link release changelog to the released version, not "latest"

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,5 +28,5 @@ jobs:
               repo: context.repo.repo,
               tag_name: tag,
               prerelease: prerelease,
-              body: 'Please see the [changelog](https://zero-to-jupyterhub.readthedocs.io/en/latest/changelog.html) for details.'
+              body: `Please see the [changelog](https://zero-to-jupyterhub.readthedocs.io/en/${tag}/changelog.html) for details.`
             });


### PR DESCRIPTION
## What

Interpolates the actual release tag into the changelog link in the auto-generated GitHub release body, instead of hardcoding `.../en/latest/changelog.html`.

## Why

Once the docs move on past a given release, the "latest" changelog no longer covers that release. For example, the 4.4.0 release body currently links to `latest`, which by now documents a newer version and has no entry for 4.4.0 — even though `.../en/4.4.0/changelog.html` does exist and is correct. The `tag` variable used for the fix is already extracted earlier in the same `github-script` step (`const tag = context.ref.slice(10)`), so this is a one-line change to the template string.

Closes #3918

## How was this tested

This repo has no documented check/lint command for `.github/workflows/*.yml` (checked CONTRIBUTING and the workflow files themselves — no actionlint/yamllint job). Verified:
- The YAML re-parses cleanly: `nix shell nixpkgs#yq-go -c yq eval '.jobs' .github/workflows/release-tag.yml`
- Read the full `github-script` step to confirm `tag` is in scope at the point of the edit and holds the expected value (the tag name, via `context.ref.slice(10)`).

This workflow only runs on tag pushes (`on: push: tags: ...`) via `github-script`, so there's no local dry-run harness for the release-body text itself beyond the above.


Marking this AI-assisted: this PR was authored by an AI coding agent (Claude).