### PR TITLE
Adding UV to speed up package builds

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -18,6 +18,12 @@ FROM python:3.14-trixie as build-stage
 # ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}). We use
 # the same technique for the directory /tmp/wheels.
 #
+# NOTE: wheel-building stays on plain pip -- uv's `pip` interface has no
+#       `wheel` subcommand, so there's nothing to speed up here with uv.
+#       The install steps below (which run far more often, on every rebuild
+#       that touches requirements.txt) are where uv pays off, so uv is
+#       installed and used only in the later stages.
+#
 COPY requirements.txt requirements.txt
 ARG PIP_CACHE_DIR=/tmp/pip-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
@@ -39,8 +45,12 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
 # provide no non-essential packages.
 #
 FROM python:3.14-slim-trixie as slim-stage
-ENV DEBIAN_FRONTEND=noninteractive
 
+# Install uv (static binary, pinned via the official distroless image) to
+# speed up installing the wheels built in build-stage compared to pip.
+COPY --from=ghcr.io/astral-sh/uv:0.12.11 /uv /uvx /usr/local/bin/
+
+ENV DEBIAN_FRONTEND=noninteractive
 ARG NB_USER=jovyan \
     NB_UID=1000 \
     HOME=/home/jovyan
@@ -67,10 +77,10 @@ RUN apt-get update \
 # install wheels built in the build stage
 # --no-index ensures _only_ wheels from the build stage are installed
 COPY requirements.txt /tmp/requirements.txt
-ARG PIP_CACHE_DIR=/tmp/pip-cache
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+ARG UV_CACHE_DIR=/tmp/uv-cache
+RUN --mount=type=cache,target=${UV_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
-    pip install \
+    uv pip install --system \
         --no-index \
         --find-links=/tmp/wheels/ \
         -r /tmp/requirements.txt
@@ -93,10 +103,11 @@ FROM slim-stage as default-stage
 
 USER root
 
-ARG PIP_CACHE_DIR=/tmp/pip-cache
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+# uv is already present here, inherited from slim-stage.
+ARG UV_CACHE_DIR=/tmp/uv-cache
+RUN --mount=type=cache,target=${UV_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
-    pip install \
+    uv pip install --system \
         --no-index \
         --find-links=/tmp/wheels/ \
         # Updates below should be repeated in build-stage.

--- a/images/singleuser-sample/Dockerfile
+++ b/images/singleuser-sample/Dockerfile
@@ -12,6 +12,12 @@
 #
 FROM python:3.14-trixie as build-stage
 
+# Install uv (static binary, pinned via the official distroless image) to
+# speed up dependency installation compared to pip. Note: uv's `pip`
+# interface has no `wheel` subcommand, so wheel-building below still goes
+# through plain pip; uv is used for the (much more common) install path.
+COPY --from=ghcr.io/astral-sh/uv:0.12.11 /uv /uvx /usr/local/bin/
+
 # Build wheels
 #
 # We set pip's cache directory and expose it across build stages via an
@@ -20,9 +26,11 @@ FROM python:3.14-trixie as build-stage
 #
 COPY requirements.txt requirements.txt
 ARG PIP_CACHE_DIR=/tmp/pip-cache
+ARG UV_CACHE_DIR=/tmp/uv-cache
 RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
-    pip install build \
- && pip wheel \
+    --mount=type=cache,target=${UV_CACHE_DIR} \
+    uv pip install --system build \
+    && pip wheel \
         --wheel-dir=/tmp/wheels \
         -r requirements.txt
 
@@ -31,8 +39,11 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
 # ---------------
 #
 FROM python:3.14-slim-trixie
-ENV DEBIAN_FRONTEND=noninteractive
 
+# Install uv here too, so the final image can install wheels with it as well.
+COPY --from=ghcr.io/astral-sh/uv:0.12.11 /uv /uvx /usr/local/bin/
+
+ENV DEBIAN_FRONTEND=noninteractive
 ENV NB_USER=jovyan \
     NB_UID=1000 \
     HOME=/home/jovyan
@@ -57,10 +68,10 @@ RUN apt-get update \
 
 # install wheels built in the build-stage
 COPY requirements.txt /tmp/requirements.txt
-ARG PIP_CACHE_DIR=/tmp/pip-cache
-RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+ARG UV_CACHE_DIR=/tmp/uv-cache
+RUN --mount=type=cache,target=${UV_CACHE_DIR} \
     --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
-    pip install \
+    uv pip install --system \
         --find-links=/tmp/wheels/ \
         -r /tmp/requirements.txt
 


### PR DESCRIPTION
<!--
Thank you for contributing to this repository!

You can help us review your changes by answering these questions.
They are all optional, but the more information you provide the easier it will be for us to review your changes.
Everyone here is a volunteer, so please help us out if you can.

If you want to discuss anything Jupyter related, or to meet other users and developers, please say hello on https://discourse.jupyter.org/ .
-->

### Checklist

<!--
Checklist of things you should always do before contributing

Make sure to read our policy if you have used an LLM in preparing this contribution.

https://compass.hub.jupyter.org/contribute/llm/

Automated contributions are not permitted.

By 'this work', we mean any code, documentation, as well as the PR description and any comments you post in the discussion.
-->

- [x] I am the author of this work
The code was created using Claude, and the build was verified locally.
### What does this PR do?

Type of change:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [x] Maintenance (testing, packaging, infrastructure, metadata)
- [ ] Other

Switches the wheel-install step in `images/singleuser-sample/Dockerfile`
and `images/hub/Dockerfile` from `pip install` to `uv pip install`, to
speed up image builds. Wheel *building* (`pip wheel ...` in `build-stage`)
stays on plain pip, since `uv` has no equivalent to `pip wheel
--wheel-dir`.

### Is this PR related to an issue, or is it part of a larger body of work?

Not tied to an existing issue — just a build-speed improvement.

### Does this PR introduce a breaking change?

No. Only the tool used to install already-built wheels changes; the
resulting images should be unchanged.

### How can this PR be tested?

Build both Dockerfiles locally (`docker build images/singleuser-sample`
and `docker build --target slim-stage` / `--target default-stage` for
`images/hub`) and confirm they succeed and produce working images.
Comparing build time with a cold and a warm BuildKit cache before/after
should show the speedup.

### What should a reviewer concentrate their feedback on?

- Whether pinning `uv` via a hand-written `COPY --from=ghcr.io/astral-sh/uv:X.Y.Z`
  is the preferred approach here, or if it should instead go through
  `ci/refreeze` like the Python base image version.
- Whether `--system` / `--no-index` flags on `uv pip install` are the right
  equivalents for this repo's use case.

### Other information

Used an LLM (Claude) to help draft the Dockerfile changes and this description;
reviewed and tested them myself before opening the PR.
