### PR TITLE
Add proxy.chp.enabled flag to allow disabling the chp proxy pod

### DIFF
--- a/jupyterhub/templates/proxy/deployment.yaml
+++ b/jupyterhub/templates/proxy/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.proxy.chp.enabled -}}
 {{- $manualHTTPS := and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual") -}}
 {{- $manualHTTPSwithsecret := and .Values.proxy.https.enabled (eq .Values.proxy.https.type "secret") -}}
 apiVersion: apps/v1
@@ -180,3 +181,4 @@ spec:
       {{- with .Values.proxy.chp.extraPodSpec }}
       {{- . | toYaml | nindent 6 }}
       {{- end }}
+{{- end }}

--- a/jupyterhub/templates/proxy/netpol.yaml
+++ b/jupyterhub/templates/proxy/netpol.yaml
@@ -2,7 +2,7 @@
 {{- $autoHTTPS := and $HTTPS (and (eq .Values.proxy.https.type "letsencrypt") .Values.proxy.https.hosts) -}}
 {{- $manualHTTPS := and $HTTPS (eq .Values.proxy.https.type "manual") -}}
 {{- $manualHTTPSwithsecret := and $HTTPS (eq .Values.proxy.https.type "secret") -}}
-{{- if .Values.proxy.chp.networkPolicy.enabled -}}
+{{- if and .Values.proxy.chp.enabled .Values.proxy.chp.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/jupyterhub/templates/proxy/pdb.yaml
+++ b/jupyterhub/templates/proxy/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.proxy.chp.pdb.enabled -}}
+{{- if and .Values.proxy.chp.enabled .Values.proxy.chp.pdb.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1594,10 +1594,7 @@ properties:
             description: |
               Default `true`.
 
-              Whether to deploy the `proxy` pod running
-              [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy),
-              along with its associated k8s resources (PodDisruptionBudget,
-              NetworkPolicy).
+              Whether to deploy configurable-http-proxy.
 
               Disable this only if you are providing your own proxy
               implementation for JupyterHub to manage instead of chp.

--- a/jupyterhub/values.schema.yaml
+++ b/jupyterhub/values.schema.yaml
@@ -1589,6 +1589,18 @@ properties:
           Configure the configurable-http-proxy (chp) pod managed by jupyterhub to route traffic
           both to itself and to user pods.
         properties:
+          enabled:
+            type: boolean
+            description: |
+              Default `true`.
+
+              Whether to deploy the `proxy` pod running
+              [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy),
+              along with its associated k8s resources (PodDisruptionBudget,
+              NetworkPolicy).
+
+              Disable this only if you are providing your own proxy
+              implementation for JupyterHub to manage instead of chp.
           revisionHistoryLimit: *revisionHistoryLimit
           networkPolicy: *networkPolicy-spec
           command:

--- a/jupyterhub/values.yaml
+++ b/jupyterhub/values.yaml
@@ -206,6 +206,7 @@ proxy:
   # chp relates to the proxy pod, which is responsible for routing traffic based
   # on dynamic configuration sent from JupyterHub to CHP's REST API.
   chp:
+    enabled: true
     revisionHistoryLimit:
     containerSecurityContext:
       runAsNonRoot: true


### PR DESCRIPTION
Gates the chp Deployment, PodDisruptionBudget, and NetworkPolicy so deployments providing their own proxy can skip the built-in CHP pod.

<!--
Thank you for contributing to this repository!

You can help us review your changes by answering these questions.
They are all optional, but the more information you provide the easier it will be for us to review your changes.
Everyone here is a volunteer, so please help us out if you can.

If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
-->

### Checklist

<!--
Checklist of things you should always do before contributing

Make sure to read our policy if you have used an LLM in preparing this contribution.

https://compass.hub.jupyter.org/contribute/llm/

Automated contributions are not permitted.

By 'this work', we mean any code, documentation, as well as the PR description and any comments you post in the discussion.
-->

- [X] I am the author of this work - Claude Sonnet used as well

### What does this PR do?
For users who want to use traefik proxy this is an easy way to disable it as opposed to a helm post render hook.   This is an advanced use case so the feature is bare minimum.

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Maintenance (testing, packaging, infrastructure, metadata)
- [ ] Other

### Is this PR related to an issue, or is it part of a larger body of work?
<!--
Please feel free to provide as much context or links to external sites as you want!
Use "Fixes #<NUM>" or "Fixes <URL to GitHub issue>" if this fixes an existing issue.
-->

Fixes https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3481

I know that there was some thought around a different way to do this, but that was 2 years ago and this changes seems pretty safe.

### Does this PR introduce a breaking change?
<!--
If so what changes might users need to make in their applications due to this PR?
-->

No

### How can this PR be tested?
<!--
If this is not fully covered by the automated tests please help us by describing the tests that you ran to verify your changes. Make sure to provide as much detail so that we can reproduce your tests.
-->
```
helm template jupyterhub jupyterhub/ | grep -A2 "^kind: Deployment" | grep -i proxy
```

```
helm template jupyterhub jupyterhub/ \
  --set proxy.chp.enabled=false \
  --set proxy.chp.pdb.enabled=true \
  --set proxy.chp.networkPolicy.enabled=true \
  > /tmp/chp-disabled.yaml
grep "^# Source:" /tmp/chp-disabled.yaml | grep proxy
```

### What should a reviewer concentrate their feedback on?
<!--
This section is particularly useful if you have a pull request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
You can use bullet points "-" if it helps.
-->

### Other information
<!--
Please provide any other information you think is relevant
-->
